### PR TITLE
ci: fix semantic-release OIDC subject after repo rename

### DIFF
--- a/.github/chainguard/main-semantic-release.sts.yaml
+++ b/.github/chainguard/main-semantic-release.sts.yaml
@@ -1,6 +1,12 @@
 issuer: https://token.actions.githubusercontent.com
 
-subject: repo:liatrio-labs/claude-code-gauntlet:ref:refs/heads/main
+# Immutable OIDC subject format: the 2026-07 rename (claude-deep-review ->
+# claude-code-gauntlet) permanently moved this repo onto GitHub's owner-ID/
+# repo-ID-qualified sub format (rollout for repos created/renamed after
+# 2026-07-15). Value copied verbatim from the token presented in run
+# 29962444808; the IDs are immutable, but a future rename would change the
+# slug portions — update them here if that ever happens.
+subject: repo:liatrio-labs@223510100/claude-code-gauntlet@1190928743:ref:refs/heads/main
 
 permissions:
   contents: write

--- a/.github/workflows/publish-marketplace.yml
+++ b/.github/workflows/publish-marketplace.yml
@@ -8,8 +8,12 @@
 name: Publish to Marketplace
 
 on:
-  release:
-    types: [published]
+  # HOLD (owner decision 2026-07-22): automatic publish-on-release is disabled
+  # until v3.1.0 — v3.0.0 must NOT deploy to the company-wide marketplace.
+  # Marketplace deployment is a manual owner action via workflow_dispatch.
+  # Re-enable automatic publishing by restoring:
+  #   release:
+  #     types: [published]
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## What

1. **STS trust-policy subject fix (L0):** the 2026-07 rename to `claude-code-gauntlet` permanently moved this repo onto GitHub's immutable OIDC subject format (`repo:OWNER@OWNER-ID/REPO@REPO-ID:...` — rollout for repos created/renamed after 2026-07-15). The octo-sts trust policy still pinned the bare-slug subject, so every semantic-release run on main has failed at token exchange (403 subject mismatch — run 29962444808) and **the pending 3.0.0 has never released** (the installed marketplace cache is v3 content under a 2.6.0 label). The new subject is copied **verbatim** from the failed run's token and cross-checked against `gh api /repos/liatrio-labs/claude-code-gauntlet/actions/oidc/customization/sub` (`sub_claim_prefix` matches exactly).

2. **Marketplace deployment HOLD:** `publish-marketplace.yml` no longer triggers on `release: published`. Deployment to the company-wide marketplace is intentionally **held until v3.1.0** (owner decision 2026-07-22) — the 3.0.0 release this fix unblocks must not auto-deploy. `workflow_dispatch` remains the owner's manual deployment path (the reusable-workflow pin stays at diagnostic SHA `6b89d0b`).

## Effect on merge

Merging this to main re-runs semantic-release with a working token: it will release the pending **3.0.0** (`feat!` from cdf19f8) — tag + `chore(release): 3.0.0` commit + `plugin.json`/`PIPELINE_VERSION` bump — with **no marketplace publication**.

Part of the V3.1 effort (issue #17, Task 0 of the implementation plan).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI trust and release automation: a wrong STS subject would still block releases, while disabling release-triggered marketplace publish is intentional but affects how v3.0.0 reaches users.
> 
> **Overview**
> **Unblocks semantic-release on `main`** by replacing the octo-sts trust `subject` with GitHub’s immutable owner/repo ID–qualified OIDC claim (`liatrio-labs@223510100/claude-code-gauntlet@1190928743`), matching tokens issued after the 2026-07 rename; the previous bare-slug subject caused 403s at token exchange and left pending **3.0.0** unreleased.
> 
> **Separately gates marketplace deployment:** `publish-marketplace.yml` no longer runs on `release: published` (owner hold until **v3.1.0** so **3.0.0** must not auto-deploy company-wide). **`workflow_dispatch`** remains the manual publish path; comments document how to restore automatic publishing later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a6f0db320a0de5fe14f25f01b04e771dcf469a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->