### PR TITLE
docs: record two verification gotchas in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,30 @@ committed via `[skip ci]`, so its release commits bypass CI and can reintroduce 
 (e.g. consecutive blank lines) that only surface later on a PR's full-repo `pre-commit run
 --all-files`. If that happens, commit the auto-fixed `CHANGELOG.md` alongside your change.
 
+`pre-commit run --all-files` means **all git-tracked files**, not all files on disk. A file you
+just created is invisible to every hook until you `git add` it, so a new doc can pass locally and
+then fail cspell or markdownlint in CI the moment it is committed — this is exactly how a new
+`SECURITY.md` reached a PR with three unknown words. `git add` new files before you trust a green
+lint run.
+
+### Contribution surface (issue forms, labels) — what cannot be tested pre-merge
+
+`tests/test_contribution_surface.py` covers what is checkable offline: issue-form schema, the
+label taxonomy in `.github/labels.json`, `bug_report.yml`'s phase list against README's
+Architecture section, and the CI-gate commands quoted in `CONTRIBUTING.md`. Two things it cannot
+reach, both of which need work sequenced *after* a merge and by someone with write access:
+
+- **GitHub serves issue forms from the default branch only.** A change under
+  `.github/ISSUE_TEMPLATE/` cannot be exercised through the real form until it lands on `main`;
+  the new-issue page keeps rendering the old form until then. Any plan that puts a form
+  submission test before the merge is mis-ordered. This matters because an invalid form does not
+  error — GitHub refuses to render it, silently.
+- **Labels must exist in the repo before a form can apply one.** GitHub drops an unknown
+  issue-form label without reporting it, so the manifest has to be synced with
+  `python3 .github/labels_diff.py --commands --repo <owner>/<repo>` (a write; a read-only token
+  cannot do it) and then confirmed with `--live -` or the `workflow_dispatch` "Verify Label
+  Taxonomy" workflow. See `docs/maintainer-issues.md`.
+
 ### Full product E2E (needs external access — usually unavailable in cloud)
 
 A real review run (`/code-gauntlet`) requires the **Claude Code CLI** (`claude`) with the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why?

Two things cost real time on #41, and neither was written down anywhere an agent would look.

**`pre-commit run --all-files` only checks git-tracked files.** A newly created file is invisible to every hook until it is `git add`ed, so `SECURITY.md` passed a full local lint run while untracked and then failed cspell with three unknown words the moment it was committed. The existing "Lint gotcha" section is exactly where someone would have looked for this.

**GitHub serves issue forms from the default branch.** A change under `.github/ISSUE_TEMPLATE/` cannot be exercised through the real form until it merges — the new-issue page keeps rendering the old form until then. My first handoff plan for #30 ordered the form-submission test *before* the merge, which would have tested the v2 form and reported a pass. Worth stating plainly because the failure mode is silent in both directions: an invalid form does not error, GitHub just refuses to render it.

## What Changed?

`AGENTS.md` only. One paragraph appended to "Lint gotcha", and one new subsection, "Contribution surface (issue forms, labels) — what cannot be tested pre-merge", which also records that a label must pre-exist in the repo before a form can apply it and that syncing `.github/labels.json` needs write access a read-only token does not have.

Both entries name what `tests/test_contribution_surface.py` does cover, so the new subsection reads as a boundary on the offline suite rather than as a warning to ignore it.

## Additional Notes

Measurement tier: **`suites-only`** per `bench/MEASUREMENT.md` — a single documentation file, inert to pipeline behavior.

- [x] Pipeline tests pass: `python -m pytest tests/ -q` — 562 passed, 245 subtests
- [x] Bench self-tests pass: `python -m pytest bench/tests/ -q` — 354 passed, 14 subtests
- [x] Workflow tests pass: `node --test workflows/test/*.test.js` — 263 pass, 0 fail (Node 24.18.0)
- [x] Bundle rebuilt and byte-exact — no `workflows/src/` edits
- [x] Parity fixtures regenerated if a deterministic transform changed — n/a
- [x] Linters/hooks pass: `pre-commit run --all-files` — every hook Passed, with `AGENTS.md` staged first, per the gotcha this PR documents
- [x] Docs, skill references, and agent contracts updated if behavior changed — n/a, no behavior change

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98132bd2-ec6f-4aab-a118-96f2b809bd64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98132bd2-ec6f-4aab-a118-96f2b809bd64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

