### PR TITLE
ci: trigger marketplace publish on release + workflow_dispatch

### DIFF
--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -5,16 +5,25 @@
 # — GitHub validates `uses:` / caller permission envelopes before any job `if:`
 # runs, so a bad pin or under-scoped permissions blocked version bumps entirely.
 #
-# Triggered by the v* tag that semantic-release pushes. Caller permissions are
-# intentionally broad so the reusable workflow can request write scopes without
-# another silent startup_failure; tighten once claude-plugins documents the
-# minimum envelope for publish-to-marketplace.yml@933e23c.
+# Prefer the `release` event (GitHub Release created by semantic-release) over
+# `push` tags: tag pushes from the release bot do not always enqueue workflows.
+# `workflow_dispatch` covers backfills (e.g. v2.5.0).
+#
+# Caller permissions are intentionally broad so the reusable workflow can
+# request write scopes without another silent startup_failure; tighten once
+# claude-plugins documents the minimum envelope for
+# publish-to-marketplace.yml@933e23c.
 name: Publish to Marketplace
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish (e.g. v2.5.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -32,6 +41,6 @@ jobs:
     uses: liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@933e23cb9d11ced816e043dfb22a94aa27ca0780
     secrets: inherit
     with:
-      tag: ${{ github.ref_name }}
+      tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
       path: "."
       strict: true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why?

`v2.5.0` released successfully after #11, but `publish-marketplace.yml` never ran — tag pushes from the release bot did not enqueue the workflow.

## What Changed?

- Trigger on `release: published` (the GitHub Release semantic-release already creates)
- Add `workflow_dispatch` with a `tag` input so `v2.5.0` (and future tags) can be backfilled

## Additional Notes

- Version bump itself is done: plugin is at **2.5.0** / [release](https://github.com/liatrio-labs/claude-deep-review/releases/tag/v2.5.0)
- After merge, will dispatch publish for `v2.5.0`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cafad862-fb08-4bda-a542-0488a971b611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cafad862-fb08-4bda-a542-0488a971b611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

