### PR TITLE
fix: address PR #5 review loose ends (dropped_no_id, dedup test, docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ SKILL.md derives `{plugin_root}` as two levels above the skill base directory. A
 ## Tests
 
 - pytest with `unittest.TestCase` style. Run: `python -m pytest tests/ -q`
-- The suite covers every pipeline script: `verify_findings.py`, `filter_findings.py`, `post_review.py`, `merge_findings.py`, `apply_validations.py`, `apply_challenges.py`, `validate_ndjson.py`.
+- The suite covers every pipeline script: `verify_findings.py`, `filter_findings.py`, `post_review.py`, `merge_findings.py`, `finding_dedup.py`, `apply_validations.py`, `apply_challenges.py`, `validate_ndjson.py`.
 
 ## Output directory convention
 

--- a/scripts/finding_dedup.py
+++ b/scripts/finding_dedup.py
@@ -8,6 +8,9 @@ delegates here). Also usable standalone for tests and tooling.
 No external dependencies. stdlib only.
 
 Usage:
+    # Standalone / SKILL.md script invocation (scripts/ is on sys.path):
+    from finding_dedup import dedup_by_id
+    # From pytest run at the repo root (repo root is on sys.path):
     from scripts.finding_dedup import dedup_by_id
 
     merged, dupes, dropped = dedup_by_id(ndjson_findings, text_findings)

--- a/scripts/merge_findings.py
+++ b/scripts/merge_findings.py
@@ -472,6 +472,17 @@ def merge(
     all_text_findings_flat = [f for findings in text_findings.values() for f in findings]
     _, pre_val_warnings = validate_findings(all_ndjson_findings_flat + all_text_findings_flat)
 
+    # --- Real dropped_no_id (production signal) ---
+    # id-less findings are stripped by _filter_valid() below and never reach
+    # dedup, so the production count must come from the pre-validation findings
+    # here. dedup_by_id keeps its own counter for direct/tooling callers.
+    # Findings duplicated across both channels are counted per occurrence (they
+    # cannot be correlated without an id), which matches "findings dropped".
+    dropped_no_id = sum(
+        1 for f in all_ndjson_findings_flat + all_text_findings_flat
+        if f.get("id") in (None, "")
+    )
+
     # Filter each channel to only valid findings
     def _filter_valid(findings_dict: dict) -> dict:
         out = {}
@@ -486,7 +497,10 @@ def merge(
     text_findings = _filter_valid(text_findings)
 
     # --- Deduplicate ---
-    merged_raw, duplicates_resolved, dropped_no_id = deduplicate(
+    # Third return (dedup's own dropped_no_id) is always 0 here because
+    # _filter_valid() already removed id-less findings; the real count is
+    # computed above from the pre-validation findings.
+    merged_raw, duplicates_resolved, _ = deduplicate(
         ndjson_findings, text_findings
     )
 
@@ -588,7 +602,8 @@ def main(argv: list[str] | None = None) -> int:
         f"merge_findings: {len(result['findings'])} findings "
         f"(ndjson={m['findings_per_channel']['ndjson']}, "
         f"text_fallback={m['findings_per_channel']['text_fallback']}, "
-        f"dupes={m['duplicates_resolved']})",
+        f"dupes={m['duplicates_resolved']}, "
+        f"dropped_no_id={m['dropped_no_id']})",
         file=sys.stderr,
     )
     if m["truncation_warnings"]:

--- a/tests/test_finding_dedup.py
+++ b/tests/test_finding_dedup.py
@@ -87,6 +87,18 @@ class TestDedupById(unittest.TestCase):
         self.assertEqual(dupes, 1)
         self.assertEqual(dropped, 0)
 
+    def test_equal_priority_keeps_first_seen_content(self):
+        """Same id + same priority: first-seen content survives; dupe is counted."""
+        first = _f(fid="X", title="first-seen")
+        second = _f(fid="X", title="should-not-win")
+        # Both in the ndjson channel → both priority 2 (equal). Dict insertion
+        # order means "first" is processed before "second".
+        merged, dupes, dropped = dedup_by_id({"a": [first], "b": [second]}, {})
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["title"], "first-seen")
+        self.assertEqual(dupes, 1)
+        self.assertEqual(dropped, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_merge_findings.py
+++ b/tests/test_merge_findings.py
@@ -731,6 +731,19 @@ class TestMerge(unittest.TestCase):
         self.assertEqual(result["methodology"]["findings_per_channel"]["text_fallback"], 0)
         self.assertEqual(result["methodology"]["duplicates_resolved"], 0)
 
+    def test_dropped_no_id_counts_idless_findings(self):
+        """methodology.dropped_no_id reflects findings dropped for a missing/empty id."""
+        missing = {
+            "dimension": "bug", "severity": "high", "file": "x.py",
+            "line_start": 1, "title": "t", "description": "d", "confidence": 80,
+        }  # every required field EXCEPT id
+        empty = dict(missing, id="")  # id present but empty — also dropped
+        valid = _make_finding(id="bug-1")
+        _write_ndjson(self._ndjson_path("bug-detector"), [missing, empty, valid])
+        result = self._run_merge()
+        self.assertEqual(result["methodology"]["dropped_no_id"], 2)
+        self.assertEqual(len(result["findings"]), 1)  # only the valid finding survives
+
 
 # ---------------------------------------------------------------------------
 # CLI: main()


### PR DESCRIPTION
## Summary

Follow-up to the deep review of #5. Closes the four loose ends that review surfaced:

- **`scripts/merge_findings.py`** — `methodology.dropped_no_id` was structurally always `0` in the production pipeline: `merge()` runs both channels through `_filter_valid()` (which rejects findings with a missing/empty `id`) *before* `deduplicate()`, so the counter never saw an id-less finding. It is now computed from the **pre-validation** findings of both channels, and surfaced in the stderr summary. `deduplicate()` / `dedup_by_id()` keep their 3-tuple signatures unchanged (the dedup counter is still useful for direct/tooling callers).
- **`tests/test_finding_dedup.py`** — adds a regression test pinning the equal-priority **first-wins** invariant (a same-id, same-priority duplicate must not overwrite the first-seen finding). Mutation-verified: flipping `>` to `>=` fails only this test.
- **`scripts/finding_dedup.py`** — docstring `Usage` example now shows both the bare standalone import and the `scripts.`-prefixed pytest import (the previous example raised `ModuleNotFoundError` under canonical standalone invocation).
- **`CLAUDE.md`** — adds `finding_dedup.py` to the "every pipeline script" list.

## Test Plan

- [x] `python -m pytest tests/ -q` — 481 tests pass (479 baseline + 2 new)
- [x] `test_dropped_no_id_counts_idless_findings` fails under the old "count from dedup" behavior (`0 != 2`)
- [x] `test_equal_priority_keeps_first_seen_content` fails under the `>` → `>=` mutation, and no other dedup test does
- [x] both `from finding_dedup import` and `from scripts.finding_dedup import` resolve in their respective contexts

## Out of scope

Issue #7 (cross-session `FindingStore`, `dedup_by_location`, standalone CLI) remains tracked separately and is intentionally not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
