### PR TITLE
ci: bump publish-to-marketplace workflow SHA to 933e23c

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@6b89d0b06b290fecedb8eaaa389d92a5c48b5833
+    uses: liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@933e23cb9d11ced816e043dfb22a94aa27ca0780
     with:
       tag: ${{ needs.release.outputs.version }}
       path: "."


### PR DESCRIPTION
Rotates the `publish-to-marketplace.yml` pin to [`933e23c`](https://github.com/liatrio-labs/claude-plugins/commit/933e23cb9d11ced816e043dfb22a94aa27ca0780), the merge commit of [liatrio-labs/claude-plugins#100](https://github.com/liatrio-labs/claude-plugins/pull/100).

## Required to avoid catalog corruption on next release

This plugin lives at the repo root and passes `path: "."` to the reusable workflow. Its marketplace entry was migrated in [liatrio-labs/claude-plugins#98](https://github.com/liatrio-labs/claude-plugins/pull/98) from the broken `source: "git-subdir"` + `path: "."` shape (which Claude Code's installer mishandles via a sparse-checkout that excludes every root subdirectory) to the working `source: "url"` + `sha` shape used by dozens of plugins in the Anthropic-official marketplace.

PR #100 in claude-plugins taught the reusable workflow to emit and bump the new shape. **Without this pin rotation, the next release would call the pre-#100 workflow whose count selector matches by `url + path` only — it would not find the now-healed `url`-shape entry, take the auto-add branch, and append a duplicate `git-subdir`+`path: "."` entry alongside it.**

After this rotation, the bump branch correctly refreshes `source.sha` on the existing entry.

## Why no other changes

- No release.yml input changes — caller still passes `tag`, `path: "."`, `strict: true`. Only the workflow SHA moves.
- No STS rotation needed — [`plugin-catalog-bump.sts.yaml`](https://github.com/liatrio-labs/claude-plugins/blob/main/.github/chainguard/plugin-catalog-bump.sts.yaml) accepts any 40-char SHA reachable on `claude-plugins/main`.

## Validated

- `actionlint` clean on the modified file.
- 1-line diff, no behavioral change in this repo.