### PR TITLE
docs: add AGENTS.md with Cursor Cloud environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+Repository-specific guidance for AI agents. See `CLAUDE.md` for the authoritative
+architecture, schema, and pipeline rules; `README.md` (Development section) and
+`CONTRIBUTING.md` for the canonical dev commands.
+
+## Cursor Cloud specific instructions
+
+This repo is a Claude Code plugin with **no runtime dependencies** — the dev
+environment is just the test/lint toolchain. Two languages are in play: Python 3
+(stdlib-only pipeline scripts + pytest) and Node (the workflow bundle + `node --test`).
+
+### Environment gotchas
+
+- **Use `python3`, not `python`.** This VM has no `python` symlink; CI uses
+  `python` because it runs on `actions/setup-python`. Run commands as
+  `python3 -m pytest ...`.
+- **Node is pinned to 24.18.0 via nvm.** The VM also ships a bundled node v22 at
+  `/exec-daemon/node` that appears earlier on the default `PATH`. Setup appended a
+  `PATH` prepend to `~/.bashrc` so the pinned Node 24 and user pip bins
+  (`~/.local/bin`, where `pytest`/`pre-commit` live) win. New login shells (the
+  default) pick this up automatically; if a tool resolves to the wrong version,
+  start a login shell (`bash -lc '...'`) or check `which node`.
+- **`node --test` needs the glob form.** Run `node --test workflows/test/*.test.js`
+  — the bare directory form is not a valid target on node 24 (also noted in CLAUDE.md).
+
+### Commands (all from repo root)
+
+- Python tests: `python3 -m pytest tests/ -q`
+- Bench self-tests: `python3 -m pytest bench/tests/ -q`
+- Workflow JS tests: `node --test workflows/test/*.test.js`
+- Lint (all hooks): `pre-commit run --all-files`
+- Rebuild the JS bundle after editing `workflows/src/*.js`: `node workflows/build.js`
+  (CI byte-verifies the committed `workflows/pipeline.js` against a fresh build).
+
+### Notes
+
+- `CHANGELOG.md` is release-automation generated. `markdownlint-fix` may want to
+  reformat it — do not commit that incidental change.
+- There is no application server / GUI. The "app" is the deterministic review
+  gauntlet; exercise it by piping a findings JSON through the pipeline scripts,
+  e.g. `python3 scripts/filter_findings.py <findings.json>`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why?

Set up a reproducible development environment for Cloud Agents and capture the non-obvious startup caveats so future agents can run tests, lint, and the pipeline without rediscovering them.

## What Changed?

- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the two-language toolchain (stdlib-only Python + pytest, Node workflow bundle), and the environment gotchas discovered during setup.
- No source/product code changed.

## Environment setup (for reviewers)

Installed dev tooling only (repo has no runtime deps):
- Node `24.18.0` (pinned) via nvm — the VM's bundled node v22 at `/exec-daemon/node` is earlier on `PATH`, so a one-time `~/.bashrc` prepend makes the pinned node + `~/.local/bin` (pytest/pre-commit) win.
- `pytest` and `pre-commit` via `pip install --user`.

Update script (dependency refresh only): `pip install --user pytest pre-commit` + `nvm install 24.18.0`.

## Verification

| Component | Command | Result |
|---|---|---|
| Python tests | `python3 -m pytest tests/ -q` | 525 passed |
| Bench self-tests | `python3 -m pytest bench/tests/ -q` | 305 passed |
| Workflow JS tests | `node --test workflows/test/*.test.js` | 263 passed |
| Bundle freshness | `node workflows/build.js` + `git diff` | matches committed `pipeline.js` |
| Lint | `pre-commit run --all-files` | all hooks pass |

Hello-world (core deterministic gauntlet): piped 3 findings through `scripts/filter_findings.py` — the high-confidence bug (88) and critical security finding (91) were delivered to the report; the low-confidence simplification nit (30) was eliminated by the confidence threshold.

[Environment verification log](https://cursor.com/agents/bc-4470ecb8-349c-4e08-8443-de0a82ba85da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_verification.log)
[Hello-world pipeline run](https://cursor.com/agents/bc-4470ecb8-349c-4e08-8443-de0a82ba85da/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_pipeline.log)

## Additional Notes

`CHANGELOG.md` is release-automation generated; `markdownlint-fix` may want to reformat it — that incidental change should not be committed (noted in AGENTS.md).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4470ecb8-349c-4e08-8443-de0a82ba85da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4470ecb8-349c-4e08-8443-de0a82ba85da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

