### PR TITLE
ci: gate Python coverage on 3.12 legs for scripts/ and bench/ (#102)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           python -m pytest tests/ -q \
             --cov=scripts --cov=.github \
-            --cov-fail-under=91
+            --cov-fail-under=91.3
 
   workflow-tests:
     name: Run Workflow JS Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,27 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pytest
-        run: pip install pytest
+        if: matrix.python-version != '3.12'
+        run: pip install pytest==9.1.1
 
       - name: Run pytest
+        if: matrix.python-version != '3.12'
         run: python -m pytest tests/ -q
+
+      - name: Install pytest + coverage (gate leg)
+        if: matrix.python-version == '3.12'
+        run: |
+          pip install "pip>=25.1"
+          pip install --group dev
+
+      - name: Run pytest with coverage gate
+        if: matrix.python-version == '3.12'
+        env:
+          COVERAGE_FILE: ${{ runner.temp }}/.coverage
+        run: |
+          python -m pytest tests/ -q \
+            --cov=scripts --cov=.github \
+            --cov-fail-under=91
 
   workflow-tests:
     name: Run Workflow JS Tests
@@ -102,7 +119,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install pytest
-        run: pip install pytest
+        if: matrix.python-version != '3.12'
+        run: pip install pytest==9.1.1
 
       - name: Run bench self-tests
+        if: matrix.python-version != '3.12'
         run: python -m pytest bench/tests/ -q
+
+      - name: Install pytest + coverage (gate leg)
+        if: matrix.python-version == '3.12'
+        run: |
+          pip install "pip>=25.1"
+          pip install --group dev
+
+      - name: Run bench self-tests with coverage gate
+        if: matrix.python-version == '3.12'
+        env:
+          COVERAGE_FILE: ${{ runner.temp }}/.coverage
+        run: |
+          python -m pytest bench/tests/ -q \
+            --cov=bench \
+            --cov-fail-under=87

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,12 @@ Thumbs.db
 __pycache__/
 *.pyc
 
+# Coverage data + reports (CI/dev only; see pyproject.toml [tool.coverage])
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
 # Claude Code local settings
 .claude/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,10 @@ fail_fast: false
 default_install_hook_types: [pre-commit, pre-push, commit-msg]
 default_stages: [pre-commit]
 
+# Pin surface: the rev: fields below pin all lint/format tooling. The CI pytest
+# stack (pytest, pytest-cov, coverage) is pinned separately in pyproject.toml
+# [dependency-groups]. Two homes on purpose — pre-commit revs can't express the
+# pytest stack, and nothing here runs it. Keep each pin in its own place.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,10 @@ takes coordinated edits across N files, fix the shape rather than documenting th
 
 ## Scripts
 
-- **stdlib-only Python.** No pip dependencies anywhere in `scripts/`.
+- **stdlib-only Python.** No pip dependencies in shipped `scripts/` runtime —
+  nothing under `scripts/` may import a non-stdlib module. Pinned CI tooling in
+  `pyproject.toml` `[dependency-groups]` (pytest, pytest-cov, coverage) is exempt
+  and never runs inside the plugin.
 - **Language-agnostic.** Scripts must not assume a language in the reviewed codebase. Use
   `--exclude-dir` for non-source directories, never `--include=*.py`-style filters.
 
@@ -31,6 +34,24 @@ python -m pytest tests/ -q            # pipeline + boundary parity
 python -m pytest bench/tests/ -q      # benchmark harness self-tests
 node --test workflows/test/*.test.js  # needs Node 24; the bare directory is not a valid target
 ```
+
+Coverage gates (CI 3.12 only). Locally, COVERAGE_FILE must be outside the repo
+tree (an in-tree data file trips the bench plugin-mutation guard):
+
+```bash
+COVDIR="$(mktemp -d)"
+COVERAGE_FILE="$COVDIR/.coverage" python -m pytest tests/ -q \
+  --cov=scripts --cov=.github --cov-fail-under=91
+COVERAGE_FILE="$COVDIR/.coverage" python -m pytest bench/tests/ -q \
+  --cov=bench --cov-fail-under=87
+```
+
+Floors 91 / 87 provisional (measured 92.41 / 88.08 on Python 3.14, 2026-08-03;
+audit 92.13 / 88.08 at ebf399d). Re-pin from the first green 3.12 CI run.
+`workflows/test/tools/record_parity.py` is test infrastructure, outside both
+scopes. Lower a floor only in the PR that causes the drop, reason in the body.
+A sudden multi-point drop means broken subprocess capture — fix capture, do not
+lower.
 
 After editing `workflows/src/*.js`, rebuild and confirm the bundle is unchanged:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,13 @@ tree (an in-tree data file trips the bench plugin-mutation guard):
 ```bash
 COVDIR="$(mktemp -d)"
 COVERAGE_FILE="$COVDIR/.coverage" python -m pytest tests/ -q \
-  --cov=scripts --cov=.github --cov-fail-under=91
+  --cov=scripts --cov=.github --cov-fail-under=91.3
 COVERAGE_FILE="$COVDIR/.coverage" python -m pytest bench/tests/ -q \
   --cov=bench --cov-fail-under=87
 ```
 
-Floors 91 / 87 provisional (measured 92.41 / 88.08 on Python 3.14, 2026-08-03;
-audit 92.13 / 88.08 at ebf399d). Re-pin from the first green 3.12 CI run.
+Floors 91.3 / 87, pinned 2026-08-03 from the first green 3.12 CI run (92.27 /
+87.96); policy: a floor sits no more than 1.0 pp below the CI 3.12 measurement.
 `workflows/test/tools/record_parity.py` is test infrastructure, outside both
 scopes. Lower a floor only in the PR that causes the drop, reason in the body.
 A sudden multi-point drop means broken subprocess capture — fix capture, do not

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+# Config + CI pin surface only — this is not a packaged project.
+# No [project] / [build-system] on purpose (see #102 / AGENTS.md).
+#
+# This table pins the CI pytest stack. Lint-tool versions are pinned by the
+# rev: fields in .pre-commit-config.yaml — keep pins in their own home; do not
+# duplicate either set here.
+[dependency-groups]
+dev = [
+  "pytest==9.1.1",
+  "pytest-cov==7.1.0",
+  "coverage[toml]==7.15.2",
+]
+
+[tool.coverage.run]
+branch = true
+relative_files = true
+parallel = true
+
+[tool.coverage.report]
+precision = 2
+show_missing = true
+omit = [
+  "bench/vendor/*",
+  "bench/tests/*",
+  "bench/workspace/*",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,10 @@ dev = [
 
 [tool.coverage.run]
 branch = true
+# patch=["subprocess"] is load-bearing: without it pytest-cov does NOT measure the
+# sys.executable child processes the suites spawn, and labels_diff / sync_agent_rules
+# read 0% (aggregate collapses ~92%->85%). coverage.py >=7.10. See #102 requirement 8.
+patch = ["subprocess"]
 relative_files = true
 parallel = true
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,7 +1,8 @@
 # scripts/
 
-Retained Python. **stdlib only** — no pip dependencies — and **language-agnostic**: never assume a
-language in the reviewed codebase.
+Retained Python. **stdlib only** — no pip dependencies in shipped runtime (CI tooling
+pinned in `pyproject.toml` `[dependency-groups]` is exempt) — and **language-agnostic**: never
+assume a language in the reviewed codebase.
 
 - **Repo root for searches.** `verify_findings.py` resolves the root at startup via
   `git rev-parse --show-toplevel`; symbol searches use `git grep -l` with `cwd=REPO_ROOT` and a

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -4,8 +4,9 @@
 
 # scripts/
 
-Retained Python. **stdlib only** — no pip dependencies — and **language-agnostic**: never assume a
-language in the reviewed codebase.
+Retained Python. **stdlib only** — no pip dependencies in shipped runtime (CI tooling
+pinned in `pyproject.toml` `[dependency-groups]` is exempt) — and **language-agnostic**: never
+assume a language in the reviewed codebase.
 
 - **Repo root for searches.** `verify_findings.py` resolves the root at startup via
   `git rev-parse --show-toplevel`; symbol searches use `git grep -l` with `cwd=REPO_ROOT` and a

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -60,7 +60,12 @@ CODEX_CAP_BYTES = 32_768
 # policy line. Enforcement is structural (tests/test_docs_registry.py), but that test
 # fires only after scratch is written; the line is what steers an agent at write time
 # to the PR/issue thread instead. Not derivable from code, no single owning site.
-AGENTS_SET_BUDGET_BYTES = 15_170
+# Raised 15_170 -> 16_266 (2026-08-03, #102): coverage-gate reproduction commands,
+# threshold policy, and the stdlib carve-out for pinned CI tooling. All three are
+# process/boundary statements no single code site owns (the gate lives in ci.yml;
+# the carve-out is a cross-surface rule about what may import what; the floor policy
+# is a merge convention). Not derivable from code.
+AGENTS_SET_BUDGET_BYTES = 16_266
 CLAUDE_MD_MAX_BYTES = 856
 
 # Root CLAUDE.md is a pointer, not a document. The line cap is a shape bound and keeps its

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -60,12 +60,12 @@ CODEX_CAP_BYTES = 32_768
 # policy line. Enforcement is structural (tests/test_docs_registry.py), but that test
 # fires only after scratch is written; the line is what steers an agent at write time
 # to the PR/issue thread instead. Not derivable from code, no single owning site.
-# Raised 15_170 -> 16_266 (2026-08-03, #102): coverage-gate reproduction commands,
+# Raised 15_170 -> 16_273 (2026-08-03, #102): coverage-gate reproduction commands,
 # threshold policy, and the stdlib carve-out for pinned CI tooling. All three are
 # process/boundary statements no single code site owns (the gate lives in ci.yml;
 # the carve-out is a cross-surface rule about what may import what; the floor policy
 # is a merge convention). Not derivable from code.
-AGENTS_SET_BUDGET_BYTES = 16_266
+AGENTS_SET_BUDGET_BYTES = 16_273
 CLAUDE_MD_MAX_BYTES = 856
 
 # Root CLAUDE.md is a pointer, not a document. The line cap is a shape bound and keeps its


### PR DESCRIPTION
## Summary

- Gates branch coverage of `scripts/` (+ `.github/labels_diff.py`) and first-party `bench/` on the existing `test` / `bench-tests` **3.12** matrix legs only — no new job, no ruleset edit.
- Pins the CI pytest stack in a `[project]`-less root `pyproject.toml` (`[dependency-groups] dev`: pytest 9.1.1, pytest-cov 7.1.0, coverage[toml] 7.15.2) with `branch = true` and load-bearing `patch = ["subprocess"]`.
- Writes `COVERAGE_FILE` to `${{ runner.temp }}` (outside the checkout) so parallel coverage data does not trip the bench plugin-mutation guard.
- Provisional floors **91** / **87** against measured **92.41%** / **88.08%** (local 3.14, 2026-08-03). Re-pin from the first green 3.12 CI run in this PR if drift warrants it (≤1.0 pp below measured).
- Documents local repro commands, threshold policy, `record_parity.py` exclusion, and the stdlib carve-out for pinned CI tooling in `AGENTS.md` (twins synced; ratchet raised with justification).

Closes #102 (Wave 2 of #101).

### Required-check status (req 6)

`Run Tests (3.12)` and `Run Bench Self-Tests (3.12)` are in the frozen `REQUIRED_PR_CHECK_CONTEXTS` tuple (from #108 / PR #112) and were added to ruleset `protect-default-branch` (16049246) when #108 landed. This gate therefore blocks merge on those contexts; if CI shows them missing from the live ruleset, treat as advisory until restored — confirm on first green run.

### Mechanism notes (adversarial / Bugbot)

- **Subprocess capture:** bare pytest-cov does *not* measure `sys.executable` children; without `patch = ["subprocess"]` the scripts aggregate collapses ~92%→~85% (`labels_diff` / `sync_agent_rules` → 0%). The 91 floor fails if capture breaks — do not lower the floor for a multi-point drop.
- **Out-of-tree `COVERAGE_FILE`:** in-tree `.coverage.*` files invalidate bench via `plugin_mutated_by_child` (24 `test_invoke` failures). CI must keep `${{ runner.temp }}`.
- Bugbot: no bugs. Contribution-surface + layout budget tests green.

## Test plan

- [x] `python -m pytest tests/ -q` — 1057 passed
- [x] `python -m pytest bench/tests/ -q` — 529 passed
- [x] Scripts gate ≥91 with out-of-tree `COVERAGE_FILE` — 92.41%
- [x] Bench gate ≥87 with out-of-tree `COVERAGE_FILE` — 88.08%
- [x] `--cov-fail-under=99` fails (gate live)
- [x] `node --test workflows/test/*.test.js` + bundle freshness
- [x] `pre-commit run --all-files`
- [x] CI 3.12 legs green — measured 92.27 / 87.96; scripts floor re-pinned to 91.3 (e172a4a), bench floor 87 within policy
- [x] Confirmed `Run Tests (3.12)` / `Run Bench Self-Tests (3.12)` present in ruleset 16049246 required checks (2026-08-03)


Made with [Cursor](https://cursor.com)
