### PR TITLE
ci: publish to marketplace after semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,3 +82,15 @@ jobs:
         id: version
         if: steps.release.outputs.released == 'true'
         run: echo "version=v$(jq -r .version .claude-plugin/plugin.json)" >> "$GITHUB_OUTPUT"
+
+  publish-to-marketplace:
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    permissions:
+      id-token: write
+      contents: read
+    uses: liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@6b89d0b06b290fecedb8eaaa389d92a5c48b5833
+    with:
+      tag: ${{ needs.release.outputs.version }}
+      path: "."
+      strict: true


### PR DESCRIPTION
## Why?

The release workflow tags new versions via semantic-release but doesn't publish to the [liatrio-labs claude-plugins marketplace](https://github.com/liatrio-labs/claude-plugins). After a successful release we want the plugin available there automatically.

## What Changed?

- Added a `publish-to-marketplace` job to `.github/workflows/release.yml` that runs after `release` succeeds.
- Gated on `needs.release.outputs.released == 'true'` so it's a no-op when semantic-release skips the version bump.
- Calls the pinned reusable workflow `liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@6b89d0b` with the new `v<version>` tag, `path: "."`, and `strict: true`.
- Grants `id-token: write` for keyless OIDC publishing; `contents: read` is sufficient since the tag already exists.

## Additional Notes

- The first publish only runs on the next release commit landing on `main`.
- No script or test changes — pre-commit and pytest were not exercised by this PR.

- [ ] Ran tests: `python -m pytest tests/ -q`
- [ ] Ran linters/hooks: `pre-commit run --all-files`
- [ ] Updated docs or skill references if behavior changed

