### PR TITLE
docs(security): record trust-boundaries posture for repo-supplied rule text (#82)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -58,6 +58,28 @@ former deep-review pipeline) and is no longer maintained.
 
 ## Scope
 
+### Trust boundaries
+
+The pipeline reads several kinds of repository-supplied text and extends each a different level of trust. The
+split is deliberate; it was decided on issue #82 (2026-08-02).
+
+- **The diff is untrusted data.** It enters the shared agent context wrapped in `<untrusted-code-content>` tags,
+  and anything that looks like an instruction inside it is data to analyze, never an instruction to follow.
+- **Rule text is trusted to steer judgment.** Project rule files (`CLAUDE.md`, `AGENTS.md`, `QODO.md`,
+  `REVIEW.md`, and their `@import` targets) are read from the checked-out working tree and are meant to shape the
+  review — that is what those files are for. The accepted consequence: a pull request can edit the rule files
+  that govern its own review and steer findings away from itself. This is not treated as a vulnerability, because
+  the diff already carries equally capable suppression channels that no rule-file control would close — in-code
+  suppression comments, intentional-change framing, and the test-only and generated-code exclusions — so a
+  crafted rule file that causes a finding *not to be raised* is a findings-quality bug, out of scope below. A
+  crafted rule file that gets content *out* of the pipeline — into a posted comment, a report, or a shell — is
+  the in-scope case below, which is why `REVIEW.md` appears on both sides of this split. If
+  suppression through rule text is ever observed in a real run, the recorded escalation is to read rule files
+  from the merge base instead of the PR head; it is held in reserve, not implemented.
+- **Anything that leaves the pipeline is untrusted, whatever its source.** Repository-derived text that reaches a
+  posted PR/MR comment, a rendered report, or a shell invocation stays fully inside the in-scope injection
+  classes below.
+
 ### In scope
 
 - **Prompt-injection defenses that can be bypassed.** Code under review is untrusted input. A crafted repository,
@@ -74,7 +96,8 @@ former deep-review pipeline) and is no longer maintained.
 ### Out of scope
 
 - **Findings quality.** Missed issues, false positives, wrong severity, and noisy output are bug reports, not
-  vulnerabilities — open an issue.
+  vulnerabilities — open an issue. That includes a finding steered away by repository rule text (see Trust
+  boundaries above).
 - **Claude Code itself and Anthropic's APIs.** Report those upstream to Anthropic.
 - **Third-party repositories under review.** A vulnerability the plugin finds, or fails to find, in someone else's
   code belongs to that project's own disclosure process.


### PR DESCRIPTION
## What

Adds a **Trust boundaries** subsection to SECURITY.md's Scope, recording the #82 trust-posture decision (2026-08-02), and extends the out-of-scope findings-quality bullet to match.

The recorded split:

- the **diff** is untrusted data (wrapped, instructions-as-data);
- **rule text** (CLAUDE.md / AGENTS.md / QODO.md / REVIEW.md + `@imports`) is trusted to steer review judgment — with the consequence that a PR can edit the rules that judge it recorded as **accepted risk**, because the diff already carries equally capable suppression channels (in-code suppression comments, intentional-change framing, test-only and generated-code exclusions) that no rule-file control would close;
- anything repository-derived that **leaves the pipeline** (posted comment, report, shell) is untrusted whatever its source.

Merge-base rule sourcing is named as the held-in-reserve escalation if suppression-through-rule-text is ever observed.

## Why

#82 asked whether repo-supplied rule text is trusted input by design; the undocumented assumption was the defect. Full decision record and rationale are in the #82 decision comment. Doc-only, Wave 1, $0 per the #101 measurement policy.

Refs #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJdadTkKojk4C2chywLGUw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to security policy; no runtime, auth, or pipeline behavior is modified.
> 
> **Overview**
> **SECURITY.md** now documents how the review pipeline treats repository-supplied text, formalizing the #82 decision (2026-08-02).
> 
> A new **Trust boundaries** subsection under Scope defines three tiers: the **diff** as untrusted data (e.g. `<untrusted-code-content>`); **rule files** (`CLAUDE.md`, `AGENTS.md`, `QODO.md`, `REVIEW.md`, `@import`s) as trusted to steer judgment, including the accepted risk that a PR can edit its own rules to suppress findings (classified as findings quality, not a vuln) versus rule text that exfiltrates into comments, reports, or shells (still in-scope injection); and **pipeline outputs** as untrusted regardless of source.
> 
> The **Findings quality** out-of-scope bullet now explicitly covers findings steered away by repository rule text, and names **merge-base rule sourcing** as a reserved escalation if suppression via rules is observed in production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbfc4ca75e7cfb16df85e18de6ee02f903d17216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->