### PR TITLE
fix(bench): decide G3 writer degrades from parsed gaps, not raw bytes

### DIFF
--- a/bench/MEASUREMENT.md
+++ b/bench/MEASUREMENT.md
@@ -76,7 +76,8 @@ python3 bench/run.py --check <RUN_ID>
    judged from that parsed array alone; their raw bytes are never scanned,
    because a wf record echoes the whole `workflows/pipeline.js` bundle into its
    `script` field and the bundle's own source contains those sentinels as
-   string constants. When such a carrier will not parse, or carries no `gaps`
+   ordinary substrings (string/template literals and comments). When such a
+   carrier will not parse, or carries no `gaps`
    at all, it falls back to a raw-text scan with that `script` field blanked
    first. Carriers with no `gaps` structure to parse — `raw.json` (a result
    envelope whose `.result` is prose) and `code-gauntlet-report-*.md` — are

--- a/bench/MEASUREMENT.md
+++ b/bench/MEASUREMENT.md
@@ -71,8 +71,16 @@ python3 bench/run.py --check <RUN_ID>
 2. Payload parse + adapter-required fields + union-schema findings check
    (requires ≥1 `code-gauntlet-findings-*.json` per PR)
 3. Zero `origin=unknown` findings; no writer no-write-proof / partial-artifacts
-   degrade (scans compact-return carriers `workflows/wf_*.json` + `raw.json`,
-   plus report / `code-gauntlet-checkpoint-all-*.json`)
+   degrade. Carriers that own a `gaps` array — `workflows/wf_*.json` (the
+   compact Workflow return) and `code-gauntlet-checkpoint-all-*.json` — are
+   judged from that parsed array alone; their raw bytes are never scanned,
+   because a wf record echoes the whole `workflows/pipeline.js` bundle into its
+   `script` field and the bundle's own source contains those sentinels as
+   string constants. When such a carrier will not parse, or carries no `gaps`
+   at all, it falls back to a raw-text scan with that `script` field blanked
+   first. Carriers with no `gaps` structure to parse — `raw.json` (a result
+   envelope whose `.result` is prose) and `code-gauntlet-report-*.md` — are
+   raw-text scanned as-is; they never embed the bundle.
 4. Plugin identity — when the Headless config echo carries `pipeline_version` and
    `plugin_root`, those receipts are validated against the repo's
    `workflows/pipeline.js` version and plugin root (primary). A complete valid

