### PR TITLE
fix: change-summarizer spawn failure on Claude Code ≥2.1.211

### DIFF
--- a/agents/change-summarizer.md
+++ b/agents/change-summarizer.md
@@ -1,7 +1,7 @@
 ---
 name: change-summarizer
 description: Produces a concise semantic summary of PR/MR changes for shared context across all review agents
-tools: none
+tools: Read  # works from prompt context only; one read-only tool satisfies the harness (zero-tool agents are refused as of Claude Code 2.1.211)
 effort: medium
 model: sonnet
 color: blue

--- a/skills/deep-review/references/investigation-methodology.md
+++ b/skills/deep-review/references/investigation-methodology.md
@@ -14,7 +14,7 @@
 > 8. `agents/validator.md`
 > 9. `agents/challenger.md`
 >
-> Each agent copy has a `<!-- Canonical source: references/investigation-methodology.md -->` comment pointing back here. `change-summarizer` is excluded (tools: none).
+> Each agent copy has a `<!-- Canonical source: references/investigation-methodology.md -->` comment pointing back here. `change-summarizer` is excluded (works from prompt context only; `tools: Read` satisfies the harness non-empty requirement).
 
 ## LSP-first investigation
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why?

Fixes #9.

Claude Code **2.1.211** introduced a guard that refuses to spawn sub-agents with an empty tools list. Our `change-summarizer` declared `tools: none`, which the harness parses as an unrecognized tool name and resolves to zero tools — so Phase 2f failed with:

> Agent 'deep-review:change-summarizer' would be spawned with zero tools — refusing.

This worked on 2.1.210 and earlier; the plugin config itself did not change.

## What Changed?

- `agents/change-summarizer.md`: `tools: none` → `tools: Read` so the agent satisfies the non-empty tools requirement while still summarizing only from the inline diff in its prompt (Read is not needed for the intended workflow).
- `skills/deep-review/references/investigation-methodology.md`: update the exclusion note to match the new frontmatter.

## Additional Notes

- [x] Ran tests: `python3 -m pytest tests/ -q` (481 passed)
- [ ] Ran linters/hooks: `pre-commit run --all-files`
- [x] Updated docs or skill references if behavior changed

No script/pipeline behavior changes — frontmatter + docs only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cafad862-fb08-4bda-a542-0488a971b611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cafad862-fb08-4bda-a542-0488a971b611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

