### PR TITLE
ci: unblock semantic-release (decouple marketplace publish)

### DIFF
--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -1,0 +1,37 @@
+# Marketplace publish is intentionally separate from semantic-release.
+#
+# From 2026-05-11 through 2026-07-16, inlining this reusable workflow call in
+# release.yml caused every main push to fail at workflow startup (0s, zero jobs)
+# — GitHub validates `uses:` / caller permission envelopes before any job `if:`
+# runs, so a bad pin or under-scoped permissions blocked version bumps entirely.
+#
+# Triggered by the v* tag that semantic-release pushes. Caller permissions are
+# intentionally broad so the reusable workflow can request write scopes without
+# another silent startup_failure; tighten once claude-plugins documents the
+# minimum envelope for publish-to-marketplace.yml@933e23c.
+name: Publish to Marketplace
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  publish-to-marketplace:
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    uses: liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@933e23cb9d11ced816e043dfb22a94aa27ca0780
+    secrets: inherit
+    with:
+      tag: ${{ github.ref_name }}
+      path: "."
+      strict: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ jobs:
     concurrency:
       group: semantic-release-${{ github.ref }}
       cancel-in-progress: false
-    outputs:
-      released: ${{ steps.release.outputs.released }}
-      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: octo-sts/action@v1.1.1
         id: octo-sts
@@ -74,23 +71,8 @@ jobs:
           after_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
           if [ -n "$after_tag" ] && [ "$after_tag" != "$before_tag" ]; then
             echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "Released ${after_tag} (was ${before_tag:-none})"
           else
             echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "No release (tag still ${after_tag:-none})"
           fi
-
-      - name: Get plugin version
-        id: version
-        if: steps.release.outputs.released == 'true'
-        run: echo "version=v$(jq -r .version .claude-plugin/plugin.json)" >> "$GITHUB_OUTPUT"
-
-  publish-to-marketplace:
-    needs: release
-    if: needs.release.outputs.released == 'true'
-    permissions:
-      id-token: write
-      contents: read
-    uses: liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@933e23cb9d11ced816e043dfb22a94aa27ca0780
-    with:
-      tag: ${{ needs.release.outputs.version }}
-      path: "."
-      strict: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why?

After merging #10, the Semantic Release workflow on `main` failed again in **0s with zero jobs** — the same failure mode every `main` push has hit since 2026-05-11 (`bbeb92b`, the `933e23c` publish-to-marketplace pin).

GitHub validates reusable-workflow `uses:` pins and the caller's permission envelope **before** any job `if:` runs. That meant the marketplace publish call blocked `semantic-release` itself, so the plugin never left `2.4.0` even though #10 was a valid `fix:` (and unreleased history also includes a `feat:` from #5).

Local dry-run on `main`: next version is **`2.5.0`** (minor — squash body of #5 contains `feat:`).

## What Changed?

- `release.yml`: run **only** semantic-release (version bump / tag / GitHub Release / changelog).
- `publish-marketplace.yml` (new): tag-triggered (`v*`) reusable-workflow call with a broader caller permission envelope + `secrets: inherit`, so a publish pin/permission issue can no longer gate version bumps.

## Additional Notes

- [x] Expected release after merge: **v2.5.0** (updates `.claude-plugin/plugin.json` + `CHANGELOG.md`, tag `v2.5.0`)
- [ ] Marketplace publish may still fail on the tag push if the `933e23c` pin or STS trust needs a follow-up — that will no longer prevent the version increment
- Issue #9 was already auto-closed by #10 (`Fixes #9`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cafad862-fb08-4bda-a542-0488a971b611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cafad862-fb08-4bda-a542-0488a971b611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

