### PR TITLE
ci: fix marketplace publish startup_failure (pin to @main)

### DIFF
--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -9,10 +9,11 @@
 # `push` tags: tag pushes from the release bot do not always enqueue workflows.
 # `workflow_dispatch` covers backfills (e.g. v2.5.0).
 #
-# Caller permissions are intentionally broad so the reusable workflow can
-# request write scopes without another silent startup_failure; tighten once
-# claude-plugins documents the minimum envelope for
-# publish-to-marketplace.yml@933e23c.
+# Pin to @main (not a commit SHA): the previous SHA pin 933e23c became
+# unresolvable and caused startup_failure on every publish attempt. Actions in
+# this org can still reach liatrio-labs/claude-plugins; floating main tracks the
+# healed url+sha catalog bump path from PR #100 without depending on a tip SHA
+# that may not survive squash-merge.
 name: Publish to Marketplace
 
 on:
@@ -38,7 +39,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    uses: liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@933e23cb9d11ced816e043dfb22a94aa27ca0780
+    uses: liatrio-labs/claude-plugins/.github/workflows/publish-to-marketplace.yml@main
     secrets: inherit
     with:
       tag: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why?

Manual **Publish to Marketplace** for `v2.5.0` failed with `startup_failure` (run [29511061920](https://github.com/liatrio-labs/claude-deep-review/actions/runs/29511061920)) — same mode that blocked release CI from May–July.

Evidence that this is a bad pin, not missing org access:
- The prior pin `@6b89d0b…` *did* resolve (release jobs ran; publish was only skipped when there was nothing to release).
- Everything after `@933e23c…` fails at startup with zero jobs.

`933e23c` was almost certainly a PR-head SHA from `claude-plugins` #100 that did not survive squash-merge onto `main`.

## What Changed?

- Pin `publish-to-marketplace.yml` to `@main` so Actions resolves a live ref.
- Keep the broader caller permission envelope + `workflow_dispatch` backfill path.

## After merge

Re-run **Actions → Publish to Marketplace → Run workflow** with tag `v2.5.0`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cafad862-fb08-4bda-a542-0488a971b611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cafad862-fb08-4bda-a542-0488a971b611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