--- a/bench/runner/check.py
+++ b/bench/runner/check.py
@@ -50,7 +50,7 @@ _DEGRADE_RE = re.compile(
 
 # Value of a JSON ``"script"`` field — a workflow record's echo of the whole
 # pipeline bundle, whose own source carries the degrade sentinels as ordinary
-# string constants (issue #52). The escape-aware body is required: a naive
+# substrings (issue #52). The escape-aware body is required: a naive
 # ``[^"]*`` stops at the first ``\"`` and leaves most of the bundle behind.
 _SCRIPT_FIELD_RE = re.compile(r'"script"\s*:\s*"(?:\\.|[^"\\])*"', re.DOTALL)
 # The same field truncated mid-write, with no closing quote.
@@ -72,8 +72,9 @@ PIPELINE_REL = Path("workflows") / "pipeline.js"
 #   workflows/wf_*.json  carries the compact return at ``result.gaps``. It also
 #       echoes the whole ~230 KB workflows/pipeline.js bundle into its
 #       ``script`` field, and that bundle's source contains the sentinels as
-#       ordinary string constants ("no write proof" x4, "partial-artifacts"
-#       x6) — so a raw scan matches on EVERY collected record, degraded or not.
+#       ordinary substrings ("no write proof" x4 string/template literals;
+#       "partial-artifacts" x6 — 1 string literal + 5 comments) — so a raw
+#       scan matches on EVERY collected record, degraded or not.
 #   code-gauntlet-checkpoint-all-*.json  the persisted checkpoint's ``gaps``.
 #
 # TEXT carriers have no ``gaps`` structure to parse, so a raw-text scan is the
@@ -337,20 +338,12 @@ def _gaps_lists(node):
             yield from _gaps_lists(value)
 
 
-def _gaps_strings(node):
-    """Yield string entries from any ``gaps`` array nested under ``node``."""
-    for gaps in _gaps_lists(node):
-        for item in gaps:
-            if isinstance(item, str):
-                yield item
-
-
 def _strip_script_field(text):
     """Blank out any JSON ``"script"`` field value ahead of a raw-text scan.
 
     ``workflows/wf_*.json`` echoes the entire pipeline bundle into that field,
     and the bundle's own source carries the degrade sentinels as ordinary
-    string constants (issue #52). Handles both a well-formed value and one
+    substrings (issue #52). Handles both a well-formed value and one
     truncated mid-write.
 
     Only STRUCTURED carriers get this treatment. The unterminated-field pattern
@@ -390,8 +383,14 @@ def _scan_degrade_text(pr_dir):
                 data = json.loads(text)
             except (json.JSONDecodeError, ValueError):
                 data = None
-            if data is not None and any(True for _ in _gaps_lists(data)):
-                matched = any(_DEGRADE_RE.search(g) for g in _gaps_strings(data))
+            gaps_lists = list(_gaps_lists(data)) if data is not None else []
+            if gaps_lists:
+                matched = any(
+                    _DEGRADE_RE.search(item)
+                    for gaps in gaps_lists
+                    for item in gaps
+                    if isinstance(item, str)
+                )
             else:
                 matched = bool(_DEGRADE_RE.search(_strip_script_field(text)))
         else:

--- a/bench/runner/check.py
+++ b/bench/runner/check.py
@@ -48,21 +48,57 @@ _DEGRADE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Value of a JSON ``"script"`` field — a workflow record's echo of the whole
+# pipeline bundle, whose own source carries the degrade sentinels as ordinary
+# string constants (issue #52). The escape-aware body is required: a naive
+# ``[^"]*`` stops at the first ``\"`` and leaves most of the bundle behind.
+_SCRIPT_FIELD_RE = re.compile(r'"script"\s*:\s*"(?:\\.|[^"\\])*"', re.DOTALL)
+# The same field truncated mid-write, with no closing quote.
+_SCRIPT_FIELD_OPEN_RE = re.compile(r'"script"\s*:\s*"(?:\\.|[^"\\])*\Z', re.DOTALL)
+
 # Expected pipeline entry relative to the plugin/repo root.
 PIPELINE_REL = Path("workflows") / "pipeline.js"
 
-# Where G3 looks for writer no-write-proof / partial-artifacts signals.
-# writeArtifacts puts that gap on the compact Workflow return (gaps[]), which
-# lands in collected workflows/wf_*.json and often in raw.json's .result text —
-# NOT in the persisted report/checkpoint (those are written before the echo
-# proof runs). Report/checkpoint remain scanned as secondary carriers.
+# Where G3 looks for writer no-write-proof / partial-artifacts signals, and how
+# each carrier is read (issue #52). writeArtifacts puts that gap on the compact
+# Workflow return (gaps[]), which lands in collected workflows/wf_*.json and
+# often in raw.json's .result text — NOT in the persisted report/checkpoint
+# (those are written before the echo proof runs). Report/checkpoint remain
+# scanned as secondary carriers.
+#
+# STRUCTURED carriers own a real ``gaps`` array, so that parsed array is the
+# authoritative — and only — signal consulted; their raw bytes are never
+# regex-scanned:
+#   workflows/wf_*.json  carries the compact return at ``result.gaps``. It also
+#       echoes the whole ~230 KB workflows/pipeline.js bundle into its
+#       ``script`` field, and that bundle's source contains the sentinels as
+#       ordinary string constants ("no write proof" x4, "partial-artifacts"
+#       x6) — so a raw scan matches on EVERY collected record, degraded or not.
+#   code-gauntlet-checkpoint-all-*.json  the persisted checkpoint's ``gaps``.
+#
+# TEXT carriers have no ``gaps`` structure to parse, so a raw-text scan is the
+# only mechanism that can ever see their signal:
+#   raw.json  the child CLI's result envelope, whose ``result`` is free prose
+#       (the model's final turn), never a nested ``gaps`` array. Measured over
+#       the retained corpus: 0/131 carry a structured ``gaps``, and 0/131 embed
+#       the bundle (max 9.5 KB — invoke.py never forwards Workflow tool-call
+#       inputs here), so scanning its bytes is both necessary and safe.
+#   code-gauntlet-report-*.md  markdown; there is no parse step to consult.
+#
 # Do not include bench-only fixture names such as deep-review-report.md.
-_DEGRADE_SCAN_PATTERNS = (
-    "workflows/wf_*.json",
-    "raw.json",
-    "code-gauntlet-report-*.md",
-    "code-gauntlet-checkpoint-all-*.json",
-)
+_DEGRADE_STRUCTURED = "structured"
+_DEGRADE_TEXT = "text"
+
+_DEGRADE_CARRIER_POLICY = {
+    "workflows/wf_*.json": _DEGRADE_STRUCTURED,
+    "raw.json": _DEGRADE_TEXT,
+    "code-gauntlet-report-*.md": _DEGRADE_TEXT,
+    "code-gauntlet-checkpoint-all-*.json": _DEGRADE_STRUCTURED,
+}
+
+# Single source of truth: the scanned patterns ARE the policy's keys, so the
+# two cannot desync. Scan order follows insertion order above.
+_DEGRADE_SCAN_PATTERNS = tuple(_DEGRADE_CARRIER_POLICY)
 
 
 def _load_json(path):
@@ -271,56 +307,95 @@ def _check_echo_identity(pr_dir, repo_root, label):
 
 
 def _iter_degrade_scan_paths(pr_dir):
-    """Yield artifact paths G3 scans for writer-degrade signals."""
+    """Yield ``(path, pattern)`` for artifacts G3 scans for writer degrades.
+
+    The pattern travels with the path so the caller can look up that carrier's
+    ``_DEGRADE_CARRIER_POLICY`` entry.
+    """
     pr_dir = Path(pr_dir)
     for pat in _DEGRADE_SCAN_PATTERNS:
         if "*" in pat:
             for path in sorted(pr_dir.glob(pat)):
                 if path.is_file():
-                    yield path
+                    yield path, pat
         else:
             path = pr_dir / pat
             if path.is_file():
-                yield path
+                yield path, pat
+
+
+def _gaps_lists(node):
+    """Yield every ``gaps`` array nested anywhere under ``node``."""
+    if isinstance(node, dict):
+        gaps = node.get("gaps")
+        if isinstance(gaps, list):
+            yield gaps
+        for value in node.values():
+            yield from _gaps_lists(value)
+    elif isinstance(node, list):
+        for value in node:
+            yield from _gaps_lists(value)
 
 
 def _gaps_strings(node):
     """Yield string entries from any ``gaps`` array nested under ``node``."""
-    if isinstance(node, dict):
-        gaps = node.get("gaps")
-        if isinstance(gaps, list):
-            for item in gaps:
-                if isinstance(item, str):
-                    yield item
-        for value in node.values():
-            yield from _gaps_strings(value)
-    elif isinstance(node, list):
-        for value in node:
-            yield from _gaps_strings(value)
+    for gaps in _gaps_lists(node):
+        for item in gaps:
+            if isinstance(item, str):
+                yield item
+
+
+def _strip_script_field(text):
+    """Blank out any JSON ``"script"`` field value ahead of a raw-text scan.
+
+    ``workflows/wf_*.json`` echoes the entire pipeline bundle into that field,
+    and the bundle's own source carries the degrade sentinels as ordinary
+    string constants (issue #52). Handles both a well-formed value and one
+    truncated mid-write.
+
+    Only STRUCTURED carriers get this treatment. The unterminated-field pattern
+    necessarily runs to end-of-text, so applying it to a TEXT carrier could
+    swallow genuine trailing prose — and TEXT carriers never embed the bundle,
+    so there is nothing there to neutralize.
+    """
+    text = _SCRIPT_FIELD_RE.sub('"script":""', text)
+    return _SCRIPT_FIELD_OPEN_RE.sub('"script":""', text)
 
 
 def _scan_degrade_text(pr_dir):
     """Return basenames of artifacts carrying writer-degrade signals.
 
-    Primary signal: compact Workflow return ``gaps`` (in ``workflows/wf_*.json``
-    / ``raw.json``). Secondary: report/checkpoint text that happens to echo it.
+    A STRUCTURED carrier is judged by its parsed ``gaps`` array and nothing
+    else: the presence of any ``gaps`` list — *including an empty one* —
+    settles the question, so the healthy ``result.gaps == []`` shape reads as
+    clean instead of falling through to a byte scan that the embedded pipeline
+    bundle would always match (issue #52).
+
+    A structured carrier that will not parse, or that has no ``gaps`` anywhere,
+    is still scanned — reporting "clean" for an artifact we could not read
+    would be a new way to lose a run — but with the bundle-bearing ``script``
+    field blanked first. TEXT carriers have no structure to consult and are
+    scanned as-is. See ``_DEGRADE_CARRIER_POLICY`` for the classification.
     """
     hits = []
     seen = set()
-    for path in _iter_degrade_scan_paths(pr_dir):
+    for path, pattern in _iter_degrade_scan_paths(pr_dir):
         label = str(path.relative_to(pr_dir)) if path.is_relative_to(pr_dir) else path.name
         try:
             text = path.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        matched = bool(_DEGRADE_RE.search(text))
-        if not matched and path.suffix == ".json":
+        if _DEGRADE_CARRIER_POLICY[pattern] == _DEGRADE_STRUCTURED:
             try:
                 data = json.loads(text)
             except (json.JSONDecodeError, ValueError):
                 data = None
-            if data is not None:
+            if data is not None and any(True for _ in _gaps_lists(data)):
                 matched = any(_DEGRADE_RE.search(g) for g in _gaps_strings(data))
+            else:
+                matched = bool(_DEGRADE_RE.search(_strip_script_field(text)))
+        else:
+            matched = bool(_DEGRADE_RE.search(text))
         if matched and label not in seen:
             seen.add(label)
             hits.append(label)

--- a/bench/tests/test_check.py
+++ b/bench/tests/test_check.py
@@ -393,8 +393,8 @@ class CheckRunTest(unittest.TestCase):
     def test_wf_script_field_bundle_literals_do_not_fail_g3(self):
         """Issue #52: a wf record echoes the whole pipeline bundle into its
         ``script`` field, and that bundle's source carries the degrade
-        sentinels as ordinary string constants. A run whose ``result.gaps`` is
-        clean must not be flagged because of them.
+        sentinels as ordinary substrings (literals and comments). A run whose
+        ``result.gaps`` is clean must not be flagged because of them.
         """
         _build_ok_run(self.run_dir)
         pr = self.run_dir / "pr-example-repo-1"

--- a/bench/tests/test_check.py
+++ b/bench/tests/test_check.py
@@ -385,6 +385,198 @@ class CheckRunTest(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertTrue(any("raw.json" in f and "partial-artifacts" in f for f in result["failures"]))
 
+    def _clean_secondary_carriers(self, pr):
+        """Blank the report/checkpoint carriers so only the wf record can fire."""
+        (pr / "code-gauntlet-report-deadbeef.md").write_text("# Report\n", encoding="utf-8")
+        _write_json(pr / "code-gauntlet-checkpoint-all-deadbeef.json", {"phases": {}})
+
+    def test_wf_script_field_bundle_literals_do_not_fail_g3(self):
+        """Issue #52: a wf record echoes the whole pipeline bundle into its
+        ``script`` field, and that bundle's source carries the degrade
+        sentinels as ordinary string constants. A run whose ``result.gaps`` is
+        clean must not be flagged because of them.
+        """
+        _build_ok_run(self.run_dir)
+        pr = self.run_dir / "pr-example-repo-1"
+        self._clean_secondary_carriers(pr)
+        _write_json(
+            pr / "workflows" / "wf_test-0001.json",
+            {
+                "runId": "wf_test-0001",
+                "scriptPath": PIPELINE,
+                "status": "completed",
+                # Escaped quotes matter: a naive "script"\s*:\s*"[^"]*" stops at
+                # the first \" and leaves the rest of the bundle in the scan.
+                "script": (
+                    'function writeArtifacts() {\n'
+                    '  return fail("writer echo did not cover all three primary '
+                    'artifact paths (no write proof)");\n'
+                    '}\n'
+                    'const note = "he said \\"partial-artifacts\\" and moved on";\n'
+                    'gaps.push("artifacts not persisted (partial-artifacts)");\n'
+                ),
+                "result": {
+                    "ok": True,
+                    "partial": False,
+                    "artifactPaths": {
+                        "findings": "code-gauntlet-findings-deadbeef.json",
+                        "report": "code-gauntlet-report-deadbeef.md",
+                        "postReview": "code-gauntlet-post-review-deadbeef.json",
+                        "checkpoints": "code-gauntlet-checkpoint-all-deadbeef.json",
+                    },
+                    "gaps": [],
+                },
+            },
+        )
+        result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
+        self.assertTrue(result["ok"], result["failures"])
+        self.assertEqual(result["failures"], [])
+
+    def test_wf_script_field_bundle_literals_with_genuine_gap_fails_g3(self):
+        """The same contaminated ``script`` field, but a genuine degrade in
+        ``result.gaps`` — the fix must not overcorrect into a false negative.
+        """
+        _build_ok_run(self.run_dir)
+        pr = self.run_dir / "pr-example-repo-1"
+        self._clean_secondary_carriers(pr)
+        _write_json(
+            pr / "workflows" / "wf_test-0001.json",
+            {
+                "runId": "wf_test-0001",
+                "scriptPath": PIPELINE,
+                "status": "completed",
+                "script": (
+                    'const note = "he said \\"partial-artifacts\\" and moved on";\n'
+                    'gaps.push("(no write proof)");\n'
+                ),
+                "result": {
+                    "ok": True,
+                    "partial": True,
+                    "artifactPaths": {
+                        "findings": None,
+                        "report": None,
+                        "postReview": None,
+                        "checkpoints": None,
+                    },
+                    "gaps": [
+                        "writeArtifacts: writer echo did not account for all four "
+                        "planned artifact paths (no write proof) — artifacts not "
+                        "persisted (partial-artifacts)"
+                    ],
+                },
+            },
+        )
+        result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any("workflows/wf_" in f and "partial-artifacts" in f for f in result["failures"])
+        )
+
+    def test_unparseable_wf_record_bundle_literals_only_does_not_fail_g3(self):
+        """A wf record truncated mid-write has no structure to consult, so it
+        falls back to a raw-text scan — with the bundle-bearing ``script``
+        field blanked first, including when its closing quote never arrived.
+        """
+        _build_ok_run(self.run_dir)
+        pr = self.run_dir / "pr-example-repo-1"
+        self._clean_secondary_carriers(pr)
+        wf_path = pr / "workflows" / "wf_test-0001.json"
+        wf_path.parent.mkdir(parents=True, exist_ok=True)
+        wf_path.write_text(
+            '{\n'
+            '  "runId": "wf_test-0001",\n'
+            '  "scriptPath": ' + json.dumps(PIPELINE) + ',\n'
+            '  "script": "const note = \\"partial-artifacts\\";\\n'
+            'return fail(\\"... (no write proof)\\");\\n',
+            encoding="utf-8",
+        )
+        with open(wf_path, encoding="utf-8") as fh:
+            self.assertRaises(json.JSONDecodeError, json.load, fh)
+        result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
+        self.assertFalse(
+            any("writer degrade" in f for f in result["failures"]), result["failures"]
+        )
+
+    def test_unparseable_wf_record_with_genuine_gap_fails_g3(self):
+        """Same truncated record, but the degrade phrase survives outside the
+        ``script`` field — the raw-text fallback must still catch it.
+        """
+        _build_ok_run(self.run_dir)
+        pr = self.run_dir / "pr-example-repo-1"
+        self._clean_secondary_carriers(pr)
+        wf_path = pr / "workflows" / "wf_test-0001.json"
+        wf_path.parent.mkdir(parents=True, exist_ok=True)
+        wf_path.write_text(
+            '{\n'
+            '  "runId": "wf_test-0001",\n'
+            '  "script": "const note = \\"harmless\\";\\n",\n'
+            '  "result": {\n'
+            '    "gaps": ["writeArtifacts: writer echo did not cover all three '
+            'primary artifact paths (no write proof) — artifacts not persisted '
+            '(partial-artifacts)"',
+            encoding="utf-8",
+        )
+        with open(wf_path, encoding="utf-8") as fh:
+            self.assertRaises(json.JSONDecodeError, json.load, fh)
+        result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any("workflows/wf_" in f and "partial-artifacts" in f for f in result["failures"])
+        )
+
+    def test_structured_carrier_clean_gaps_ignores_stray_bytes(self):
+        """For a structured carrier the parsed ``gaps`` array is authoritative:
+        a sentinel elsewhere in the document does not make the run degraded.
+        """
+        _build_ok_run(self.run_dir)
+        pr = self.run_dir / "pr-example-repo-1"
+        _write_json(
+            pr / "code-gauntlet-checkpoint-all-deadbeef.json",
+            {
+                "gaps": [],
+                "phases": {
+                    "challenge": {
+                        "note": "challenger quoted 'partial-artifacts' from the source"
+                    }
+                },
+            },
+        )
+        result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
+        self.assertTrue(result["ok"], result["failures"])
+
+    def test_text_carrier_keeps_prose_after_truncated_script_field(self):
+        """A TEXT carrier's bytes are scanned as-is (issue #52).
+
+        Script-blanking is for structured carriers only: the unterminated-field
+        pattern runs to end-of-text, so applying it here would swallow the
+        genuine prose that follows a truncated ``script`` field.
+        """
+        _build_ok_run(self.run_dir)
+        pr = self.run_dir / "pr-example-repo-1"
+        (pr / "raw.json").write_text(
+            '{"type": "result", "meta": {"script": "a snippet that never closes\n'
+            "MEANWHILE elsewhere in the prose: no write proof for findings.json\n",
+            encoding="utf-8",
+        )
+        result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any("raw.json" in f and "no-write-proof" in f for f in result["failures"]),
+            result["failures"],
+        )
+
+    def test_degrade_carrier_policy_covers_every_scan_pattern(self):
+        """The scanned patterns and their policies cannot desync (issue #52)."""
+        self.assertEqual(
+            set(check._DEGRADE_SCAN_PATTERNS), set(check._DEGRADE_CARRIER_POLICY)
+        )
+        self.assertTrue(check._DEGRADE_SCAN_PATTERNS)
+        for pattern in check._DEGRADE_SCAN_PATTERNS:
+            self.assertIn(
+                check._DEGRADE_CARRIER_POLICY[pattern],
+                (check._DEGRADE_STRUCTURED, check._DEGRADE_TEXT),
+            )
+
     def test_stale_marketplace_script_path_fails_g4(self):
         _build_ok_run(
             self.run_dir,


### PR DESCRIPTION
Closes #52.

## Problem

G3's writer-degrade half raw-text-scanned each carrier's whole bytes **first**, and only consulted parsed structure if that scan missed. Every collected `workflows/wf_*.json` embeds the ~230 KB `workflows/pipeline.js` bundle in its `script` field, and the bundle's own source carries the sentinels as ordinary string constants (`no write proof` ×4, `partial-artifacts` ×6) — so every wf record matched, always.

In the 2026-07-27 smoke, 2 of 3 PRs were false-flagged while their `result.gaps` were clean. Since most open work-queue issues name that smoke as their verification gate, "the smoke passed" carried near-zero information about writer degradation specifically.

## Fix

`_DEGRADE_CARRIER_POLICY` classifies each carrier, and `_DEGRADE_SCAN_PATTERNS` is **derived from its keys** so the two cannot desync. Lookup is direct indexing, so an unclassified future pattern raises rather than guessing.

| Carrier | Policy | Why |
|---|---|---|
| `workflows/wf_*.json` | structured | owns `result.gaps`; embeds the bundle in `script` |
| `code-gauntlet-checkpoint-all-*.json` | structured | owns a real `gaps` array |
| `raw.json` | text | envelope; signal is prose in `.result`, no `gaps` array exists |
| `code-gauntlet-report-*.md` | text | not JSON |

A structured carrier is judged **solely** by its parsed `gaps` array. The load-bearing detail: presence of any gaps list — *including an empty one* — settles it. Treating "gaps present but clean" as "no gaps" would send the healthy `result.gaps == []` shape back to the byte scan and the bug would return.

A structured carrier that will not parse, or has no `gaps` at all, is still scanned rather than reported clean — silently passing an artifact we could not read would be a new way to lose a run — but with the bundle-bearing `script` value blanked first. That blanking is scoped to structured carriers only: its unterminated-field pattern necessarily runs to end-of-text, so applying it to a text carrier could swallow genuine trailing prose, and text carriers never embed the bundle (measured 0/131 `raw.json`, 0/27 report `.md`).

The `origin=unknown` half of G3 is untouched (requirement 2).

## Validation

Tier: **suites-only**, per the issue.

| Check | Result |
|---|---|
| `pytest bench/tests/ -q` | 529 passed (522 on main, +7 new) |
| `pytest tests/ -q` | 763 passed |
| `node --test workflows/test/*.test.js` | 392 passed |

**Full-corpus sweep** — old vs new `_scan_degrade_text` across all 137 pr-dirs in 29 run dirs: exactly **2** flags disappear (grafana#80329, cal.com#22345), both confirmed false positives (parsed gaps hold only `artifact-content-proof` checksum entries; a whole-structure walk excluding `script`/`gaps` found zero sentinels in any sibling field). **0 genuine-signal regressions, 0 new flags.**

**Live confirmation** — `python3 bench/run.py --check smoke-20260727-205454-f99d948`: grafana and cal.com clear; discourse-graphite's 3 genuine hits (wf record, `raw.json`, report `.md`) and its 5 `origin=unknown` findings all preserved. The remaining `pipeline_version '3.2.0' != '3.2.1'` lines are pre-existing G4 drift — HEAD has moved past the smoke commit — and are present on main too.

## Tests added

Requirements 4 and 5 are covered by `test_wf_script_field_bundle_literals_do_not_fail_g3` and `test_wf_script_field_bundle_literals_with_genuine_gap_fails_g3`; the pre-existing `test_workflow_return_partial_artifacts_gap_fails_g3` passes unmodified. Also added: unparseable-record handling in both directions, structured-carrier authority over stray bytes, text-carrier prose preservation, and a policy/pattern coverage guard.

Independently verified that 4 of the 7 new tests fail against `main` (real regression guards); 2 are the negative controls requirement 5 asks for; 1 guards the text-carrier scoping described above.

## Known, non-blocking

- A structured carrier with `gaps == []` but a genuine signal in a *sibling* field is not flagged. This is the design requirement 1 mandates; `raw.json` independently carries the same signal as prose, and CLAUDE.md documents that `writeArtifacts` reports gaps exclusively via `gaps[]`.
- Unrelated and pre-existing (identical on main): `_DEGRADE_RE`'s third alternative `partial.artifacts` has an unescaped `.`, so it also matches `partial artifacts` / `partialXartifacts` in prose — a false-positive vector for the two text carriers. Out of scope here; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTKzwKm4YbznKaw9gteQJC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the mechanical smoke checker and its tests; behavior is regression-tested and removes known false positives without dropping real degrade signals on text carriers.
> 
> **Overview**
> Fixes **false G3 smoke failures** where every `workflows/wf_*.json` looked degraded because the checker regex-scanned full artifact bytes before consulting structure. Those records embed the whole `workflows/pipeline.js` bundle in `script`, and the bundle source contains the “no write proof” / “partial-artifacts” phrases as literals.
> 
> G3 now uses **`_DEGRADE_CARRIER_POLICY`**: `wf_*.json` and checkpoint JSON are **structured** and judged only from parsed `gaps` (including `gaps: []` as clean). Unparseable or gap-less structured files fall back to a text scan with the `script` value blanked via escape-aware regex. **`raw.json` and report markdown stay text-only** scans with no script stripping.
> 
> `bench/MEASUREMENT.md` gate 3 text matches this behavior. **Seven new tests** cover bundle literals, genuine gaps, truncated JSON, policy sync, and text-carrier scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3c923ff0bd5e3a0c725ab5f88edc4a57631cda0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->