### PR TITLE
chore: wire semantic-release and CI workflows

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,9 @@
 {
   "name": "deep-review",
-  "version": "2.4.0",
-  "description": "Multi-agent code review plugin. Dispatches up to seven concern-specialized agents with deterministic verification, prompt injection defense, and flexible delivery (PR/MR comments, markdown, chat). Supports GitHub and GitLab."
+  "version": "2.3.4",
+  "description": "Multi-agent code review plugin. Dispatches up to seven concern-specialized agents with deterministic verification, prompt injection defense, and flexible delivery (PR/MR comments, markdown, chat). Supports GitHub and GitLab.",
+  "author": {
+    "name": "Matt Saliano"
+  },
+  "keywords": ["code-review", "multi-agent", "github", "gitlab", "ci"]
 }

--- a/.github/chainguard/main-semantic-release.sts.yaml
+++ b/.github/chainguard/main-semantic-release.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:liatrio-labs/claude-deep-review:ref:refs/heads/main
+
+permissions:
+  contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,84 @@
+name: Semantic Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip ci]') }}
+    permissions:
+      contents: read
+      id-token: write
+    concurrency:
+      group: semantic-release-${{ github.ref }}
+      cancel-in-progress: false
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: octo-sts/action@v1.1.1
+        id: octo-sts
+        with:
+          scope: ${{ github.repository }}
+          identity: main-semantic-release
+
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Get GitHub App User ID
+        id: get-user-id
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: echo "user-id=$(gh api "/users/octo-sts[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git author
+        env:
+          USER_ID: ${{ steps.get-user-id.outputs.user-id }}
+        run: |
+          git config --global user.name 'octo-sts[bot]'
+          git config --global user.email "${USER_ID}+octo-sts[bot]@users.noreply.github.com"
+
+      - name: Use token for pushes to origin
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          git remote set-url origin \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install python-semantic-release
+        run: pip install "python-semantic-release>=10.0.0,<11.0.0"
+
+      - name: Semantic Release
+        id: release
+        env:
+          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+        run: |
+          set -euo pipefail
+          before_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          semantic-release -c .releaserc.toml version
+          after_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$after_tag" ] && [ "$after_tag" != "$before_tag" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Get plugin version
+        id: version
+        if: steps.release.outputs.released == 'true'
+        run: echo "version=v$(jq -r .version .claude-plugin/plugin.json)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,26 @@
+name: Validate Plugin
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate plugin.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Claude Code
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Validate plugin manifest
+        run: claude plugin validate .
+
+      - name: Print plugin metadata
+        run: |
+          jq -r '"  \(.name) \(.version): \(.description)"' .claude-plugin/plugin.json

--- a/.releaserc.toml
+++ b/.releaserc.toml
@@ -1,0 +1,17 @@
+[semantic_release]
+tag_format = "v{version}"
+allow_zero_version = true
+major_on_zero = false
+version_variables = [".claude-plugin/plugin.json:version"]
+commit_message = "chore(release): {version} [skip ci]"
+
+[semantic_release.changelog.default_templates]
+changelog_file = "CHANGELOG.md"
+output_format = "md"
+
+[semantic_release.branches]
+main = { match = "main" }
+
+[semantic_release.remote]
+type = "github"
+token = { env = "GH_TOKEN" }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# CHANGELOG
+
+<!-- version list -->


### PR DESCRIPTION
## What this PR does

Adds the GitHub Actions wiring for conventional-commit-driven releases on `liatrio-labs/claude-deep-review`. After this lands and the maintainer setup below is complete, every `feat:` / `fix:` / `perf:` commit on `main` cuts a tag, bumps `.claude-plugin/plugin.json`, and prepends to `CHANGELOG.md` via Octo STS keyless OIDC.

**Files added**

- `.github/workflows/release.yml` — `python-semantic-release` driven by Octo STS OIDC.
- `.github/workflows/validate.yml` — runs `claude plugin validate .` on PR + `main`.
- `.github/workflows/pr-title-lint.yml` — conventional-commit gate on PR titles.
- `.github/chainguard/main-semantic-release.sts.yaml` — STS identity, subject pinned to `repo:liatrio-labs/claude-deep-review:ref:refs/heads/main`.
- `.releaserc.toml` — `version_variables` points at `.claude-plugin/plugin.json:version` (flat-layout repo).
- `CHANGELOG.md` — seeded empty; semantic-release prepends on each release.

**Files modified**

- `.claude-plugin/plugin.json` — added `author` and `keywords` to match the canonical scaffolder shape. `name`, `version`, `description` unchanged.

**Not included (deferred to follow-up PR)**

The `publish-to-marketplace` reusable-workflow caller is intentionally **not** wired. The scaffolder template hardcodes `liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml`, but that repo currently 404s unauthenticated. Confirm the canonical marketplace repo with the Liatrio team, then add the job in a follow-up PR (see "Follow-up" at the bottom).

---

## ⚠️ MAINTAINER ACTION REQUIRED — DO BEFORE MERGE

These three steps need write/admin access on the repo. **Step 3 is critical:** without the seed tag, the first `feat:` after merge will release as **`v0.1.0`** (resetting the version line), not `v2.4.0`. Verified against `python-semantic-release` v10 docs — `version_variables` is write-only; the algorithm uses git tags as the source of truth and falls back to `0.0.0` (not the manifest) when no tag exists.

### 1. Authorize the Octo STS GitHub App on this repo

App ID `801323`. The release workflow uses `octo-sts/action@v1.1.1` to mint a short-lived token via OIDC against the `main-semantic-release` identity in `.github/chainguard/main-semantic-release.sts.yaml`. Without this authorization, the very first step of `release.yml` fails.

### 2. Create a branch ruleset on `main` with Octo STS as a bypass actor

Semantic-release pushes the version-bump commit + tag back to `main` on a **push event** (not a PR event), so Octo STS must have `bypass_mode: always` — `pull_request` mode is insufficient.

```bash
gh api repos/liatrio-labs/claude-deep-review/rulesets --method POST --input - <<'RULESET'
{
  "name": "protect-default-branch",
  "target": "branch",
  "enforcement": "active",
  "conditions": {
    "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
  },
  "rules": [
    { "type": "deletion" },
    { "type": "non_fast_forward" },
    {
      "type": "pull_request",
      "parameters": {
        "required_approving_review_count": 0,
        "dismiss_stale_reviews_on_push": true,
        "require_code_owner_review": false,
        "require_last_push_approval": false,
        "required_review_thread_resolution": false,
        "allowed_merge_methods": ["squash", "merge", "rebase"]
      }
    }
  ],
  "bypass_actors": [
    { "actor_id": 801323, "actor_type": "Integration", "bypass_mode": "always" }
  ]
}
RULESET
```

### 3. 🛑 SEED THE `v2.3.4` TAG — REQUIRED TO PRESERVE THE VERSION LINE

The repo has zero git tags but the manifest is at `2.3.4`. `python-semantic-release` v10 ignores the manifest version when no tags exist and starts from `0.0.0`. **Before any `feat:` / `fix:` / `perf:` commit lands on `main`, run:**

```bash
git fetch origin
git tag v2.3.4 origin/main
git push origin v2.3.4
```

This anchors semantic-release at the existing version. After this:

- next `fix:` → `v2.3.5`
- next `feat:` → `v2.4.0`
- next `feat!:` (breaking) → `v3.0.0`

If you forget this step and merge a `feat:` commit before tagging, the version line resets to `v0.1.0` and `.claude-plugin/plugin.json` will be force-updated to `0.1.0`. To recover, you'd need to delete the bad tag and the bad release, restore the manifest, and seed `v2.3.4` retroactively — annoying but recoverable.

**The merge of this PR itself is safe** because the commit type is `chore:`, which doesn't trigger a release. Sequence the maintainer steps in any order, but **complete step 3 before any release-cutting commit type lands.**

---

## Verification done locally

- `claude plugin validate .` → ✅ `Validation passed`
- `python3 -m pytest tests/ -q` → ✅ `473 passed in 0.77s`
- Workflow YAML files diffed against the `scaffold-labs-plugin` template; only intentional adaptations differ (paths from `plugin/` → `.`, `publish-to-marketplace` job dropped).

## Follow-up (separate PR, after marketplace repo is confirmed)

1. Resolve the pinned SHA:
   ```bash
   gh api "repos/<marketplace-owner>/<marketplace-repo>/commits?path=.github/workflows/publish-to-marketplace.yml&per_page=1" --jq ".[0].sha"
   ```
2. Append to `.github/workflows/release.yml`:
   ```yaml
   publish-to-marketplace:
     needs: release
     if: needs.release.outputs.released == 'true'
     permissions:
       id-token: write
       contents: read
     uses: <marketplace-owner>/<marketplace-repo>/.github/workflows/publish-to-marketplace.yml@<resolved-sha>
     with:
       tag: ${{ needs.release.outputs.version }}
       path: "."
       strict: true
   ```
3. The next release after that lands opens an onboarding PR against the marketplace catalog.

