### PR TITLE
chore: restore version line to 2.4.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "deep-review",
-  "version": "0.1.0",
+  "version": "2.4.0",
   "description": "Multi-agent code review plugin. Dispatches up to seven concern-specialized agents with deterministic verification, prompt injection defense, and flexible delivery (PR/MR comments, markdown, chat). Supports GitHub and GitLab.",
   "author": {
-    "name": "Matt Saliano"
+    "name": "Lee Hopper"
   },
   "keywords": ["code-review", "multi-agent", "github", "gitlab", "ci"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ docs/temp/
 docs/design/
 docs/superpowers/
 docs/improvement-backlog.md
+/.deep-review/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
 # CHANGELOG
 
 <!-- version list -->
-
-## v0.1.0 (2026-05-06)
-
-- Initial Release


### PR DESCRIPTION
## Why?

Recovery from the semantic-release first-run cliff Matt warned about. The merge of #1 produced commit `9542b28` which force-rewrote `.claude-plugin/plugin.json` from `2.3.4` to `0.1.0` because no prior git tag existed when `python-semantic-release` ran. The bad `v0.1.0` tag and release have already been deleted on origin.

## What Changed?

- `.claude-plugin/plugin.json`: `version` `0.1.0` → `2.4.0`; `author.name` → `Lee Hopper`
- `CHANGELOG.md`: drop the auto-generated `v0.1.0` entry; restore empty seed
- `.gitignore`: cover `.deep-review/` runtime output (added by deep-review skill)

## Additional Notes

`chore:` so this commit does not trigger another release. After merge, main will be tagged `v2.4.0` manually so the next `feat:`/`fix:`/`perf:` commit picks up from the right place (`v2.4.1` for fix, `v2.5.0` for feat).

- [x] Ran tests: `python -m pytest tests/ -q` — 473 passed
- [x] Ran linters/hooks: pre-commit clean
- [x] Updated docs or skill references if behavior changed — n/a