### PR TITLE
chore(tooling): gate ruff and mypy via pre-commit (#104 part B)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Mechanical ruff format + safe --fix from #104 part A (#128 squash).
+1864baf336b57d4c27e5c7ab981c0832b66a93c9

--- a/.github/labels_diff.py
+++ b/.github/labels_diff.py
@@ -55,9 +55,14 @@ def load_manifest(path=MANIFEST):
         _die(f"{path} must be an object with a non-empty `labels` array")
     for entry in labels:
         if not isinstance(entry, dict):
-            _die(f"{path}: every label must be an object, got {json.dumps(entry)[:200]}")
-        missing = [key for key in ("name", "color", "description")
-                   if not isinstance(entry.get(key), str)]
+            _die(
+                f"{path}: every label must be an object, got {json.dumps(entry)[:200]}"
+            )
+        missing = [
+            key
+            for key in ("name", "color", "description")
+            if not isinstance(entry.get(key), str)
+        ]
         if missing:
             _die(f"{path}: label {json.dumps(entry)[:120]} is missing string {missing}")
     return labels
@@ -74,12 +79,18 @@ def load_live(source):
     because a failed API read is what a maintainer will actually hit.
     """
     try:
-        text = sys.stdin.read() if source == "-" else Path(source).read_text(encoding="utf-8")
+        text = (
+            sys.stdin.read()
+            if source == "-"
+            else Path(source).read_text(encoding="utf-8")
+        )
     except OSError as error:
         _die(f"cannot read the label response: {error}")
     if not text.strip():
-        _die(f"no JSON in {'stdin' if source == '-' else source}: "
-             "the `gh api` read produced nothing")
+        _die(
+            f"no JSON in {'stdin' if source == '-' else source}: "
+            "the `gh api` read produced nothing"
+        )
 
     decoder = json.JSONDecoder()
     entries, offset = [], 0
@@ -92,8 +103,10 @@ def load_live(source):
         except json.JSONDecodeError as error:
             _die(f"could not parse the label response as JSON: {error}")
         if not isinstance(page, list):
-            _die("expected a JSON array of labels from `gh api`, got "
-                 f"{json.dumps(page)[:200]}")
+            _die(
+                "expected a JSON array of labels from `gh api`, got "
+                f"{json.dumps(page)[:200]}"
+            )
         entries.extend(page)
 
     while entries and all(isinstance(entry, list) for entry in entries):
@@ -103,11 +116,13 @@ def load_live(source):
     for entry in entries:
         if not isinstance(entry, dict) or "name" not in entry:
             _die(f"expected label objects with a name, got {json.dumps(entry)[:200]}")
-        labels.append({
-            "name": entry["name"],
-            "color": (entry.get("color") or "").lower(),
-            "description": entry.get("description") or "",
-        })
+        labels.append(
+            {
+                "name": entry["name"],
+                "color": (entry.get("color") or "").lower(),
+                "description": entry.get("description") or "",
+            }
+        )
     return labels
 
 
@@ -119,8 +134,10 @@ def diff(manifest, live):
         (label, by_name[label["name"]])
         for label in manifest
         if label["name"] in by_name
-        and (by_name[label["name"]]["color"] != label["color"]
-             or by_name[label["name"]]["description"] != label["description"])
+        and (
+            by_name[label["name"]]["color"] != label["color"]
+            or by_name[label["name"]]["description"] != label["description"]
+        )
     ]
     managed = {label["name"] for label in manifest}
     unmanaged = sorted(label["name"] for label in live if label["name"] not in managed)
@@ -130,13 +147,20 @@ def diff(manifest, live):
 def command(label, repo=None):
     # `--force` updates an existing label in place instead of failing on conflict. It
     # never deletes, so a label absent from the manifest is left alone.
-    argv = ["gh", "label", "create", shlex.quote(label["name"]),
-            "--color", shlex.quote(label["color"]),
-            "--description", shlex.quote(label["description"])]
+    argv = [
+        "gh",
+        "label",
+        "create",
+        shlex.quote(label["name"]),
+        "--color",
+        shlex.quote(label["color"]),
+        "--description",
+        shlex.quote(label["description"]),
+    ]
     if repo:
         # Without this, `gh` infers the target from the working directory's git remote.
         argv += ["--repo", shlex.quote(repo)]
-    return " ".join(argv + ["--force"])
+    return " ".join([*argv, "--force"])
 
 
 def check_emittable(manifest):
@@ -144,10 +168,14 @@ def check_emittable(manifest):
     for label in manifest:
         for field in ("name", "description"):
             if label[field].startswith("-"):
-                _die(f"{label['name']!r}: {field} starts with '-', which `gh` would read "
-                     "as a flag")
+                _die(
+                    f"{label['name']!r}: {field} starts with '-', which `gh` would read "
+                    "as a flag"
+                )
         if not HEX_COLOR.match(label["color"]):
-            _die(f"{label['name']!r}: color {label['color']!r} is not 6-digit lowercase hex")
+            _die(
+                f"{label['name']!r}: color {label['color']!r} is not 6-digit lowercase hex"
+            )
 
 
 def emit(labels, manifest, repo):
@@ -160,15 +188,27 @@ def emit(labels, manifest, repo):
 
 def main(argv=None):
     parser = argparse.ArgumentParser(
-        description="Compare .github/labels.json against a repository's live labels.")
-    parser.add_argument("--live", metavar="PATH",
-                        help="JSON array of the repository's labels, or - for stdin")
-    parser.add_argument("--commands", action="store_true",
-                        help="print gh label create commands instead of a drift report")
-    parser.add_argument("--repo", metavar="OWNER/REPO",
-                        help="pass --repo to the emitted gh commands")
-    parser.add_argument("--manifest", metavar="PATH", default=MANIFEST,
-                        help="taxonomy manifest to read (default: .github/labels.json)")
+        description="Compare .github/labels.json against a repository's live labels."
+    )
+    parser.add_argument(
+        "--live",
+        metavar="PATH",
+        help="JSON array of the repository's labels, or - for stdin",
+    )
+    parser.add_argument(
+        "--commands",
+        action="store_true",
+        help="print gh label create commands instead of a drift report",
+    )
+    parser.add_argument(
+        "--repo", metavar="OWNER/REPO", help="pass --repo to the emitted gh commands"
+    )
+    parser.add_argument(
+        "--manifest",
+        metavar="PATH",
+        default=MANIFEST,
+        help="taxonomy manifest to read (default: .github/labels.json)",
+    )
     args = parser.parse_args(argv)
 
     manifest = load_manifest(args.manifest)
@@ -187,16 +227,25 @@ def main(argv=None):
         print(f"missing: {label['name']}")
     for label, live in diverging:
         print(f"diverging: {label['name']}")
-        print(f"    live:     color={live['color']} description={live['description']!r}")
-        print(f"    manifest: color={label['color']} description={label['description']!r}")
+        print(
+            f"    live:     color={live['color']} description={live['description']!r}"
+        )
+        print(
+            f"    manifest: color={label['color']} description={label['description']!r}"
+        )
     for name in unmanaged:
-        print(f"unmanaged (in the repo, absent from the manifest, left untouched): {name}")
+        print(
+            f"unmanaged (in the repo, absent from the manifest, left untouched): {name}"
+        )
 
     if missing or diverging:
         sys.stdout.flush()
-        print(f"\n{len(missing)} missing, {len(diverging)} diverging — run "
-              "`python3 .github/labels_diff.py --commands --live <file> --repo <owner>/<repo>` "
-              "from the repo root", file=sys.stderr)
+        print(
+            f"\n{len(missing)} missing, {len(diverging)} diverging — run "
+            "`python3 .github/labels_diff.py --commands --live <file> --repo <owner>/<repo>` "
+            "from the repo root",
+            file=sys.stderr,
+        )
         return 1
     print(f"in sync: {len(manifest)} labels match the manifest")
     return 0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,3 +82,18 @@ repos:
         # not of whichever file happens to be edited.
         files: ^(CLAUDE\.md|AGENTS\.md|[^/]+/(AGENTS|CLAUDE)\.md|scripts/sync_agent_rules\.py)$
         pass_filenames: false
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.1
+    hooks:
+      - id: ruff-check
+        # Report-only: a rewriting linter can change semantics; format is the only auto-writer.
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.3.0
+    hooks:
+      - id: mypy
+        pass_filenames: false
+        args: ["--config-file", "pyproject.toml"]
+        additional_dependencies: []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,14 @@ node workflows/build.js
 # Run full pre-commit checks across the repo
 pre-commit run --all-files
 
+# Run the pinned Python lint, format, and type checks
+pre-commit run ruff-check --all-files
+pre-commit run ruff-format --all-files
+pre-commit run mypy --all-files
+
+# Optional: ignore mass mechanical reflows in git blame
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+
 # Run markdown linting only
 pre-commit run markdownlint-fix --all-files
 

--- a/bench/golden/fetch_shas.py
+++ b/bench/golden/fetch_shas.py
@@ -111,7 +111,8 @@ def fetch_one(owner, repo, pr_number, run=None):
 
 
 def main():
-    golden_urls = sorted(json.load(open(GOLDEN / "benchmark_data.min.json")).keys())
+    with open(GOLDEN / "benchmark_data.min.json") as handle:
+        golden_urls = sorted(json.load(handle).keys())
     out = {}
     missing = []
     for url in golden_urls:

--- a/bench/profile_run.py
+++ b/bench/profile_run.py
@@ -206,7 +206,7 @@ def analyze_agent_transcript(path: Path):
     time (per issue-38 requirement 6's own definition of the split).
     """
     rows = read_jsonl(path)
-    result = {
+    result: dict[str, Any] = {
         "transcript_path": str(path),
         "message_count": len(rows),
         "first_ts": None,

--- a/bench/report.py
+++ b/bench/report.py
@@ -171,7 +171,7 @@ RELEASES = (
         ),
         "what_changed": (
             "Full workflow-native rewrite: an 8-stage pipeline running in the "
-            "Workflow runtime, −49% tokens vs v2."
+            "Workflow runtime, \u221249% tokens vs v2."
         ),
         "bar_check": False,
         "extra_note": "",
@@ -244,7 +244,7 @@ def git_short_sha(cwd=None):
         sha = out.stdout.strip()
         if out.returncode == 0 and sha:
             return sha
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         pass
     return "uncommitted"
 
@@ -267,7 +267,7 @@ def fmt_money(x):
 def fmt_int(x):
     if x is None:
         return "—"
-    return f"{int(round(x)):,}"
+    return f"{round(x):,}"
 
 
 def fmt_millions(x, digits=1):
@@ -285,7 +285,7 @@ def fmt_delta_pp(new, old):
 
 
 def fmt_delta_pct(new, old):
-    """Signed relative change, e.g. tokens −49%."""
+    """Signed relative change, e.g. tokens -49%."""
     if new is None or not old:
         return "—"
     return f"{(new - old) / old * 100:+.0f}%"
@@ -619,7 +619,9 @@ def _run_marker(x, y, tier, var, reverted, headline):
         oy = (-4.6, -1.8, 1.8, 4.6, 1.8, -1.8)
         d = (
             "M"
-            + " L".join(f"{x + dx:.1f},{y + dy:.1f}" for dx, dy in zip(ox, oy))
+            + " L".join(
+                f"{x + dx:.1f},{y + dy:.1f}" for dx, dy in zip(ox, oy, strict=True)
+            )
             + " Z"
         )
         g.append(f'<path class="mk mk-fill" d="{d}" style="fill:var({var})" />')
@@ -642,8 +644,8 @@ def _run_marker(x, y, tier, var, reverted, headline):
 def build_runs_svg(points, top_anchor, v2_base, ceiling):
     """Two stacked panels on a shared, time-ordered run axis.
 
-    Panel A is golden recall (0–100%) with the v2-baseline and top-anchor bars; panel
-    B is noise rate (0–40%) with the ceiling. Colour encodes the tool, marker shape
+    Panel A is golden recall (0-100%) with the v2-baseline and top-anchor bars; panel
+    B is noise rate (0-40%) with the ceiling. Colour encodes the tool, marker shape
     encodes the tier, reverted experiments are faded, and the two gate headlines carry
     a halo + direct label. Every marker has a ≥24px hover/focus target.
     """
@@ -695,7 +697,7 @@ def build_runs_svg(points, top_anchor, v2_base, ceiling):
             )
             parts.append(
                 f'<text class="axis" x="{m_left - 8:.1f}" y="{y + 3.5:.1f}" '
-                f'text-anchor="end">{int(round(t * 100))}%</text>'
+                f'text-anchor="end">{round(t * 100)}%</text>'
             )
 
     panel_grid((0.0, 0.25, 0.5, 0.75, 1.0), yA, A_DOM)
@@ -928,7 +930,8 @@ def build_explainer_html(top_anchor, v2_base, ceiling):
             ("Recall", "= goldens caught ÷ all goldens. The headline, gated metric."),
             (
                 "Noise rate",
-                "= noise ÷ all delivered comments — ‘how often are we wrong’. Gated: must stay under the ceiling.",
+                "= noise ÷ all delivered comments — \u2018how often are we "
+                "wrong\u2019. Gated: must stay under the ceiling.",
             ),
             (
                 "Valid-extra",
@@ -979,10 +982,10 @@ def build_explainer_html(top_anchor, v2_base, ceiling):
         "fail a gate; a mini run is the 6-PR paired cut; a subset run is gate-grade; "
         "a holdout run confirms it on fresh PRs; a custom run is an explicit --prs "
         "list (including pre-mini paired legs such as Gate-2). By owner "
-        "decision v3 delivers ~4× the comments of v2, so its lower precision is a "
+        "decision v3 delivers ~4\u00d7 the comments of v2, so its lower precision is a "
         "bigger denominator, not weaker findings. Gate-2 re-baselined its token target "
-        "to the v2 baseline on 2026-07-21: the original −20%-vs-Gate-1 target was "
-        "self-referential (it measured only −1.8%) and was retired. Two child-model "
+        "to the v2 baseline on 2026-07-21: the original \u221220%-vs-Gate-1 target was "
+        "self-referential (it measured only \u22121.8%) and was retired. Two child-model "
         "smokes render faded because they are confounded experiments — a subagent-model "
         "pin cascaded the [1m] context variant onto the pipeline agents — and were "
         "reverted.</p></div>"
@@ -1096,7 +1099,7 @@ def subset_comparison(rows, baselines):
 
 
 def _efficiency(row, n_goldens):
-    """Per-run value-efficiency figures. ``goldens`` is tp = round(recall × N) —
+    """Per-run value-efficiency figures. ``goldens`` is tp = round(recall x N) —
     distinct known issues caught, the numerator of golden_recall — NOT the
     per_bucket golden_matched comment count (a comment can match several goldens).
 
@@ -1203,10 +1206,10 @@ def build_verdict_html(rows, baselines, ceiling):
             "Comments delivered",
             fmt_int(a["delivered"]),
             fmt_int(b["delivered"]),
-            (f"{b['delivered'] / a['delivered']:.1f}×" if a["delivered"] else "—"),
+            (f"{b['delivered'] / a['delivered']:.1f}\u00d7" if a["delivered"] else "—"),
             arrow(b["delivered"], a["delivered"]),
             "context",
-            "~4× more by design — a bigger denominator, not worse findings",
+            "~4\u00d7 more by design — a bigger denominator, not worse findings",
         ),
     ]
 
@@ -1226,7 +1229,7 @@ def build_verdict_html(rows, baselines, ceiling):
 
     # Takeaway sentence, generated from the numbers above.
     ratio = (a["tok_per_gold"] / b["tok_per_gold"]) if b["tok_per_gold"] else None
-    ratio_txt = f"{ratio:.1f}× leaner" if ratio else "leaner"
+    ratio_txt = f"{ratio:.1f}\u00d7 leaner" if ratio else "leaner"
     noise_dir = "rises" if (b["noise"] or 0) > (a["noise"] or 0) else "falls"
     takeaway = (
         f"v3 catches {b['goldens']} of the {n_goldens} known issues to v2's "
@@ -1482,7 +1485,7 @@ def build_anchor_section_html(baselines, v3_row, v3_holdout_row):
     caption = (
         f"Every tool judged on {gate_desc}. <em>deep-review v3</em> leads on "
         "recall while holding noise far below the external tools; <em>claude</em> is "
-        "the published Claude Code CLI row. Anchors are the upstream tools’ stored "
+        "the published Claude Code CLI row. Anchors are the upstream tools\u2019 stored "
         "candidates re-judged under our pinned judge." + corroboration
     )
     return (
@@ -1516,7 +1519,7 @@ def build_table_html(groups, top_anchor, ceiling):
         run = html.escape(truncate_middle(rid))
         note = ""
         if grp["count"] > 1 and grp["identical"]:
-            note = f' <span class="note">×{grp["count"]} identical</span>'
+            note = f' <span class="note">\u00d7{grp["count"]} identical</span>'
         pb = r.get("per_bucket") or {}
         delivered = sum(pb.values()) if pb else r.get("total_candidates")
         kind, glyph, desc = classify(r, top_anchor, ceiling)
@@ -1602,9 +1605,9 @@ def build_footnotes_html(baselines, rows=None):
         "<b>† Precision (strict)</b> is reported, not gated: it counts valid-extras "
         "— real issues outside the golden answer key — as misses, so it drops as a "
         "run delivers more comments even when quality holds. Noise rate is the gated "
-        "‘how often are we wrong’ metric.",
+        "\u2018how often are we wrong\u2019 metric.",
         pin_line,
-        "Owner-amended N=1 protocol: runs 2–3, baseline extension, and full-50 "
+        "Owner-amended N=1 protocol: runs 2\u20133, baseline extension, and full-50 "
         "tracking were dropped under the budget cap.",
         f"δ_noise = {dn_txt} proposed {html.escape(str(dn.get('proposed', '')))}, "
         "pending owner sign-off.",

--- a/bench/report.py
+++ b/bench/report.py
@@ -245,6 +245,7 @@ def git_short_sha(cwd=None):
         if out.returncode == 0 and sha:
             return sha
     except (OSError, subprocess.SubprocessError):
+        # git missing, not a repo, or timeout — degrade to a stable label
         pass
     return "uncommitted"
 

--- a/bench/run.py
+++ b/bench/run.py
@@ -34,6 +34,7 @@ import sys
 import time
 import traceback
 from collections import defaultdict
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -400,9 +401,7 @@ def _valid_naive_comment(item):
     if path is not None and not isinstance(path, str):
         return False
     line = item.get("line")
-    if line is not None and (not isinstance(line, int) or isinstance(line, bool)):
-        return False
-    return True
+    return line is None or (isinstance(line, int) and not isinstance(line, bool))
 
 
 def _parse_comments_block(body):
@@ -537,10 +536,8 @@ def _invoke_naive(
     try:
         out, _ = proc.communicate(input=prompt, timeout=timeout_s)
     except subprocess.TimeoutExpired:
-        try:
+        with suppress(ProcessLookupError, PermissionError, OSError):
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except (ProcessLookupError, PermissionError, OSError):
-            pass
         try:
             out, _ = proc.communicate(timeout=10)
         except (subprocess.TimeoutExpired, ValueError, OSError):
@@ -718,7 +715,7 @@ def _run_prs(
             _collect_artifacts(output_dir, pr_dir)
             if not is_naive:
                 invoke.collect_workflow_records(claude_home, pr_dir, wf_baseline)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - fail only this PR and continue
             # PR-granular progress: an unexpected error (bad JSON, an OSError during
             # collection, a plain bug) must fail only this PR and let the tier continue --
             # distinct from the mirror block's DriftError->drifted and
@@ -742,7 +739,7 @@ def _run_prs(
             # self-healed by the next make_worktree anyway); warn and move on.
             try:
                 mirrors.remove_worktree(mirror, worktree)
-            except Exception as cleanup_exc:
+            except Exception as cleanup_exc:  # noqa: BLE001 - best-effort cleanup
                 print(
                     f"!! worktree cleanup failed for {url} ({cleanup_exc}) -- continuing",
                     file=sys.stderr,

--- a/bench/runner/anchors.py
+++ b/bench/runner/anchors.py
@@ -302,7 +302,7 @@ def _cache_key(judge_pin, candidates):
 
 
 def _subset_candidates(anchors, urls, tools):
-    """Restrict the anchor candidates to ``urls`` × ``tools`` (empty entries dropped)."""
+    """Restrict anchor candidates to ``urls`` x ``tools`` (empty entries dropped)."""
     out = {}
     for url in urls:
         tools_map = anchors.get(url, {})

--- a/bench/runner/invoke.py
+++ b/bench/runner/invoke.py
@@ -21,6 +21,7 @@ import shutil
 import signal
 import subprocess
 import sys
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -134,9 +135,9 @@ class InvokeResult:
     cost_usd: float = 0.0
     per_model: dict = field(default_factory=dict)
     echo_ok: bool = False
-    payload_path: str = None
-    raw_json_path: str = None
-    reason: str = None
+    payload_path: str | None = None
+    raw_json_path: str | None = None
+    reason: str | None = None
 
 
 # --------------------------------------------------------------------------- env
@@ -147,7 +148,7 @@ def _pr_number(pr):
         value = pr.get(key)
         if value is not None:
             return value
-    owner, repo, number = _parse_url(pr.get("url", ""))
+    _owner_name, _repo_name, number = _parse_url(pr.get("url", ""))
     if number is not None:
         return number
     raise KeyError("pr dict has no pr_number/number and no parseable url")
@@ -532,10 +533,8 @@ def build_env(pr, run_dir, base_env, child_auth=API_AUTH_MODE):
 
 
 def _kill_group(proc):
-    try:
+    with suppress(ProcessLookupError, PermissionError, OSError):
         os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-    except (ProcessLookupError, PermissionError, OSError):
-        pass
 
 
 # ---------------------------------------------------------------- plugin integrity
@@ -626,10 +625,8 @@ def _reset_plugin_repo(repo_root, mutations):
             if target.is_dir():
                 shutil.rmtree(target, ignore_errors=True)
             else:
-                try:
+                with suppress(OSError):
                     target.unlink()
-                except OSError:
-                    pass
         else:
             _git(["checkout", "--", path], repo_root)
 
@@ -1065,10 +1062,8 @@ def invoke_review(
             proc.wait(timeout=timeout_s)
         except subprocess.TimeoutExpired:
             _kill_group(proc)
-            try:
+            with suppress(subprocess.TimeoutExpired):
                 proc.wait(timeout=10)
-            except subprocess.TimeoutExpired:
-                pass
             # A killed child may have left the plugin repo dirty; reset so the NEXT PR
             # starts from a clean plugin (this PR is already invalid via 'timeout').
             leftover = _plugin_mutations(REPO_ROOT, baseline_dirty)

--- a/bench/tests/fakes/fake_claude.py
+++ b/bench/tests/fakes/fake_claude.py
@@ -192,9 +192,7 @@ def _write_report(lines):
     if not output_dir:
         return
     os.makedirs(output_dir, exist_ok=True)
-    body = (
-        ["# Deep Review Report", "", "## Methodology", "", "```"] + lines + ["```", ""]
-    )
+    body = ["# Deep Review Report", "", "## Methodology", "", "```", *lines, "```", ""]
     with open(os.path.join(output_dir, "deep-review-report.md"), "w") as fh:
         fh.write("\n".join(body) + "\n")
 

--- a/bench/tests/test_adapter.py
+++ b/bench/tests/test_adapter.py
@@ -235,7 +235,7 @@ class TestPayloadToCandidatesGitHub(unittest.TestCase):
         cands, _ = payload_to_candidates(payload, GOLDEN_A)
         entries = cands[GOLDEN_A]["deep-review"]
         # index i candidate corresponds to index i posted comment
-        for i, (entry, comment) in enumerate(zip(entries, posted)):
+        for i, (entry, comment) in enumerate(zip(entries, posted, strict=True)):
             self.assertEqual(
                 entry["text"],
                 comment["body"],
@@ -287,7 +287,7 @@ class TestPayloadToCandidatesGitLab(unittest.TestCase):
         self.assertEqual(stats, {"n_candidates": len(discussions), "n_skipped": 0})
         entries = cands[GOLDEN_B]["deep-review"]
         self.assertEqual(len(entries), len(discussions))
-        for entry, disc in zip(entries, discussions):
+        for entry, disc in zip(entries, discussions, strict=True):
             self.assertEqual(entry["text"], disc["body"])
             self.assertEqual(entry["path"], disc["position"]["new_path"])
             self.assertEqual(entry["line"], disc["position"]["new_line"])

--- a/bench/tests/test_anchors.py
+++ b/bench/tests/test_anchors.py
@@ -76,8 +76,8 @@ class AnchorCandidatesFileTests(unittest.TestCase):
 
     def test_candidate_entries_have_scorer_shape(self):
         # step3's get_candidates reads c["text"]; provenance is source="extracted".
-        for url, tools in self.anchors.items():
-            for tool, cands in tools.items():
+        for tools in self.anchors.values():
+            for cands in tools.values():
                 self.assertIsInstance(cands, list)
                 for c in cands:
                     self.assertIn("text", c)
@@ -469,14 +469,16 @@ class AnchorScorerStageFailureTests(unittest.TestCase):
         fake = SimpleNamespace(
             returncode=1, stdout="", stderr="Traceback: boom in dedup"
         )
-        with mock.patch.object(score.subprocess, "run", return_value=fake):
-            with self.assertRaises(RuntimeError) as ctx:
-                anchors._run_scorer_stages(
-                    "claude-opus-4-8-20260101",
-                    "api-key",
-                    anchors.MARTIAN_BASE_URL,
-                    "results/claude-opus-4-8-20260101/dedup_groups.json",
-                )
+        with (
+            mock.patch.object(score.subprocess, "run", return_value=fake),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            anchors._run_scorer_stages(
+                "claude-opus-4-8-20260101",
+                "api-key",
+                anchors.MARTIAN_BASE_URL,
+                "results/claude-opus-4-8-20260101/dedup_groups.json",
+            )
         msg = str(ctx.exception)
         self.assertIn("dedup", msg)  # the failing stage is named
         self.assertIn("boom", msg)  # stderr tail is surfaced

--- a/bench/tests/test_check.py
+++ b/bench/tests/test_check.py
@@ -938,9 +938,11 @@ class CheckCliTest(unittest.TestCase):
 
     def test_check_cli_fails_on_gate(self):
         (self.run_dir / "pr-example-repo-1" / "post-review-payload.json").unlink()
-        with contextlib.redirect_stdout(io.StringIO()):
-            with contextlib.redirect_stderr(io.StringIO()):
-                rc = run.main(["--check", self.run_dir.name])
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            rc = run.main(["--check", self.run_dir.name])
         self.assertEqual(rc, 1)
 
     def test_check_missing_run_is_exit_2(self):
@@ -964,9 +966,11 @@ class CheckCliTest(unittest.TestCase):
         manifest = json.loads((self.run_dir / "run.json").read_text())
         manifest["anchor"] = "naive"
         _write_json(self.run_dir / "run.json", manifest)
-        with contextlib.redirect_stdout(io.StringIO()):
-            with contextlib.redirect_stderr(io.StringIO()):
-                rc = run.main(["--check", self.run_dir.name])
+        with (
+            contextlib.redirect_stdout(io.StringIO()),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            rc = run.main(["--check", self.run_dir.name])
         self.assertEqual(rc, 2)
 
 

--- a/bench/tests/test_checkpoint.py
+++ b/bench/tests/test_checkpoint.py
@@ -56,7 +56,7 @@ class CheckpointTestCase(unittest.TestCase):
 
     def test_all_valid_statuses_roundtrip(self):
         valid = ["pending", "ok", "timeout", "invalid", "drifted", "failed"]
-        for status, url in zip(valid, GOLDEN_URLS):
+        for status, url in zip(valid, GOLDEN_URLS, strict=True):
             self.cp.mark(url, status)
             self.assertEqual(self.cp.status(url), status)
 

--- a/bench/tests/test_golden.py
+++ b/bench/tests/test_golden.py
@@ -24,9 +24,7 @@ class TestGoldenData(unittest.TestCase):
         cls.minf = _load("benchmark_data.min.json")
         cls.subsets = _load("subsets.json")
         cls.labels = _load("pr_labels.json")
-        cls.raw = {
-            f: _load(f"golden_comments/{f}.json") for f in GOLDEN_FILES
-        }
+        cls.raw = {f: _load(f"golden_comments/{f}.json") for f in GOLDEN_FILES}
 
     # --- totals -------------------------------------------------------------
 

--- a/bench/tests/test_invoke.py
+++ b/bench/tests/test_invoke.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import patch
 
 # Import via the intended package path regardless of how pytest is invoked.
@@ -195,7 +196,7 @@ class BuildEnvTest(InvokeTestBase):
         }
         (cfg_dir / ".claude.json").write_text(json.dumps(existing))
 
-        env = build_env(PR, self.run_dir, {})
+        build_env(PR, self.run_dir, {})
         data = json.loads((cfg_dir / ".claude.json").read_text())
         # existing content preserved
         self.assertEqual(data["numStartups"], 4)
@@ -1209,7 +1210,7 @@ class ChildProcessCredentialEnvTest(InvokeTestBase):
     credential vars (presence only -- never values) and the assertions read that.
     """
 
-    POLLUTED = {
+    POLLUTED: ClassVar[dict[str, str]] = {
         "ANTHROPIC_API_KEY": "sk-ambient-should-not-arrive",
         "ANTHROPIC_AUTH_TOKEN": "at-ambient-should-not-arrive",
         "CLAUDE_CODE_USE_BEDROCK": "1",

--- a/bench/tests/test_report.py
+++ b/bench/tests/test_report.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from typing import ClassVar
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -156,7 +157,7 @@ class TestGrouping(unittest.TestCase):
         # anchor + naive + collapsed v2 == 3 table rows, oldest first.
         self.assertEqual(len(groups), 3)
         self.assertEqual(groups[0]["row"]["tool"], "anchor-claude")
-        v2 = [g for g in groups if g["row"]["tool"] == "deep-review-v2"][0]
+        v2 = next(g for g in groups if g["row"]["tool"] == "deep-review-v2")
         self.assertEqual(v2["count"], 2)
         self.assertTrue(v2["identical"])
 
@@ -461,7 +462,7 @@ class TestSubscriptionCostHonesty(unittest.TestCase):
     derived per-golden aggregate drops it, and the table cell keeps it behind a ‡.
     """
 
-    SUB_ROW = {
+    SUB_ROW: ClassVar[dict] = {
         "run_id": "mini-20260724-subauth",
         "ts": "2026-07-24T10:00:00Z",
         "tier": "mini",
@@ -563,7 +564,7 @@ class TestSubscriptionCostHonesty(unittest.TestCase):
         )
 
     def test_rendered_page_marks_a_subscription_run(self):
-        out = _render(rows=FIXTURE_ROWS + [self.SUB_ROW])
+        out = _render(rows=[*FIXTURE_ROWS, self.SUB_ROW])
         self.assertIn("‡", out)
         self.assertIn("auth_mode=subscription", out)
 

--- a/bench/tests/test_run_cli.py
+++ b/bench/tests/test_run_cli.py
@@ -656,7 +656,7 @@ class LoopHardeningTest(RunTestBase):
         run_dir = self.runs_root / "run-oserror"
         run_dir.mkdir(parents=True)
         cp = run.checkpoint.Checkpoint(run_dir)
-        summary = run._run_prs(run_dir, urls, cp, metas, set(), 60, None, {})
+        run._run_prs(run_dir, urls, cp, metas, set(), 60, None, {})
 
         self.assertEqual(cp.status(urls[0]), "failed")
         detail = self._detail(cp, urls[0])
@@ -967,9 +967,11 @@ class ChildAuthCliTest(RunTestBase):
         self.assertEqual(args.child_auth, "api")
 
     def test_bogus_mode_is_an_argparse_error(self):
-        with contextlib.redirect_stderr(io.StringIO()) as err:
-            with self.assertRaises(SystemExit) as cm:
-                run.parse_args(["--tier", "smoke", "--child-auth", "oauth"])
+        with (
+            contextlib.redirect_stderr(io.StringIO()) as err,
+            self.assertRaises(SystemExit) as cm,
+        ):
+            run.parse_args(["--tier", "smoke", "--child-auth", "oauth"])
         self.assertEqual(cm.exception.code, 2)
         self.assertIn("--child-auth", err.getvalue())
 
@@ -980,9 +982,11 @@ class ChildAuthCliTest(RunTestBase):
             captured.update(kwargs)
             return ["stop before the run starts"]
 
-        with patch.object(run, "check_prereqs", spy):
-            with contextlib.redirect_stderr(io.StringIO()):
-                rc = run.main(["--tier", "smoke", "--child-auth", "subscription"])
+        with (
+            patch.object(run, "check_prereqs", spy),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            rc = run.main(["--tier", "smoke", "--child-auth", "subscription"])
         self.assertEqual(rc, 2)
         self.assertEqual(captured.get("child_auth"), "subscription")
 
@@ -994,9 +998,11 @@ class ChildAuthCliTest(RunTestBase):
             captured.update(kwargs)
             return ["stop before the run starts"]
 
-        with patch.object(run, "check_prereqs", spy):
-            with contextlib.redirect_stderr(io.StringIO()):
-                self.assertEqual(run.main(argv), 2)
+        with (
+            patch.object(run, "check_prereqs", spy),
+            contextlib.redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(run.main(argv), 2)
         return captured.get("child_auth")
 
     def _write_resumable(self, run_id, child_auth):
@@ -1323,14 +1329,14 @@ class ChildAuthJudgeKeyNoteTest(RunTestBase):
 
     def test_main_prints_the_note_once_prereqs_pass(self):
         stderr = io.StringIO()
-        with patch.object(run, "check_prereqs", lambda **kwargs: []):
-            with patch.object(run, "_new_run", lambda args: 0):
-                with patch.dict(os.environ, {}, clear=True):
-                    self._patch_global("ENV_PATH", self.missing_env)
-                    with contextlib.redirect_stderr(stderr):
-                        rc = run.main(
-                            ["--tier", "smoke", "--child-auth", "subscription"]
-                        )
+        with (
+            patch.object(run, "check_prereqs", lambda **kwargs: []),
+            patch.object(run, "_new_run", lambda args: 0),
+            patch.dict(os.environ, {}, clear=True),
+            contextlib.redirect_stderr(stderr),
+        ):
+            self._patch_global("ENV_PATH", self.missing_env)
+            rc = run.main(["--tier", "smoke", "--child-auth", "subscription"])
         self.assertEqual(rc, 0)
         self.assertIn("judge", stderr.getvalue().lower())
 
@@ -1561,9 +1567,11 @@ class PrsListTest(RunTestBase):
         self.assertEqual(args.prs, self.subsets["mini"])
 
     def test_unknown_url_is_argparse_error(self):
-        with contextlib.redirect_stderr(io.StringIO()) as err:
-            with self.assertRaises(SystemExit) as cm:
-                run.parse_args(["--prs", "https://github.com/nope/nope/pull/999999"])
+        with (
+            contextlib.redirect_stderr(io.StringIO()) as err,
+            self.assertRaises(SystemExit) as cm,
+        ):
+            run.parse_args(["--prs", "https://github.com/nope/nope/pull/999999"])
         self.assertEqual(cm.exception.code, 2)
         self.assertIn("not in shas.json", err.getvalue())
 

--- a/bench/tests/test_score.py
+++ b/bench/tests/test_score.py
@@ -13,13 +13,14 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from bench.runner import (
+from bench.runner import (  # noqa: E402
     ledger,
     score,
 )
@@ -98,18 +99,22 @@ class ResolveJudgePinTests(unittest.TestCase):
         write_json(self.baselines, {"judge_pin": None})
         # env has no key and BENCH_DIR points at a keyless tmp dir, so the bench/.env
         # fallback finds nothing either -> genuinely keyless, no network call.
-        with mock.patch.object(score, "BENCH_DIR", Path(self._tmp.name)):
-            with self.assertRaises(RuntimeError):
-                resolve_judge_pin(env={}, baselines_path=self.baselines)
+        with (
+            mock.patch.object(score, "BENCH_DIR", Path(self._tmp.name)),
+            self.assertRaises(RuntimeError),
+        ):
+            resolve_judge_pin(env={}, baselines_path=self.baselines)
 
     def test_no_dated_snapshot_raises(self):
         write_json(self.baselines, {"judge_pin": None})
         models = {"data": [{"id": "claude-opus-4-8"}, {"id": "claude-opus-4-8[1m]"}]}
-        with mock.patch.object(score, "_http_get_json", lambda url, headers: models):
-            with self.assertRaises(RuntimeError):
-                resolve_judge_pin(
-                    env={"ANTHROPIC_API_KEY": "k"}, baselines_path=self.baselines
-                )
+        with (
+            mock.patch.object(score, "_http_get_json", lambda url, headers: models),
+            self.assertRaises(RuntimeError),
+        ):
+            resolve_judge_pin(
+                env={"ANTHROPIC_API_KEY": "k"}, baselines_path=self.baselines
+            )
 
     def test_pick_snapshot_helper_selects_newest(self):
         self.assertEqual(
@@ -524,9 +529,11 @@ class ScorerStageFailureTests(unittest.TestCase):
         fake = SimpleNamespace(
             returncode=1, stdout="", stderr="Traceback: boom in dedup"
         )
-        with mock.patch.object(score.subprocess, "run", return_value=fake):
-            with self.assertRaises(RuntimeError) as ctx:
-                score.run_scorer_stages(pin, "api-key", Path("/tmp/model-dir"))
+        with (
+            mock.patch.object(score.subprocess, "run", return_value=fake),
+            self.assertRaises(RuntimeError) as ctx,
+        ):
+            score.run_scorer_stages(pin, "api-key", Path("/tmp/model-dir"))
         msg = str(ctx.exception)
         self.assertIn("dedup", msg)  # the failing stage is named
         self.assertIn("boom", msg)  # stderr tail is surfaced
@@ -717,7 +724,7 @@ class AuthModeTests(unittest.TestCase):
     here would silently destroy the only record of what the run consumed.
     """
 
-    METRICS = {
+    METRICS: ClassVar[dict] = {
         "n_prs": 1,
         "golden_recall": 0.0,
         "valid_extra_rate": 0.0,
@@ -728,7 +735,11 @@ class AuthModeTests(unittest.TestCase):
         "per_dimension": {},
         "drift": {},
     }
-    COSTS = {"tokens_total": 4321, "cost_usd": 27.0, "per_model": {}}
+    COSTS: ClassVar[dict] = {
+        "tokens_total": 4321,
+        "cost_usd": 27.0,
+        "per_model": {},
+    }
 
     def _row(self, manifest):
         return score._build_ledger_row(

--- a/bench/tests/test_shas.py
+++ b/bench/tests/test_shas.py
@@ -144,9 +144,11 @@ class TestFetchOne(unittest.TestCase):
                 return SimpleNamespace(returncode=0, stdout=out, stderr="")
             return SimpleNamespace(returncode=1, stdout="", stderr="compare boom")
 
-        with mock.patch.object(fetch_shas.time, "sleep", lambda *_: None):
-            with self.assertRaises(RuntimeError):
-                fetch_shas.fetch_one("o", "r", 1, run=run)
+        with (
+            mock.patch.object(fetch_shas.time, "sleep", lambda *_: None),
+            self.assertRaises(RuntimeError),
+        ):
+            fetch_shas.fetch_one("o", "r", 1, run=run)
 
 
 if __name__ == "__main__":

--- a/scripts/apply_challenges.py
+++ b/scripts/apply_challenges.py
@@ -442,7 +442,7 @@ def main():
     # ------------------------------------------------------------------
     # Load inputs
     # ------------------------------------------------------------------
-    findings, prior_eliminated, envelope = load_filtered(args.filtered_json)
+    findings, prior_eliminated, _envelope = load_filtered(args.filtered_json)
     challenges = load_challenges(args.challenges_json)
 
     total_input = len(findings)

--- a/scripts/assemble_artifacts.py
+++ b/scripts/assemble_artifacts.py
@@ -137,6 +137,7 @@ import os
 import struct
 import sys
 import tempfile
+from contextlib import suppress
 
 PLAN_VERSION = 2
 PLAN_CHECKSUM_KEY = "planChecksum"
@@ -167,7 +168,7 @@ FNV_PRIME = 0x01000193
 def utf16_code_units(s):
     """The UTF-16 code units of `s`, exactly what JS charCodeAt() walks."""
     raw = s.encode("utf-16-le", "surrogatepass")
-    return struct.unpack("<%dH" % (len(raw) // 2), raw)
+    return struct.unpack(f"<{len(raw) // 2}H", raw)
 
 
 def utf16_len(s):
@@ -181,7 +182,7 @@ def fnv1a32(s):
     for unit in utf16_code_units(s):
         h ^= unit
         h = (h * FNV_PRIME) & 0xFFFFFFFF
-    return "fnv1a32:0x%08x" % h
+    return f"fnv1a32:0x{h:08x}"
 
 
 def normalize_content(s):
@@ -250,34 +251,33 @@ def assert_js_reproducible(obj, path="$"):
     stack = [(obj, path)]
     while stack:
         node, where = stack.pop()
-        if node is None or isinstance(node, bool) or isinstance(node, str):
+        if node is None or isinstance(node, (bool, str)):
             continue
         if isinstance(node, int):
             if not (-JS_MAX_SAFE_INTEGER <= node <= JS_MAX_SAFE_INTEGER):
                 raise JsSerializationError(
-                    "integer at %s is outside JS's safe integer range (%r)"
-                    % (where, node)
+                    f"integer at {where} is outside JS's safe integer range ({node!r})"
                 )
             continue
         if isinstance(node, float):
             raise JsSerializationError(
-                "non-integer number at %s (%r): JS and Python spell such numbers "
-                "differently, so the derived artifact would diverge" % (where, node)
+                f"non-integer number at {where} ({node!r}): JS and Python spell "
+                "such numbers differently, so the derived artifact would diverge"
             )
         if isinstance(node, list):
             for i, item in enumerate(node):
-                stack.append((item, "%s[%d]" % (where, i)))
+                stack.append((item, f"{where}[{i}]"))
             continue
         if isinstance(node, dict):
             for key, value in node.items():
                 if not isinstance(key, str):
                     raise JsSerializationError(
-                        "non-string object key at %s (%r)" % (where, key)
+                        f"non-string object key at {where} ({key!r})"
                     )
-                stack.append((value, "%s.%s" % (where, key)))
+                stack.append((value, f"{where}.{key}"))
             continue
         raise JsSerializationError(
-            "value at %s has no JSON representation (%s)" % (where, type(node).__name__)
+            f"value at {where} has no JSON representation ({type(node).__name__})"
         )
 
 
@@ -308,7 +308,7 @@ def escape_lone_surrogates(s):
             i += 2
             continue
         if 0xD800 <= cp <= 0xDFFF:
-            out.append("\\u%04x" % cp)
+            out.append(f"\\u{cp:04x}")
             i += 1
             continue
         out.append(s[i])
@@ -368,18 +368,14 @@ def write_text_atomic(path, text):
         os.umask(umask)
         os.chmod(tmp, 0o666 & ~umask)
     except BaseException:
-        try:
+        with suppress(OSError):
             os.unlink(tmp)
-        except OSError:
-            pass  # best-effort cleanup; the original exception below is what must propagate
         raise
     try:
         os.replace(tmp, path)
     except BaseException:
-        try:
+        with suppress(OSError):
             os.unlink(tmp)
-        except OSError:
-            pass  # best-effort cleanup; the original exception below is what must propagate
         raise
 
 
@@ -422,28 +418,28 @@ def _load_source(path, cache, errors):
     cache[path] = None
     try:
         raw = read_text(path)
-    except Exception as exc:  # includes UnicodeDecodeError (a ValueError)
-        errors.append("source not found or unreadable: %s (%s)" % (path, exc))
+    except Exception as exc:  # noqa: BLE001 - includes UnicodeDecodeError (a ValueError)
+        errors.append(f"source not found or unreadable: {path} ({exc})")
         return None
     try:
         data = json.loads(raw)
     except ValueError as exc:
-        errors.append("source is not valid JSON: %s (%s)" % (path, exc))
+        errors.append(f"source is not valid JSON: {path} ({exc})")
         return None
     if not isinstance(data, list):
-        errors.append("source must be a JSON array of findings: %s" % path)
+        errors.append(f"source must be a JSON array of findings: {path}")
         return None
     by_id = {}
     for index, item in enumerate(data):
         if not isinstance(item, dict):
-            errors.append("source entry %d is not an object: %s" % (index, path))
+            errors.append(f"source entry {index} is not an object: {path}")
             return None
         fid = item.get("id")
         if not isinstance(fid, str) or not fid:
-            errors.append("source entry %d has no usable string id: %s" % (index, path))
+            errors.append(f"source entry {index} has no usable string id: {path}")
             return None
         if fid in by_id:
-            errors.append("duplicate id %r in source: %s" % (fid, path))
+            errors.append(f"duplicate id {fid!r} in source: {path}")
             return None
         by_id[fid] = item
     cache[path] = by_id
@@ -456,9 +452,7 @@ def _project(by_id, ids, source_path, label, errors):
     out = []
     for fid in ids:
         if fid not in by_id:
-            errors.append(
-                "%s id %r not present in source %s" % (label, fid, source_path)
-            )
+            errors.append(f"{label} id {fid!r} not present in source {source_path}")
             continue
         out.append(by_id[fid])
     return out
@@ -475,10 +469,9 @@ def _serialize(document, label, errors):
     """js_stringify_pretty with every failure turned into a structural error."""
     try:
         return js_stringify_pretty(document)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - converted to a structural error
         errors.append(
-            "could not serialize the %s artifact: %s: %s"
-            % (label, type(exc).__name__, exc)
+            f"could not serialize the {label} artifact: {type(exc).__name__}: {exc}"
         )
         return None
 
@@ -491,22 +484,22 @@ def _assemble(plan_path):
     try:
         with open(plan_path, encoding="utf-8", newline="") as fh:
             plan_raw = fh.read()
-    except Exception as exc:
-        errors.append("plan not found or unreadable: %s (%s)" % (plan_path, exc))
+    except Exception as exc:  # noqa: BLE001 - converted to a structural error
+        errors.append(f"plan not found or unreadable: {plan_path} ({exc})")
         return _receipt(False, None, None, verified, [], errors)
     try:
         plan = json.loads(normalize_content(plan_raw))
     except ValueError as exc:
-        errors.append("plan is not valid JSON: %s (%s)" % (plan_path, exc))
+        errors.append(f"plan is not valid JSON: {plan_path} ({exc})")
         return _receipt(False, None, None, verified, [], errors)
     if not isinstance(plan, dict):
-        errors.append("plan must be a JSON object: %s" % plan_path)
+        errors.append(f"plan must be a JSON object: {plan_path}")
         return _receipt(False, None, None, verified, [], errors)
 
     plan_version = plan.get("planVersion")
     if plan_version != PLAN_VERSION:
         errors.append(
-            "unsupported planVersion %r (expected %d)" % (plan_version, PLAN_VERSION)
+            f"unsupported planVersion {plan_version!r} (expected {PLAN_VERSION})"
         )
         return _receipt(False, plan_version, None, verified, [], errors)
 
@@ -518,25 +511,26 @@ def _assemble(plan_path):
     declared = plan.get(PLAN_CHECKSUM_KEY)
     if not isinstance(declared, str) or not declared:
         errors.append(
-            "plan carries no %s — an unproven instruction set is not executed: %s"
-            % (PLAN_CHECKSUM_KEY, plan_path)
+            f"plan carries no {PLAN_CHECKSUM_KEY} — an unproven instruction set is "
+            f"not executed: {plan_path}"
         )
         return _receipt(False, plan_version, None, verified, [], errors)
     try:
         actual = plan_checksum(plan)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - converted to a structural error
         errors.append(
-            "plan checksum could not be recomputed: %s: %s" % (type(exc).__name__, exc)
+            f"plan checksum could not be recomputed: {type(exc).__name__}: {exc}"
         )
         return _receipt(False, plan_version, None, verified, [], errors)
     if actual != declared:
         errors.append(
-            "plan checksum mismatch: declared %s, recomputed %s — the persist plan "
+            f"plan checksum mismatch: declared {declared}, recomputed {actual} — "
+            "the persist plan "
             "changed in transit; it is the instruction set for which findings reach "
-            "the post-review artifact, so it is NOT executed" % (declared, actual)
+            "the post-review artifact, so it is NOT executed"
         )
         sys.stderr.write(
-            "plan checksum mismatch: declared %s, recomputed %s\n" % (declared, actual)
+            f"plan checksum mismatch: declared {declared}, recomputed {actual}\n"
         )
         return _receipt(False, plan_version, actual, verified, [], errors)
 
@@ -547,18 +541,14 @@ def _assemble(plan_path):
         path = entry.get("path")
         try:
             content = read_text(path)
-        except Exception as exc:
-            errors.append(
-                "expected artifact not found or unreadable: %s (%s)" % (path, exc)
-            )
+        except Exception as exc:  # noqa: BLE001 - converted to a structural error
+            errors.append(f"expected artifact not found or unreadable: {path} ({exc})")
             continue
         if isinstance(path, str) and path.endswith(".json"):
             try:
                 json.loads(content)
             except ValueError as exc:
-                errors.append(
-                    "expected artifact is not valid JSON: %s (%s)" % (path, exc)
-                )
+                errors.append(f"expected artifact is not valid JSON: {path} ({exc})")
                 continue
         chars = utf16_len(content)
         checksum = fnv1a32(content)
@@ -575,8 +565,8 @@ def _assemble(plan_path):
         )
         if not matched:
             sys.stderr.write(
-                "content-proof mismatch: %s (expected %s chars / %s, got %d / %s)\n"
-                % (path, entry.get("chars"), entry.get("checksum"), chars, checksum)
+                f"content-proof mismatch: {path} (expected {entry.get('chars')} chars "
+                f"/ {entry.get('checksum')}, got {chars} / {checksum})\n"
             )
 
     if errors:
@@ -633,7 +623,7 @@ def _assemble(plan_path):
         elif cp_ids:
             errors.append(
                 "checkpoint skeleton has no phases.challenge.findings array to receive "
-                "%d challenge finding(s)" % len(cp_ids)
+                f"{len(cp_ids)} challenge finding(s)"
             )
         text = _serialize(skeleton, "checkpoint", errors)
         if text is not None:
@@ -649,10 +639,8 @@ def _assemble(plan_path):
     for path, text in pending:
         try:
             write_text_atomic(path, text)
-        except Exception as exc:
-            errors.append(
-                "could not write %s (%s: %s)" % (path, type(exc).__name__, exc)
-            )
+        except Exception as exc:  # noqa: BLE001 - converted to a structural error
+            errors.append(f"could not write {path} ({type(exc).__name__}: {exc})")
             continue
         written.append(
             {
@@ -678,14 +666,14 @@ def assemble(plan_path):
     """
     try:
         return _assemble(plan_path)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - the one-line-receipt contract
         return _receipt(
             False,
             None,
             None,
             [],
             [],
-            ["assembler failed unexpectedly: %s: %s" % (type(exc).__name__, exc)],
+            [f"assembler failed unexpectedly: {type(exc).__name__}: {exc}"],
         )
 
 
@@ -713,12 +701,11 @@ def _minimal_receipt_line(exc):
                 "verified": [],
                 "written": [],
                 "errors": [
-                    "receipt could not be serialized: %s: %s"
-                    % (type(exc).__name__, exc)
+                    f"receipt could not be serialized: {type(exc).__name__}: {exc}"
                 ],
             }
         )
-    except Exception:
+    except Exception:  # noqa: BLE001 - the one-line-receipt contract
         return (
             '{"ok": false, "planVersion": null, "planChecksum": null, '
             '"verified": [], "written": [], '
@@ -743,7 +730,7 @@ def main(argv=None):
             json.dumps(receipt, ensure_ascii=False, allow_nan=False)
         )
         ok = bool(receipt["ok"])
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - stdout is never empty
         line = _minimal_receipt_line(exc)
         ok = False
     sys.stdout.write(line + "\n")

--- a/scripts/await_workflow.py
+++ b/scripts/await_workflow.py
@@ -237,7 +237,7 @@ def task_roots(environ=None):
         bases.append(tmpdir.rstrip(os.sep) or os.sep)
     roots, seen = [], set()
     for base in bases:
-        candidate = os.path.join(base, "claude-%d" % os.getuid())
+        candidate = os.path.join(base, f"claude-{os.getuid()}")
         real = os.path.realpath(candidate)
         if real in seen:
             continue
@@ -738,7 +738,7 @@ def emit(payload):
             {
                 "await": "error",
                 "gap": "workflow-timeout",
-                "message": "result would not serialize: %s" % exc,
+                "message": f"result would not serialize: {exc}",
             },
             separators=(",", ":"),
         )
@@ -885,8 +885,8 @@ def await_terminal(args, environ=None):
     marker = build_marker("timeout", args, observed, since_epoch, started_at)
     marker["gap"] = "workflow-timeout"
     marker["detail"] = (
-        "no terminal workflow result after %d attempts; declare the gap and "
-        "deliver whatever partial artifacts exist" % args.max_attempts
+        f"no terminal workflow result after {args.max_attempts} attempts; declare "
+        "the gap and deliver whatever partial artifacts exist"
     )
     return marker, 4
 
@@ -921,7 +921,7 @@ def build_parser(environ=None):
         default=DEFAULT_MAX_ATTEMPTS,
         metavar="M",
         help="Total attempts allowed before declaring the workflow-timeout gap "
-        "(default %d)." % DEFAULT_MAX_ATTEMPTS,
+        f"(default {DEFAULT_MAX_ATTEMPTS}).",
     )
     parser.add_argument(
         "--timeout-seconds",
@@ -929,8 +929,8 @@ def build_parser(environ=None):
         type=float,
         default=default_timeout_seconds(environ),
         metavar="S",
-        help="Per-invocation wait. Defaults to %d, lowered automatically when "
-        "BASH_MAX_TIMEOUT_MS is exported." % DEFAULT_TIMEOUT_SECONDS,
+        help=f"Per-invocation wait. Defaults to {DEFAULT_TIMEOUT_SECONDS}, lowered "
+        "automatically when BASH_MAX_TIMEOUT_MS is exported.",
     )
     parser.add_argument(
         "--poll-interval",
@@ -938,7 +938,7 @@ def build_parser(environ=None):
         type=float,
         default=DEFAULT_POLL_INTERVAL,
         metavar="P",
-        help="Seconds between checks (default %d)." % DEFAULT_POLL_INTERVAL,
+        help=f"Seconds between checks (default {DEFAULT_POLL_INTERVAL}).",
     )
     parser.add_argument(
         "--artifacts-dir",
@@ -960,7 +960,7 @@ def build_parser(environ=None):
         default=DEFAULT_ARTIFACTS_GRACE_SECONDS,
         metavar="G",
         help="How long to keep waiting for the compact return once every artifact "
-        "is present (default %d)." % DEFAULT_ARTIFACTS_GRACE_SECONDS,
+        f"is present (default {DEFAULT_ARTIFACTS_GRACE_SECONDS}).",
     )
     parser.add_argument(
         "--since-epoch",
@@ -993,7 +993,7 @@ def main(argv=None, environ=None):
         payload, code = _wait_error_payload(args, "interrupted"), 4
     except Exception as exc:  # noqa: BLE001 - the never-print-nothing contract
         payload, code = (
-            _wait_error_payload(args, "%s: %s" % (type(exc).__name__, exc)),
+            _wait_error_payload(args, f"{type(exc).__name__}: {exc}"),
             4,
         )
     # One emit site for every outcome — including the error markers above — so a

--- a/scripts/collect_project_rules.py
+++ b/scripts/collect_project_rules.py
@@ -80,6 +80,7 @@ import re
 import stat
 import sys
 import tempfile
+from contextlib import suppress
 
 # The one place a convention filename is added. Ordered: this order is also the
 # tie-break precedence when two files at the same directory level state
@@ -352,7 +353,7 @@ class _Collector:
                 self._skip(os.path.join(containing_dir, raw), reason)
                 continue
             self.visit(
-                target, "import:" + self._display(real), depth + 1, chain + (real,)
+                target, "import:" + self._display(real), depth + 1, (*chain, real)
             )
 
 
@@ -420,7 +421,7 @@ def render(sources):
         return ""
     parts = []
     for entry in sources:
-        parts.append("### %s\n" % entry["path"])
+        parts.append(f"### {entry['path']}\n")
         text = entry["text"]
         parts.append(text if text.endswith("\n") else text + "\n")
         parts.append("\n")
@@ -449,12 +450,8 @@ def write_text_atomic(path, text):
         os.chmod(tmp, 0o666 & ~umask)
         os.replace(tmp, path)
     except BaseException:
-        try:
+        with suppress(OSError):
             os.unlink(tmp)
-        except OSError:
-            # Best-effort cleanup: unlink can fail (already removed, perms,
-            # races). Never mask the original write/replace error.
-            pass
         raise
 
 
@@ -472,8 +469,8 @@ def _gaps(collector):
     ]
     for entry in security:
         gaps.append(
-            "project_rules_refused: %s (%s) — pointer refused; it is not a "
-            "markdown file inside the repository" % (entry["path"], entry["reason"])
+            f"project_rules_refused: {entry['path']} ({entry['reason']}) — pointer "
+            "refused; it is not a markdown file inside the repository"
         )
     for entry in collector.skipped:
         if entry["reason"] in (
@@ -483,14 +480,14 @@ def _gaps(collector):
             "depth_exceeded",
         ):
             gaps.append(
-                "project_rules_truncated: %s (%s) — its rules are NOT in "
-                "the review context" % (entry["path"], entry["reason"])
+                f"project_rules_truncated: {entry['path']} ({entry['reason']}) — its "
+                "rules are NOT in the review context"
             )
     for entry in collector.skipped:
         if entry["reason"] in ("missing", "cycle", "not_regular"):
             gaps.append(
-                "project_rules_unresolved: %s (%s) — this pointer did not resolve "
-                "to rule content" % (entry["path"], entry["reason"])
+                f"project_rules_unresolved: {entry['path']} ({entry['reason']}) — "
+                "this pointer did not resolve to rule content"
             )
     if not collector.sources:
         gaps.append(
@@ -606,11 +603,9 @@ def main(argv=None):
         )
         return 0
     except Exception as exc:  # noqa: BLE001 — a receipt on every path
-        sys.stderr.write("collect_project_rules: %s\n" % exc)
-        try:
+        sys.stderr.write(f"collect_project_rules: {exc}\n")
+        with suppress(Exception):
             write_text_atomic(args.out, render(collector.sources) if collector else "")
-        except Exception:  # noqa: BLE001
-            pass
         _emit(
             _receipt(
                 ok=False,
@@ -619,7 +614,7 @@ def main(argv=None):
                 skipped=collector.skipped if collector else [],
                 total_bytes=0,
                 truncated=False,
-                gaps=["project_rules_failed: %s" % exc],
+                gaps=[f"project_rules_failed: {exc}"],
             )
         )
         return 1

--- a/scripts/detect_prior_review.py
+++ b/scripts/detect_prior_review.py
@@ -642,9 +642,9 @@ def main():
 
     try:
         signal = select_latest(entries)
-    except Exception as exc:  # pragma: no cover — defensive: detection never blocks
+    except Exception as exc:  # noqa: BLE001  # pragma: no cover - detection never blocks
         signal = None
-        errors = errors + [f"detection failed: {exc}"]
+        errors = [*errors, f"detection failed: {exc}"]
 
     git_facts = resolve_git_facts(
         signal.get("sha") if signal else None, args.head_sha, errors

--- a/scripts/filter_findings.py
+++ b/scripts/filter_findings.py
@@ -659,7 +659,7 @@ def detect_disagreement(findings):
     suppressed_ids = set()
     suppressed = []
 
-    for key, group in location_groups.items():
+    for group in location_groups.values():
         if len(group) < 2:
             continue
 
@@ -734,7 +734,7 @@ def detect_disagreement(findings):
         consensus_groups.setdefault(group_key, []).append(finding)
 
     boosted_count = 0
-    for group_key, group in consensus_groups.items():
+    for group in consensus_groups.values():
         count = len(group)
         agents_in_group = [f.get("agent", "") for f in group if f.get("agent")]
 
@@ -772,7 +772,7 @@ def detect_disagreement(findings):
         key = (finding.get("file", ""), finding.get("line_start", 0))
         location_groups_active.setdefault(key, []).append(finding)
 
-    for key, group in location_groups_active.items():
+    for group in location_groups_active.values():
         if len(group) < 2:
             group[0].setdefault("contradiction", False)
             group[0].setdefault("security_escalation", False)
@@ -984,10 +984,7 @@ def _is_test_correctness_finding(finding):
     description = finding.get("description", "")
     combined = f"{title}\n{description}"
 
-    for pattern in _TEST_CORRECTNESS_PATTERNS:
-        if pattern.search(combined):
-            return True
-    return False
+    return any(pattern.search(combined) for pattern in _TEST_CORRECTNESS_PATTERNS)
 
 
 def group_by_proximity(findings, line_proximity=5):

--- a/scripts/materialize_artifacts.py
+++ b/scripts/materialize_artifacts.py
@@ -235,20 +235,20 @@ def plan_entries(payload, output_root, errors):
     checked = []
     for index, entry in enumerate(entries):
         if not isinstance(entry, dict):
-            errors.append("entry %d is not an object" % index)
+            errors.append(f"entry {index} is not an object")
             return None, None
         path = entry.get("path")
         text = entry.get("text")
         if not isinstance(path, str) or not path:
-            errors.append("entry %d has no usable string path" % index)
+            errors.append(f"entry {index} has no usable string path")
             return None, None
         if not isinstance(text, str):
-            errors.append("entry %d (%s) carries no string text" % (index, path))
+            errors.append(f"entry {index} ({path}) carries no string text")
             return None, None
         if not _confined(path, output_root):
             errors.append(
-                "entry %d writes outside the output directory: %s is not inside %s"
-                % (index, path, output_root)
+                f"entry {index} writes outside the output directory: {path} is not "
+                f"inside {output_root}"
             )
             return None, None
         checked.append((path, text))
@@ -258,8 +258,8 @@ def plan_entries(payload, output_root, errors):
         return None, None
     if plan_path not in [path for path, _text in checked]:
         errors.append(
-            "the named persist plan %s is not among the entries this payload carries"
-            % plan_path
+            f"the named persist plan {plan_path} is not among the entries this "
+            "payload carries"
         )
         return None, None
     return checked, plan_path
@@ -277,9 +277,7 @@ def write_entries(entries, materialized, errors):
         try:
             write_text_atomic(path, text)
         except Exception as exc:  # noqa: BLE001 - reported, never raised
-            errors.append(
-                "could not write %s (%s: %s)" % (path, type(exc).__name__, exc)
-            )
+            errors.append(f"could not write {path} ({type(exc).__name__}: {exc})")
             ok = False
             continue
         materialized.append(
@@ -316,15 +314,11 @@ def proof_gaps(receipt, plan_text):
         if not isinstance(entry, dict) or entry.get("content_proof") == "match":
             continue
         gaps.append(
-            "artifact-content-proof: %s on disk differs from the bytes the workflow "
-            "returned (expected %s chars/%s, got %s/%s)"
-            % (
-                entry.get("path"),
-                entry.get("expected_chars"),
-                entry.get("expected_checksum"),
-                entry.get("chars"),
-                entry.get("checksum"),
-            )
+            f"artifact-content-proof: {entry.get('path')} on disk differs from the "
+            "bytes the workflow returned "
+            f"(expected {entry.get('expected_chars')} chars/"
+            f"{entry.get('expected_checksum')}, got {entry.get('chars')}/"
+            f"{entry.get('checksum')})"
         )
     try:
         expected = {
@@ -333,7 +327,7 @@ def proof_gaps(receipt, plan_text):
             if isinstance(item, dict)
         }
     except ValueError:
-        return gaps + ["the persist plan just written is not valid JSON"]
+        return [*gaps, "the persist plan just written is not valid JSON"]
     for entry in receipt.get("written") or []:
         if not isinstance(entry, dict):
             continue
@@ -341,7 +335,7 @@ def proof_gaps(receipt, plan_text):
         if want is None:
             gaps.append(
                 "artifact-content-proof: the persist plan carries no derived-content "
-                "expectation for %s (no content proof)" % entry.get("path")
+                f"expectation for {entry.get('path')} (no content proof)"
             )
             continue
         if entry.get("chars") == want.get("chars") and entry.get(
@@ -349,15 +343,10 @@ def proof_gaps(receipt, plan_text):
         ) == want.get("checksum"):
             continue
         gaps.append(
-            "artifact-content-proof: derived document %s does not match the "
-            "pipeline's own derivation (wrote %s chars/%s, the pipeline derived %s/%s)"
-            % (
-                entry.get("path"),
-                entry.get("chars"),
-                entry.get("checksum"),
-                want.get("chars"),
-                want.get("checksum"),
-            )
+            f"artifact-content-proof: derived document {entry.get('path')} does not "
+            "match the pipeline's own derivation "
+            f"(wrote {entry.get('chars')} chars/{entry.get('checksum')}, the pipeline "
+            f"derived {want.get('chars')}/{want.get('checksum')})"
         )
     return gaps
 
@@ -392,8 +381,8 @@ def materialize(task, nonce, output_dir, environ=None):
     if payload is None:
         errors.append(
             "no task output file carrying this run's returned artifacts was found "
-            "(looked at %d candidate file(s) for target %r / nonce %r)"
-            % (scanned, task, nonce)
+            f"(looked at {scanned} candidate file(s) for target {task!r} / nonce "
+            f"{nonce!r})"
         )
         return _receipt(False, source, scanned, materialized, None, gaps, errors)
 
@@ -433,7 +422,7 @@ def _minimal_receipt_line(exc):
                 [],
                 None,
                 [],
-                ["receipt could not be serialized: %s: %s" % (type(exc).__name__, exc)],
+                [f"receipt could not be serialized: {type(exc).__name__}: {exc}"],
             )
         )
     except Exception:  # noqa: BLE001 - the never-print-nothing contract
@@ -485,7 +474,7 @@ def main(argv=None, environ=None):
             [],
             None,
             [],
-            ["materializer failed unexpectedly: %s: %s" % (type(exc).__name__, exc)],
+            [f"materializer failed unexpectedly: {type(exc).__name__}: {exc}"],
         )
     try:
         line = escape_lone_surrogates(

--- a/scripts/merge_findings.py
+++ b/scripts/merge_findings.py
@@ -192,11 +192,9 @@ def _try_parse_json_at(text: str, start: int) -> dict | None:
                 candidate = text[start : i + 1]
                 try:
                     parsed = json.loads(candidate)
-                    if isinstance(parsed, dict):
-                        return parsed
-                    return None
                 except json.JSONDecodeError:
                     return None
+                return parsed if isinstance(parsed, dict) else None
         i += 1
     return None
 

--- a/scripts/merge_findings.py
+++ b/scripts/merge_findings.py
@@ -99,8 +99,8 @@ def _ndjson_path(findings_dir: str, agent: str, session_sha: str) -> str:
 
 def parse_ndjson_file(path: str, agent: str) -> tuple[list[dict], list[str]]:
     """Parse a single NDJSON file. Returns (findings, warnings)."""
-    findings = []
-    parse_warnings = []
+    findings: list[dict] = []
+    parse_warnings: list[str] = []
 
     if not os.path.exists(path):
         return findings, parse_warnings
@@ -191,7 +191,10 @@ def _try_parse_json_at(text: str, start: int) -> dict | None:
             if depth == 0:
                 candidate = text[start : i + 1]
                 try:
-                    return json.loads(candidate)
+                    parsed = json.loads(candidate)
+                    if isinstance(parsed, dict):
+                        return parsed
+                    return None
                 except json.JSONDecodeError:
                     return None
         i += 1
@@ -239,8 +242,8 @@ def parse_text_file(path: str, agent: str) -> tuple[list[dict], list[str], bool,
         has_prose: True if text has meaningful non-JSON, non-SKIP content
         has_skip_lines: True if text contains SKIP: lines
     """
-    findings = []
-    parse_warnings = []
+    findings: list[dict] = []
+    parse_warnings: list[str] = []
     has_prose = False
     has_skip_lines = False
 
@@ -299,7 +302,8 @@ def deduplicate(
     """
     from finding_dedup import dedup_by_id
 
-    return dedup_by_id(ndjson_findings, text_findings)
+    result: tuple[list[dict], int, int] = dedup_by_id(ndjson_findings, text_findings)
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/post_review.py
+++ b/scripts/post_review.py
@@ -85,8 +85,8 @@ from review_marker import SHA_RE, build_footer
 # be written into the payload file. main() resets all three at startup.
 
 DRY_RUN = False
-_CAPTURED = []
-_SKIP_WARNINGS = []
+_CAPTURED: list[dict] = []
+_SKIP_WARNINGS: list[str] = []
 
 
 # ---------------------------------------------------------------------------
@@ -139,7 +139,7 @@ def post_json(cmd_prefix, payload):
     try:
         with os.fdopen(fd, "w") as f:
             json.dump(payload, f, ensure_ascii=False)
-        cmd = cmd_prefix + ["--input", tmppath]
+        cmd = [*cmd_prefix, "--input", tmppath]
         stdout, stderr, rc = run_api(cmd)
         if rc != 0:
             die(
@@ -176,14 +176,12 @@ def detect_platform():
     ssh_match = re.match(r"git@([^:]+):(.+?)(?:\.git)?$", url)
     if ssh_match:
         host = ssh_match.group(1)
-        path = ssh_match.group(2)
     else:
         # https://host/path or http://host/path
         https_match = re.match(r"https?://([^/]+)/(.+?)(?:\.git)?$", url)
         if not https_match:
             return None, None
         host = https_match.group(1)
-        path = https_match.group(2)
 
     if "github.com" in host:
         return "github", host
@@ -306,7 +304,7 @@ def valid_lines_for_file(valid_lines, filepath):
     if valid_lines is None:
         return None
     stripped = re.sub(r"^[ab]/", "", filepath)
-    lines = sorted({l for fp, l in valid_lines if fp == filepath or fp == stripped})
+    lines = sorted({line for fp, line in valid_lines if fp in (filepath, stripped)})
     return lines[:10]
 
 
@@ -638,7 +636,7 @@ def post_gitlab(data, valid_lines, new_files=None):
             "Content-Type: application/json",
             f"projects/{project_id}/merge_requests/{mr_iid}/discussions",
         ]
-        resp = post_json(cmd_prefix, payload)
+        post_json(cmd_prefix, payload)
         posted += 1
 
     if DRY_RUN:

--- a/scripts/review_marker.py
+++ b/scripts/review_marker.py
@@ -260,7 +260,7 @@ def find_marker(text):
                 found["_legacy"] = match.group(1) == LEGACY_MARKER_TOKEN
                 return found
         return None
-    except Exception:  # pragma: no cover — defensive: a reader never raises
+    except Exception:  # noqa: BLE001  # pragma: no cover - a reader never raises
         return None
 
 
@@ -290,7 +290,7 @@ def parse_prose_footer(text):
             if sha_match:
                 found = sha_match.group(1)
         return found
-    except Exception:  # pragma: no cover — defensive: a reader never raises
+    except Exception:  # noqa: BLE001  # pragma: no cover - a reader never raises
         return None
 
 

--- a/scripts/sync_agent_rules.py
+++ b/scripts/sync_agent_rules.py
@@ -95,11 +95,11 @@ def main(argv=None):
         return 0
     if args.check:
         sys.stderr.write(
-            "stale generated twins: %s\nrun: python3 scripts/sync_agent_rules.py\n"
-            % ", ".join(stale)
+            f"stale generated twins: {', '.join(stale)}\n"
+            "run: python3 scripts/sync_agent_rules.py\n"
         )
         return 1
-    print("regenerated: %s" % ", ".join(stale))
+    print(f"regenerated: {', '.join(stale)}")
     return 0
 
 

--- a/scripts/verify_findings.py
+++ b/scripts/verify_findings.py
@@ -457,18 +457,12 @@ def classify_blame(finding, base_branch):
     # RF-05: removed unreachable branch ``blamed_sha.startswith(full_sha)`` —
     # blamed_sha is always the shorter side, so only check full_sha.startswith(blamed_sha).
     def sha_in_pr(blamed_sha, pr_set):
-        for full_sha in pr_set:
-            if full_sha.startswith(blamed_sha):
-                return True
-        return False
+        return any(full_sha.startswith(blamed_sha) for full_sha in pr_set)
 
     has_pr_commit = any(sha_in_pr(s, pr_commits) for s in blamed_shas)
 
     # "new" if any blamed commit is in the PR branch; otherwise "surfaced"
-    if has_pr_commit:
-        classification = "new"
-    else:
-        classification = "surfaced"
+    classification = "new" if has_pr_commit else "surfaced"
 
     finding["blame_metadata"] = {
         "classification": classification,
@@ -786,7 +780,7 @@ def verify_factual(finding):
         # Proportional penalty: scale reduction by fraction of symbols missing
         # e.g., 1 of 4 found → miss_ratio=0.75 → reduction of ~52
         # e.g., 3 of 4 found → miss_ratio=0.25 → reduction of ~18
-        reduction = int(round(miss_ratio * 70))
+        reduction = round(miss_ratio * 70)
         new_confidence = max(30, original_confidence - reduction)
         finding["confidence"] = new_confidence
         finding["factual_verification"] = {
@@ -986,7 +980,7 @@ def _half_up_int(value):
         return None
     # Explicit half-up, not round(): Python's round() is half-to-even, and the
     # spelling of this decision should not depend on which runtime reads the code.
-    return int(math.floor(value + 0.5))
+    return math.floor(value + 0.5)
 
 
 def _coerce_numeric_fields(finding):

--- a/tests/test_agent_contracts.py
+++ b/tests/test_agent_contracts.py
@@ -28,7 +28,8 @@ DISCOVERY_AGENTS = [
 # (issue #48). The 7 discovery agents plus the three other file-readers: validator and
 # change-summarizer are handed the shared context path by the same stage inputs the
 # discovery agents are; challenger is not, but it opens the code under review itself.
-COMPLETE_READ_AGENTS = DISCOVERY_AGENTS + [
+COMPLETE_READ_AGENTS = [
+    *DISCOVERY_AGENTS,
     "validator",
     "challenger",
     "change-summarizer",

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -26,6 +26,7 @@ import subprocess
 import sys
 import unittest
 from pathlib import Path
+from typing import ClassVar
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -259,13 +260,13 @@ class TestCollectorDedup(unittest.TestCase):
 class TestRulesFileQuotations(unittest.TestCase):
     """Quoted spans attributed to AGENTS.md/CLAUDE.md must exist in a rules file."""
 
-    QUOTE_NEAR_RULES = re.compile(
+    QUOTE_NEAR_RULES: ClassVar[re.Pattern[str]] = re.compile(
         r"`?(?:[A-Za-z0-9_./-]+/)?(?:CLAUDE|AGENTS)\.md`?"
         r"\s+(?:says\s+|states\s+|already applies[^\n(]{0,100}\(\s*)?"
         r'["\u201c]([^"\u201d\n]{12,})["\u201d]',
         re.IGNORECASE,
     )
-    QUOTE_EXEMPTIONS = {
+    QUOTE_EXEMPTIONS: ClassVar[set[tuple[str, str]]] = {
         (
             "skills/code-gauntlet/references/false-positive-exclusions.md",
             "all functions must have JSDoc",
@@ -350,7 +351,7 @@ class TestClaimsResolve(unittest.TestCase):
     it vouch for itself, so this docstring describes those defects without spelling them.
     """
 
-    FILES = [
+    FILES: ClassVar[list[str]] = [
         "AGENTS.md",
         "CLAUDE.md",
         "REVIEW.md",
@@ -361,7 +362,7 @@ class TestClaimsResolve(unittest.TestCase):
 
     # Backticked prose terms that are English, schema field names, or host globals named
     # precisely because they are ABSENT — none of them are repo symbols.
-    NOT_SYMBOLS = {
+    NOT_SYMBOLS: ClassVar[set[str]] = {
         "description",
         "evidence",
         "suggestion",

--- a/tests/test_apply_challenges.py
+++ b/tests/test_apply_challenges.py
@@ -67,10 +67,9 @@ def _make_challenge(id_, score, justification=None):
 
 def _write_json(data):
     """Write data to a temp file and return the path."""
-    f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-    json.dump(data, f)
-    f.close()
-    return f.name
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(data, f)
+        return f.name
 
 
 # ---------------------------------------------------------------------------
@@ -147,9 +146,8 @@ class TestLoadFiltered(unittest.TestCase):
             load_filtered("/nonexistent/path.json")
 
     def test_invalid_json_exits(self):
-        f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-        f.write("not json {{{")
-        f.close()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not json {{{")
         try:
             with self.assertRaises(SystemExit):
                 load_filtered(f.name)
@@ -195,9 +193,8 @@ class TestLoadChallenges(unittest.TestCase):
             load_challenges("/nonexistent/challenges.json")
 
     def test_invalid_json_exits(self):
-        f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-        f.write("[bad json")
-        f.close()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("[bad json")
         try:
             with self.assertRaises(SystemExit):
                 load_challenges(f.name)
@@ -747,9 +744,11 @@ class TestMainCLI(unittest.TestCase):
         c_path = _write_json(challenges)
         try:
             captured = io.StringIO()
-            with patch("sys.argv", ["apply_challenges.py", f_path, c_path]):
-                with patch("sys.stdout", captured):
-                    main()
+            with (
+                patch("sys.argv", ["apply_challenges.py", f_path, c_path]),
+                patch("sys.stdout", captured),
+            ):
+                main()
             output = json.loads(captured.getvalue())
             self.assertIn("findings", output)
             self.assertNotIn("filtered", output)

--- a/tests/test_apply_validations.py
+++ b/tests/test_apply_validations.py
@@ -50,10 +50,9 @@ def _make_finding(**kwargs):
 
 def _write_json(data):
     """Write data to a temp file, return the path."""
-    f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-    json.dump(data, f)
-    f.close()
-    return f.name
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(data, f)
+        return f.name
 
 
 # ---------------------------------------------------------------------------
@@ -108,9 +107,8 @@ class TestLoadFindings(unittest.TestCase):
             load_findings("/nonexistent/path/findings.json")
 
     def test_invalid_json_exits(self):
-        f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-        f.write("{not valid json}")
-        f.close()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{not valid json}")
         try:
             with self.assertRaises(SystemExit):
                 load_findings(f.name)
@@ -164,9 +162,8 @@ class TestLoadValidations(unittest.TestCase):
             load_validations("/nonexistent/validations.json")
 
     def test_invalid_json_exits(self):
-        f = tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False)
-        f.write("not json")
-        f.close()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not json")
         try:
             with self.assertRaises(SystemExit):
                 load_validations(f.name)

--- a/tests/test_assemble_artifacts.py
+++ b/tests/test_assemble_artifacts.py
@@ -30,6 +30,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from typing import ClassVar
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, REPO_ROOT)
@@ -100,11 +101,11 @@ def finding(fid, **over):
     artifact-writer boundary adds (line/end_line/body)."""
     f = {
         "id": fid,
-        "file": "src/%s.js" % fid,
+        "file": f"src/{fid}.js",
         "line_start": 10,
         "line_end": 12,
-        "title": "finding %s" % fid,
-        "description": "a real problem in %s" % fid,
+        "title": f"finding {fid}",
+        "description": f"a real problem in {fid}",
         "severity": "high",
         "confidence": 90,
         "dimension": "bug",
@@ -275,7 +276,7 @@ class TestCrossRuntimeChecksumParity(unittest.TestCase):
     """The JS implementation runs in the sandbox; Python runs on disk. They must
     agree exactly — surrogate pairs (emoji, astral plane) are the trap."""
 
-    STRINGS = [
+    STRINGS: ClassVar[list[str]] = [
         "",
         "a",
         "hello world",
@@ -286,7 +287,7 @@ class TestCrossRuntimeChecksumParity(unittest.TestCase):
         "😀",
         "😀🎉🚀",
         "mixed 😀 café 日本語 tail",
-        "𝕏 astral plane 𝔸𝔹ℂ",
+        "\U0001d54f astral plane \U0001d538\U0001d539\u2102",
         "line1\nline2\ttab\r\n",
         "𠜎𠜱𠝹",  # CJK extension B (astral)
     ]
@@ -300,9 +301,9 @@ class TestCrossRuntimeChecksumParity(unittest.TestCase):
             )
             self.assertEqual(proc.returncode, 0, proc.stderr)
             js_checksum, js_chars = proc.stdout.strip().split(" ")
-            self.assertEqual(js_checksum, fnv1a32(s), "checksum mismatch for %r" % s)
+            self.assertEqual(js_checksum, fnv1a32(s), f"checksum mismatch for {s!r}")
             self.assertEqual(
-                int(js_chars), utf16_len(s), "char count mismatch for %r" % s
+                int(js_chars), utf16_len(s), f"char count mismatch for {s!r}"
             )
 
 
@@ -533,7 +534,7 @@ class TestStructuralHardFailures(unittest.TestCase):
         self.assertEqual(receipt["written"], [])
         self.assertTrue(
             any(needle in e for e in receipt["errors"]),
-            "expected %r in %r" % (needle, receipt["errors"]),
+            f"expected {needle!r} in {receipt['errors']!r}",
         )
         self.assertFalse(os.path.exists(ws.post_path))
         self.assertFalse(os.path.exists(ws.checkpoint_path))
@@ -617,7 +618,9 @@ class TestChecksumMismatchIsNotFatal(unittest.TestCase):
             self.assertEqual(proc.returncode, 0, proc.stderr)
             receipt = json.loads(proc.stdout)
             self.assertTrue(receipt["ok"])
-            entry = [e for e in receipt["verified"] if e["path"] == ws.findings_path][0]
+            entry = next(
+                e for e in receipt["verified"] if e["path"] == ws.findings_path
+            )
             self.assertEqual(entry["content_proof"], "mismatch")
             self.assertEqual(entry["expected_checksum"], "fnv1a32:0xdeadbeef")
             self.assertEqual(entry["expected_chars"], 999999)
@@ -645,28 +648,36 @@ class TestWriteToolNormalizationTolerance(unittest.TestCase):
         with _Workspace() as ws:
             ws.write(ws.findings_path, ws.findings_json + "\n")
             receipt = json.loads(run_script(ws.write_plan(ws.plan())).stdout)
-            entry = [e for e in receipt["verified"] if e["path"] == ws.findings_path][0]
+            entry = next(
+                e for e in receipt["verified"] if e["path"] == ws.findings_path
+            )
             self.assertEqual(entry["content_proof"], "match")
 
     def test_crlf_trailing_newline_still_matches(self):
         with _Workspace() as ws:
             ws.write(ws.findings_path, ws.findings_json + "\r\n")
             receipt = json.loads(run_script(ws.write_plan(ws.plan())).stdout)
-            entry = [e for e in receipt["verified"] if e["path"] == ws.findings_path][0]
+            entry = next(
+                e for e in receipt["verified"] if e["path"] == ws.findings_path
+            )
             self.assertEqual(entry["content_proof"], "match")
 
     def test_bom_prefix_still_matches(self):
         with _Workspace() as ws:
             ws.write(ws.findings_path, "﻿" + ws.findings_json)
             receipt = json.loads(run_script(ws.write_plan(ws.plan())).stdout)
-            entry = [e for e in receipt["verified"] if e["path"] == ws.findings_path][0]
+            entry = next(
+                e for e in receipt["verified"] if e["path"] == ws.findings_path
+            )
             self.assertEqual(entry["content_proof"], "match")
 
     def test_two_trailing_newlines_is_a_real_mismatch(self):
         with _Workspace() as ws:
             ws.write(ws.findings_path, ws.findings_json + "\n\n")
             receipt = json.loads(run_script(ws.write_plan(ws.plan())).stdout)
-            entry = [e for e in receipt["verified"] if e["path"] == ws.findings_path][0]
+            entry = next(
+                e for e in receipt["verified"] if e["path"] == ws.findings_path
+            )
             self.assertEqual(entry["content_proof"], "mismatch")
 
 
@@ -676,16 +687,20 @@ class TestNonAsciiContent(unittest.TestCase):
 
     def test_astral_and_cjk_content_round_trips(self):
         findings = [
-            finding("F1", description="日本語の説明 😀 with an astral 𝕏"),
+            finding("F1", description="日本語の説明 😀 with an astral \U0001d54f"),
             finding("F2", title="中文标题 🎉"),
         ]
         with _Workspace(findings=findings) as ws:
             receipt = json.loads(run_script(ws.write_plan(ws.plan())).stdout)
             self.assertTrue(receipt["ok"], receipt)
-            entry = [e for e in receipt["verified"] if e["path"] == ws.findings_path][0]
+            entry = next(
+                e for e in receipt["verified"] if e["path"] == ws.findings_path
+            )
             self.assertEqual(entry["content_proof"], "match")
             post = json.loads(ws.read(ws.post_path))
-            self.assertEqual(post[0]["description"], "日本語の説明 😀 with an astral 𝕏")
+            self.assertEqual(
+                post[0]["description"], "日本語の説明 😀 with an astral \U0001d54f"
+            )
             self.assertEqual(post[1]["title"], "中文标题 🎉")
 
     def test_non_ascii_is_not_escaped_in_the_derived_json(self):
@@ -805,7 +820,7 @@ class TestPlanChecksumCrossRuntime(unittest.TestCase):
         cases = [
             [finding("F1"), finding("F2")],
             [
-                finding("A", description="日本語 😀 astral 𝕏"),
+                finding("A", description="日本語 😀 astral \U0001d54f"),
                 finding("B", title="中文 🎉"),
             ],
             [],
@@ -933,7 +948,7 @@ class TestAnyFailureStillReturnsAReceipt(unittest.TestCase):
         self.assertFalse(receipt["ok"], receipt)
         self.assertTrue(
             any(needle in e for e in receipt["errors"]),
-            "expected %r in %r" % (needle, receipt["errors"]),
+            f"expected {needle!r} in {receipt['errors']!r}",
         )
         self.assertNotIn("Traceback", proc.stderr)
         return receipt
@@ -1026,7 +1041,7 @@ class TestCrossRuntimeStringifyParity(unittest.TestCase):
     control characters, empty containers, and the numeric edges (L1-3)."""
 
     # Documents as JSON TEXT so escapes survive the argv hop into node unchanged.
-    AGREE = [
+    AGREE: ClassVar[list[str]] = [
         "[]",
         "{}",
         '[{}, [], "", null, true, false]',
@@ -1042,14 +1057,14 @@ class TestCrossRuntimeStringifyParity(unittest.TestCase):
         '["\\u0000\\u0001\\u001f"]',  # control characters
         '["\\b\\f\\n\\r\\t"]',
         '["quote \\" backslash \\\\ slash /"]',
-        '["café — naïve", "日本語", "𝕏 astral", "\\u007f"]',
+        '["café — naïve", "日本語", "\U0001d54f astral", "\\u007f"]',
         "[0, -0, 1, -1, 9007199254740991, -9007199254740991]",
         '{"line_start": 10, "line_end": 12, "confidence": 90}',
         '[{"id": "F1", "d": "多行\\ntext\\twith escapes"}]',
     ]
 
     # Documents whose naive json.dumps spelling PROVABLY differs from JSON.stringify.
-    DIVERGENT = [
+    DIVERGENT: ClassVar[list[str]] = [
         "[1e-7]",  # 1e-7   vs 1e-07
         "[0.000001]",  # 0.000001 vs 1e-06
         "[90.0]",  # 90     vs 90.0
@@ -1064,7 +1079,8 @@ class TestCrossRuntimeStringifyParity(unittest.TestCase):
     # does; 1e-7 does not) needs exactly the Number#toString port the precondition
     # exists to avoid. NaN/Infinity are here too — json.loads accepts them bare,
     # JSON.parse rejects them, JSON.stringify spells them `null`.
-    REFUSE = DIVERGENT + [
+    REFUSE: ClassVar[list[str]] = [
+        *DIVERGENT,
         "[1.5]",
         "[1e21]",
         "[9007199254740992]",
@@ -1075,9 +1091,9 @@ class TestCrossRuntimeStringifyParity(unittest.TestCase):
     def test_python_matches_node_over_the_trap_corpus(self):
         node_or_skip(self)
         expected = js_stringify_many(self.AGREE)
-        for text, want in zip(self.AGREE, expected):
+        for text, want in zip(self.AGREE, expected, strict=True):
             got = js_stringify_pretty(json.loads(text))
-            self.assertEqual(got, want, "divergence for %s" % text)
+            self.assertEqual(got, want, f"divergence for {text}")
 
     def test_the_agreed_output_is_always_utf8_encodable(self):
         # The L1-1 crash: a raw lone surrogate in the output cannot be encoded.
@@ -1095,9 +1111,9 @@ class TestCrossRuntimeStringifyParity(unittest.TestCase):
         node_or_skip(self)
         provable = [t for t in self.DIVERGENT if t != '{"stats": {"rate": 0.5}}']
         expected = js_stringify_many(provable)
-        for text, want in zip(provable, expected):
+        for text, want in zip(provable, expected, strict=True):
             naive = json.dumps(json.loads(text), indent=2, ensure_ascii=False)
-            self.assertNotEqual(naive, want, "%s no longer diverges" % text)
+            self.assertNotEqual(naive, want, f"{text} no longer diverges")
 
 
 class TestDerivedDocumentsAgreeWithTheJsSerialization(unittest.TestCase):
@@ -1115,7 +1131,10 @@ class TestDerivedDocumentsAgreeWithTheJsSerialization(unittest.TestCase):
 
     def test_written_entries_match_what_node_would_have_computed(self):
         node_or_skip(self)
-        findings = [finding("F1", description="日本語 😀 𝕏 prose"), finding("F2")]
+        findings = [
+            finding("F1", description="日本語 😀 \U0001d54f prose"),
+            finding("F2"),
+        ]
         with _Workspace(findings=findings) as ws:
             receipt = json.loads(run_script(ws.write_plan(ws.plan())).stdout)
             self.assertTrue(receipt["ok"], receipt)
@@ -1220,7 +1239,7 @@ class TestCheckpointSkeletonGuardMirrorsTheJsOne(unittest.TestCase):
         self.assertEqual(receipt["written"], [])
         self.assertTrue(
             any(needle in e for e in receipt["errors"]),
-            "expected %r in %r" % (needle, receipt["errors"]),
+            f"expected {needle!r} in {receipt['errors']!r}",
         )
         self.assertFalse(os.path.exists(ws.checkpoint_path))
 

--- a/tests/test_await_workflow.py
+++ b/tests/test_await_workflow.py
@@ -175,7 +175,7 @@ def run_main(argv, environ=None):
 def sole_json_line(stdout):
     """Assert stdout is exactly one line of JSON and return the parsed object."""
     lines = [line for line in stdout.split("\n") if line != ""]
-    assert len(lines) == 1, "expected exactly one stdout line, got %d" % len(lines)
+    assert len(lines) == 1, f"expected exactly one stdout line, got {len(lines)}"
     return json.loads(lines[0])
 
 
@@ -442,17 +442,17 @@ class TestScanCostIsBounded(unittest.TestCase):
     def test_dense_open_braces_are_fast(self):
         found, elapsed = self._timed("{" * 200_000)
         self.assertIsNone(found)
-        self.assertLess(elapsed, 1.0, "%.2fs for 200k open braces" % elapsed)
+        self.assertLess(elapsed, 1.0, f"{elapsed:.2f}s for 200k open braces")
 
     def test_dense_brace_quote_pairs_are_fast(self):
         found, elapsed = self._timed('{"' * 200_000)
         self.assertIsNone(found)
-        self.assertLess(elapsed, 1.0, "%.2fs for 200k brace-quote pairs" % elapsed)
+        self.assertLess(elapsed, 1.0, f"{elapsed:.2f}s for 200k brace-quote pairs")
 
     def test_many_line_leading_braces_are_fast(self):
         found, elapsed = self._timed('\n{"a":' * 50_000)
         self.assertIsNone(found)
-        self.assertLess(elapsed, 2.0, "%.2fs for 50k line-leading fragments" % elapsed)
+        self.assertLess(elapsed, 2.0, f"{elapsed:.2f}s for 50k line-leading fragments")
 
     def test_a_real_return_after_heavy_noise_is_still_found(self):
         text = "{" * 50_000 + "\n" + json.dumps(SUCCESS_RETURN)
@@ -518,7 +518,7 @@ class TestEveryBoundIsDisclosed(unittest.TestCase):
         self.assertIsNone(stopped)
 
     def test_candidate_bound_is_reported(self):
-        text = "\n".join('{"n":%d}' % i for i in range(2000)) + "\n"
+        text = "\n".join(f'{{"n":{i}}}' for i in range(2000)) + "\n"
         found, _, stopped = find_terminal(text)
         self.assertIsNone(found)
         self.assertIn(stopped, ("max_candidates", "max_probes"))
@@ -528,7 +528,7 @@ class TestEveryBoundIsDisclosed(unittest.TestCase):
         text = (
             json.dumps(SUCCESS_RETURN)
             + "\n"
-            + "\n".join('{"n":%d}' % i for i in range(2000))
+            + "\n".join(f'{{"n":{i}}}' for i in range(2000))
             + "\n"
         )
         found, _, stopped = find_terminal(text)
@@ -1270,7 +1270,7 @@ class TestNextCommand(unittest.TestCase):
             argv += ["--" + key.replace("_", "-"), str(value)]
         # Target last, behind `--` — the same shape the script emits, and the
         # only shape that survives a target beginning with a dash.
-        return build_parser({}).parse_args(argv + ["--", target])
+        return build_parser({}).parse_args([*argv, "--", target])
 
     def test_increments_the_attempt(self):
         cmd = build_next_command(self._args(attempt=2, max_attempts=4), None, 1.0)
@@ -1475,7 +1475,7 @@ class TestArtifactNamingLockstep(unittest.TestCase):
             if "checkpoint" in template:
                 continue  # composed via checkpointPath(); asserted below
             literal = template.replace("{sha}", "${sha}")
-            self.assertIn(literal, source, "%s is not produced by stages.js" % template)
+            self.assertIn(literal, source, f"{template} is not produced by stages.js")
 
     def test_checkpoint_all_is_still_how_the_combined_checkpoint_is_named(self):
         """The checkpoint name is composed, so assert both halves of it."""

--- a/tests/test_collect_project_rules.py
+++ b/tests/test_collect_project_rules.py
@@ -74,7 +74,7 @@ class _RepoCase(unittest.TestCase):
     def run_script(self, *extra, **kwargs):
         """Run in-process (fast, importable) and return (exit_code, receipt, body)."""
         repo = kwargs.pop("repo", self.repo)
-        argv = ["--repo-root", repo, "--out", self.out] + list(extra)
+        argv = ["--repo-root", repo, "--out", self.out, *list(extra)]
         from io import StringIO
 
         saved = sys.stdout
@@ -88,8 +88,8 @@ class _RepoCase(unittest.TestCase):
         self.assertEqual(
             len(lines),
             1,
-            "stdout must be EXACTLY one line of JSON; got %d line(s): %r"
-            % (len(lines), captured),
+            f"stdout must be EXACTLY one line of JSON; got {len(lines)} line(s): "
+            f"{captured!r}",
         )
         receipt = json.loads(lines[0])
         # "" for a missing file as well as an empty one; the distinction between
@@ -195,7 +195,7 @@ class TestSecurityBoundary(_RepoCase):
         # The payload ends in .md so it is a real candidate and actually reaches
         # the join logic under test, rather than being dropped earlier.
         outside = self.write("secret.md", "ABS-CANARY\n", root=self.base)
-        self.write("CLAUDE.md", "@%s\n" % outside)
+        self.write("CLAUDE.md", f"@{outside}\n")
         _, receipt, body = self.run_script()
         self.assertNotIn("ABS-CANARY", body)
         self.assertIn("absolute_path", self.reasons(receipt))
@@ -293,12 +293,12 @@ class TestSecurityBoundary(_RepoCase):
         self.assertEqual(
             [],
             [s for s in receipt["skipped"] if s["reason"] != "duplicate_of"],
-            "prose at-signs must not produce skip entries: %r" % receipt["skipped"],
+            f"prose at-signs must not produce skip entries: {receipt['skipped']!r}",
         )
         self.assertEqual(
             [],
             [g for g in receipt["gaps"] if "refused" in g],
-            "prose at-signs must not produce refusal gaps: %r" % receipt["gaps"],
+            f"prose at-signs must not produce refusal gaps: {receipt['gaps']!r}",
         )
 
 
@@ -372,11 +372,9 @@ class TestBounds(_RepoCase):
         # exists because the constant was once deleted as apparent dead code —
         # nothing referenced it and nothing failed.
         cap = 10
-        self.write(
-            "CLAUDE.md", "\n".join("@f%d.md" % i for i in range(cap + 20)) + "\n"
-        )
+        self.write("CLAUDE.md", "\n".join(f"@f{i}.md" for i in range(cap + 20)) + "\n")
         for i in range(cap + 20):
-            self.write("f%d.md" % i, "")
+            self.write(f"f{i}.md", "")
         _, receipt, _ = self.run_script("--max-files", str(cap))
         # Only the pointer list itself contributes bytes; every target is empty,
         # so the byte caps are nowhere near tripping and cannot be what stopped
@@ -398,10 +396,10 @@ class TestBounds(_RepoCase):
         # script's view of a repo identical to the harness's.
         self.write("CLAUDE.md", "@d1.md\n")
         for i in range(1, MAX_IMPORT_DEPTH + 1):
-            self.write("d%d.md" % i, "RULE-D%d\n@d%d.md\n" % (i, i + 1))
-        self.write("d%d.md" % (MAX_IMPORT_DEPTH + 1), "RULE-TOO-DEEP\n")
+            self.write(f"d{i}.md", f"RULE-D{i}\n@d{i + 1}.md\n")
+        self.write(f"d{MAX_IMPORT_DEPTH + 1}.md", "RULE-TOO-DEEP\n")
         _, receipt, body = self.run_script()
-        self.assertIn("RULE-D%d" % MAX_IMPORT_DEPTH, body)
+        self.assertIn(f"RULE-D{MAX_IMPORT_DEPTH}", body)
         self.assertNotIn("RULE-TOO-DEEP", body)
         self.assertIn("depth_exceeded", self.reasons(receipt))
 
@@ -418,8 +416,8 @@ class TestBounds(_RepoCase):
         # cycle" is one of the reasons explicitly named as belonging in gaps[].
         self.assertTrue(
             any("cycle" in g for g in receipt["gaps"]),
-            "an import cycle must reach the human-readable gaps list: %r"
-            % receipt["gaps"],
+            f"an import cycle must reach the human-readable gaps list: "
+            f"{receipt['gaps']!r}",
         )
 
 
@@ -441,10 +439,10 @@ class TestDiscovery(_RepoCase):
 
     def test_all_declared_source_filenames_are_collected(self):
         for name in PROJECT_RULE_FILENAMES:
-            self.write(name, "RULE-FROM-%s\n" % name.replace(".md", ""))
+            self.write(name, f"RULE-FROM-{name.replace('.md', '')}\n")
         _, _, body = self.run_script()
         for name in PROJECT_RULE_FILENAMES:
-            self.assertIn("RULE-FROM-%s" % name.replace(".md", ""), body)
+            self.assertIn(f"RULE-FROM-{name.replace('.md', '')}", body)
 
     def test_changed_files_accepts_dict_shaped_entries(self):
         self.write("CLAUDE.md", "ROOT-RULE\n")
@@ -518,7 +516,7 @@ class TestDisclosureContract(_RepoCase):
         _, receipt, _ = self.run_script()
         self.assertTrue(receipt["skipped"])
         for entry in receipt["skipped"]:
-            self.assertTrue(entry.get("reason"), "silent skip: %r" % entry)
+            self.assertTrue(entry.get("reason"), f"silent skip: {entry!r}")
 
     def test_subprocess_invocation_keeps_stdout_to_one_json_line(self):
         # The in-process helper asserts this too, but Phase 2 invokes the script
@@ -541,7 +539,7 @@ class TestDisclosureContract(_RepoCase):
         for entry in receipt["skipped"]:
             self.assertFalse(
                 entry["path"].startswith("/"),
-                "receipt leaked an absolute host path: %r" % entry["path"],
+                f"receipt leaked an absolute host path: {entry['path']!r}",
             )
 
 

--- a/tests/test_contribution_surface.py
+++ b/tests/test_contribution_surface.py
@@ -544,24 +544,26 @@ class TestLabelsDiffHelper(unittest.TestCase):
             {"name": "ok", "color": "fff; echo pwned", "description": "not hex"},
         ]
         for entry in unusable:
-            with self.subTest(entry=entry["description"]):
-                with tempfile.TemporaryDirectory() as tmp:
-                    path = Path(tmp) / "labels.json"
-                    path.write_text(json.dumps({"labels": [entry]}), encoding="utf-8")
-                    result = subprocess.run(
-                        [
-                            sys.executable,
-                            str(LABELS_DIFF),
-                            "--manifest",
-                            str(path),
-                            "--commands",
-                        ],
-                        cwd=REPO,
-                        capture_output=True,
-                        text=True,
-                    )
-                    self.assertEqual(result.returncode, 2, result.stdout)
-                    self.assertEqual(result.stdout, "", "nothing may be emitted")
+            with (
+                self.subTest(entry=entry["description"]),
+                tempfile.TemporaryDirectory() as tmp,
+            ):
+                path = Path(tmp) / "labels.json"
+                path.write_text(json.dumps({"labels": [entry]}), encoding="utf-8")
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        str(LABELS_DIFF),
+                        "--manifest",
+                        str(path),
+                        "--commands",
+                    ],
+                    cwd=REPO,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 2, result.stdout)
+                self.assertEqual(result.stdout, "", "nothing may be emitted")
 
 
 class TestIssueFormSchema(unittest.TestCase):
@@ -999,7 +1001,7 @@ def _agents_coverage_gate_commands(text: str) -> set[str]:
     heading = re.search(r"(?m)^Coverage gates\b.*$", text)
     if not heading:
         raise AssertionError("AGENTS.md missing 'Coverage gates' section")
-    rest = text[heading.end():]
+    rest = text[heading.end() :]
     fence = re.search(r"```bash\n(.*?)```", rest, re.DOTALL)
     if not fence:
         raise AssertionError("AGENTS.md Coverage gates missing ```bash fence")
@@ -1009,7 +1011,9 @@ def _agents_coverage_gate_commands(text: str) -> set[str]:
     # not create a confusing residual-\n false fail (interior blanks stay).
     commands = {c.rstrip("\n") for c in chunks if c.strip()}
     if len(commands) < 3:
-        raise AssertionError(f"expected ≥3 gate commands in AGENTS.md, found {len(commands)}")
+        raise AssertionError(
+            f"expected ≥3 gate commands in AGENTS.md, found {len(commands)}"
+        )
     return commands
 
 
@@ -1040,21 +1044,25 @@ def _ci_run_blocks(text: str) -> list[str]:
                 content_indent = indent
             if indent < content_indent and line.strip():
                 break
-            collected.append(line[content_indent:] if content_indent is not None else line)
+            collected.append(
+                line[content_indent:] if content_indent is not None else line
+            )
             i += 1
         blocks.append("\n".join(collected).rstrip("\n"))
     return blocks
 
 
 def _ci_gate_commands(text: str) -> set[str]:
-    return {b for b in _ci_run_blocks(text) if any(marker in b for marker in GATE_MARKERS)}
+    return {
+        b for b in _ci_run_blocks(text) if any(marker in b for marker in GATE_MARKERS)
+    }
 
 
 def _ci_workflow_tests_node_version(text: str) -> str:
     """The node-version: value under the workflow-tests job (stdlib; no PyYAML)."""
     lines = text.splitlines()
     in_job = False
-    for index, line in enumerate(lines):
+    for line in lines:
         if re.match(r"^  workflow-tests:\s*$", line):
             in_job = True
             continue

--- a/tests/test_contribution_surface.py
+++ b/tests/test_contribution_surface.py
@@ -893,6 +893,28 @@ class TestContributingDocs(unittest.TestCase):
                     scope.match(path), f"cspell scope does not cover {path}"
                 )
 
+    def test_contributing_python_lint_hook_ids_match_pre_commit_config(self):
+        """Documented `pre-commit run <id>` commands stay tied to real hook ids."""
+        expected = {"ruff-check", "ruff-format", "mypy"}
+        contributing = _read("CONTRIBUTING.md")
+        hooks = _read(".pre-commit-config.yaml")
+        declared = set(re.findall(r"^\s+- id: ([^\s#]+)", hooks, re.M))
+        documented = set(
+            re.findall(
+                r"pre-commit run (ruff-check|ruff-format|mypy) --all-files",
+                contributing,
+            )
+        )
+        self.assertEqual(
+            documented,
+            expected,
+            "CONTRIBUTING.md must document exactly the Python lint/format/type hooks",
+        )
+        self.assertTrue(
+            expected.issubset(declared),
+            f"hooks {sorted(expected - declared)} missing from .pre-commit-config.yaml",
+        )
+
 
 # Required PR check-run names for ruleset 16049246 (protect-default-branch).
 # Any new always-on PR gate must update THIS tuple and the live ruleset in the

--- a/tests/test_detect_prior_review.py
+++ b/tests/test_detect_prior_review.py
@@ -85,7 +85,7 @@ def _run_main(argv):
     stdout = io.StringIO()
     code = 0
     with (
-        patch.object(sys, "argv", ["detect_prior_review.py"] + list(argv)),
+        patch.object(sys, "argv", ["detect_prior_review.py", *list(argv)]),
         contextlib.redirect_stdout(stdout),
     ):
         try:

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -219,9 +219,9 @@ def table_named(tables, keyword):
 def claude_md_bullet(anchor):
     """The single agents/AGENTS.md line containing `anchor`."""
     lines = [
-        l
-        for l in (REPO / "agents" / "AGENTS.md").read_text().splitlines()
-        if anchor in l
+        line
+        for line in (REPO / "agents" / "AGENTS.md").read_text().splitlines()
+        if anchor in line
     ]
     if len(lines) != 1:
         raise AssertionError(
@@ -500,7 +500,7 @@ class TestReportFormatFieldTables(unittest.TestCase):
             expected,
             documented,
             "report-format.md documents a field set that is not "
-            "registry ∪ {suggested_fix_code}",
+            "registry \u222a {suggested_fix_code}",
         )
 
     def test_canonical_table_matches_registry(self):

--- a/tests/test_filter_findings.py
+++ b/tests/test_filter_findings.py
@@ -1221,9 +1221,11 @@ class TestDedupCrossAgent(unittest.TestCase):
             from scripts.filter_findings import main as filter_main
 
             buf = io.StringIO()
-            with mock_patch("sys.argv", ["filter_findings.py", tmppath]):
-                with contextlib.redirect_stdout(buf):
-                    filter_main()
+            with (
+                mock_patch("sys.argv", ["filter_findings.py", tmppath]),
+                contextlib.redirect_stdout(buf),
+            ):
+                filter_main()
             result = json.loads(buf.getvalue())
             stats = result["stats"]
             self.assertIn("cross_agent_deduped", stats)

--- a/tests/test_materialize_artifacts.py
+++ b/tests/test_materialize_artifacts.py
@@ -60,7 +60,7 @@ def record_task_output(tmp, nonce=NONCE):
         timeout=60,
     )
     if proc.returncode != 0:
-        raise RuntimeError("recorder failed: %s" % proc.stderr)
+        raise RuntimeError(f"recorder failed: {proc.stderr}")
     return task_path, out_dir
 
 
@@ -83,7 +83,7 @@ def run_cli(args, environ=None):
     env = dict(os.environ)
     env.update(environ or {})
     proc = subprocess.run(
-        [sys.executable, SCRIPT] + args,
+        [sys.executable, SCRIPT, *args],
         cwd=REPO_ROOT,
         capture_output=True,
         text=True,
@@ -91,7 +91,7 @@ def run_cli(args, environ=None):
         env=env,
     )
     lines = [line for line in proc.stdout.splitlines() if line.strip()]
-    assert len(lines) == 1, "expected exactly one stdout line, got %r" % proc.stdout
+    assert len(lines) == 1, f"expected exactly one stdout line, got {proc.stdout!r}"
     return proc.returncode, json.loads(lines[0]), proc.stdout
 
 
@@ -104,8 +104,7 @@ class MaterializeTestCase(unittest.TestCase):
     def artifact(self, name):
         return os.path.join(
             self.out_dir,
-            "code-gauntlet-%s-abc1234.%s"
-            % (name, "md" if name == "report" else "json"),
+            f"code-gauntlet-{name}-abc1234.{'md' if name == 'report' else 'json'}",
         )
 
     def read(self, path):
@@ -123,8 +122,7 @@ class TestHappyPath(MaterializeTestCase):
             self.assertEqual(
                 self.read(entry["path"]),
                 entry["text"],
-                "%s is not byte-identical to what the workflow returned"
-                % entry["path"],
+                f"{entry['path']} is not byte-identical to what the workflow returned",
             )
 
     def test_the_bytes_a_transcriber_loses_survive(self):
@@ -138,7 +136,7 @@ class TestHappyPath(MaterializeTestCase):
         self.assertIn('\\"receipt\\"', description)
         self.assertIn("C:\\tmp\\out", description)
         self.assertIn("😀", description)
-        self.assertIn("𝕏", description)
+        self.assertIn("\U0001d54f", description)
         self.assertGreater(len(description), 1000, "long prose was not shortened")
         self.assertEqual(findings[0]["body"], description, "the v2 alias too")
 
@@ -312,7 +310,7 @@ class TestFailureModes(MaterializeTestCase):
 
     def test_a_payload_naming_no_plan_writes_nothing(self):
         def drop(payload):
-            payload["planPath"] = "%s/not-an-entry.json" % self.out_dir
+            payload["planPath"] = f"{self.out_dir}/not-an-entry.json"
 
         rewrite_payload(self.task, drop)
 

--- a/tests/test_post_review.py
+++ b/tests/test_post_review.py
@@ -24,6 +24,7 @@ import sys
 import tempfile
 import unittest
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -1628,7 +1629,7 @@ class TestWriterWrapperByteParity(_DryRunTestBase):
     the manual and wrapper payloads stay byte-identical either way.
     """
 
-    FINDINGS = [
+    FINDINGS: ClassVar[list[dict]] = [
         {
             "file": "foo.py",
             "line": 2,

--- a/tests/test_review_marker.py
+++ b/tests/test_review_marker.py
@@ -356,7 +356,7 @@ class TestMalformed(unittest.TestCase):
                     find_marker(text)
                     has_prose_footer(text)
                     parse_prose_footer(text)
-                except Exception as exc:  # pragma: no cover - this is the failure path
+                except Exception as exc:  # noqa: BLE001  # pragma: no cover
                     self.fail(f"raised {exc!r} on {text!r}")
 
 
@@ -399,7 +399,7 @@ class TestMaxMarkerScans(unittest.TestCase):
         garbage = "<!-- code-gauntlet-findings: {" * 5000
         try:
             result = find_marker(garbage)
-        except Exception as exc:  # pragma: no cover - this is the failure path
+        except Exception as exc:  # noqa: BLE001  # pragma: no cover
             self.fail(f"raised {exc!r} on a garbage-heavy body")
         self.assertIsNone(result)
 

--- a/tests/test_validate_ndjson.py
+++ b/tests/test_validate_ndjson.py
@@ -53,16 +53,14 @@ class TestValidateValidInput(unittest.TestCase):
         self.assertEqual(rc, 0)
 
     def test_whitespace_only_file_is_ok(self):
-        with _TmpFile(b"\n\n  \n") as path:
-            with patch("sys.stderr", new=io.StringIO()):
-                rc = validate(path)
+        with _TmpFile(b"\n\n  \n") as path, patch("sys.stderr", new=io.StringIO()):
+            rc = validate(path)
         self.assertEqual(rc, 0)
 
     def test_single_valid_finding(self):
         line = b'{"id":"bug-1","title":"X","description":"Y"}\n'
-        with _TmpFile(line) as path:
-            with patch("sys.stderr", new=io.StringIO()) as err:
-                rc = validate(path)
+        with _TmpFile(line) as path, patch("sys.stderr", new=io.StringIO()) as err:
+            rc = validate(path)
         self.assertEqual(rc, 0)
         self.assertIn("1 valid finding", err.getvalue())
 
@@ -72,9 +70,8 @@ class TestValidateValidInput(unittest.TestCase):
             b'{"id":"bug-2","title":"b"}\n'
             b'{"id":"bug-3","title":"c"}\n'
         )
-        with _TmpFile(content) as path:
-            with patch("sys.stderr", new=io.StringIO()) as err:
-                rc = validate(path)
+        with _TmpFile(content) as path, patch("sys.stderr", new=io.StringIO()) as err:
+            rc = validate(path)
         self.assertEqual(rc, 0)
         self.assertIn("3 valid finding", err.getvalue())
 
@@ -104,9 +101,8 @@ class TestValidateInvalidInput(unittest.TestCase):
         """The headline bug — agent embeds a raw \\n inside a JSON string,
         producing two physical lines neither of which parses."""
         content = b'{"id":"bug-1","description":"First sentence.\nSecond sentence."}\n'
-        with _TmpFile(content) as path:
-            with patch("sys.stderr", new=io.StringIO()) as err:
-                rc = validate(path)
+        with _TmpFile(content) as path, patch("sys.stderr", new=io.StringIO()) as err:
+            rc = validate(path)
         self.assertEqual(rc, 1)
         out = err.getvalue()
         self.assertIn("invalid line", out)
@@ -141,9 +137,8 @@ class TestValidateInvalidInput(unittest.TestCase):
             b'across lines"}\n'
             b'{"id":"bug-3"}\n'
         )
-        with _TmpFile(content) as path:
-            with patch("sys.stderr", new=io.StringIO()) as err:
-                rc = validate(path)
+        with _TmpFile(content) as path, patch("sys.stderr", new=io.StringIO()) as err:
+            rc = validate(path)
         self.assertEqual(rc, 1)
         out = err.getvalue()
         # 2 valid findings (lines 1 + 4); 2 invalid lines (the split halves on 2 + 3).
@@ -152,18 +147,16 @@ class TestValidateInvalidInput(unittest.TestCase):
 
     def test_invalid_line_diagnostic_includes_line_number(self):
         content = b'{"id":"bug-1"}\nthis is not json at all\n'
-        with _TmpFile(content) as path:
-            with patch("sys.stderr", new=io.StringIO()) as err:
-                rc = validate(path)
+        with _TmpFile(content) as path, patch("sys.stderr", new=io.StringIO()) as err:
+            rc = validate(path)
         self.assertEqual(rc, 1)
         self.assertIn("line 2", err.getvalue())
 
     def test_invalid_line_diagnostic_truncates_long_snippet(self):
         long_payload = b"x" * 500
         content = b'{"id":"bug-1","description":"' + long_payload + b'\nbroken"}\n'
-        with _TmpFile(content) as path:
-            with patch("sys.stderr", new=io.StringIO()) as err:
-                rc = validate(path)
+        with _TmpFile(content) as path, patch("sys.stderr", new=io.StringIO()) as err:
+            rc = validate(path)
         self.assertEqual(rc, 1)
         # Snippet truncation prevents stderr from being flooded by a single
         # giant invalid line.
@@ -183,9 +176,8 @@ class TestMainEntrypoint(unittest.TestCase):
         self.assertEqual(rc, 2)
 
     def test_main_dispatches_to_validate(self):
-        with _TmpFile(b'{"ok":true}\n') as path:
-            with patch("sys.stderr", new=io.StringIO()):
-                rc = main(["validate_ndjson.py", path])
+        with _TmpFile(b'{"ok":true}\n') as path, patch("sys.stderr", new=io.StringIO()):
+            rc = main(["validate_ndjson.py", path])
         self.assertEqual(rc, 0)
 
 

--- a/tests/test_verify_findings.py
+++ b/tests/test_verify_findings.py
@@ -1433,8 +1433,12 @@ class TestReceipt(unittest.TestCase):
             findings_path = f.name
         with tempfile.NamedTemporaryFile("w", suffix=".patch", delete=False) as f:
             empty_diff = f.name  # empty diff -> parse_diff_lines returns set()
-        legacy_out = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
-        receipt_out = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
+        with (
+            tempfile.NamedTemporaryFile(suffix=".json", delete=False) as legacy_file,
+            tempfile.NamedTemporaryFile(suffix=".json", delete=False) as receipt_file,
+        ):
+            legacy_out = legacy_file.name
+            receipt_out = receipt_file.name
         try:
             # Legacy positional path (the baseline the receipt must reproduce).
             self._run_main(
@@ -1555,7 +1559,8 @@ class TestReceipt(unittest.TestCase):
                 json.dumps({"findings": self._findings(), "base_branch": "main"}) + "}"
             )
             corrupt_path = f.name
-        out_path = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out_file:
+            out_path = out_file.name
         try:
             with (
                 patch("sys.stderr", new_callable=io.StringIO),
@@ -1921,7 +1926,8 @@ class TestReceiptDeltaEchoEndToEnd(unittest.TestCase):
         findings = self._findings()
         in_path = self._write_input(findings)
         empty_diff = self._empty_diff()
-        out_path = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out_file:
+            out_path = out_file.name
         try:
             proc = subprocess.run(
                 [
@@ -1974,7 +1980,8 @@ class TestReceiptDeltaEchoEndToEnd(unittest.TestCase):
         findings = self._findings()
         in_path = self._write_input(findings)
         empty_diff = self._empty_diff()
-        out_path = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out_file:
+            out_path = out_file.name
         try:
             proc = subprocess.run(
                 [
@@ -2015,7 +2022,8 @@ class TestReceiptDeltaEchoEndToEnd(unittest.TestCase):
         findings = self._findings()
         in_path = self._write_input(findings)
         empty_diff = self._empty_diff()
-        out_path = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out_file:
+            out_path = out_file.name
         unrelated_cwd = tempfile.mkdtemp()
         try:
             proc = subprocess.run(
@@ -2064,7 +2072,8 @@ class TestReceiptDeltaEchoEndToEnd(unittest.TestCase):
         findings[0]["severity"] = 3.14  # JS-unspellable; no downgrade will overwrite it
         in_path = self._write_input(findings)
         empty_diff = self._empty_diff()
-        out_path = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out_file:
+            out_path = out_file.name
         try:
             proc = subprocess.run(
                 [
@@ -2242,7 +2251,8 @@ class TestReceiptStringLineNumbers(unittest.TestCase):
             in_path = f.name
         with tempfile.NamedTemporaryFile("w", suffix=".patch", delete=False) as f:
             empty_diff = f.name
-        out_path = tempfile.NamedTemporaryFile(suffix=".json", delete=False).name
+        with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as out_file:
+            out_path = out_file.name
         try:
             self._run_main(
                 [

--- a/tests/test_workflows_dead_exports.py
+++ b/tests/test_workflows_dead_exports.py
@@ -60,7 +60,9 @@ def _opens_regex(code_tail: str) -> bool:
     if code_tail[-1] in _REGEX_PRECEDERS:
         return True
     word = _TRAILING_WORD.search(code_tail)
-    return bool(word) and word.group(1) in _REGEX_KEYWORDS
+    if word is None:
+        return False
+    return word.group(1) in _REGEX_KEYWORDS
 
 
 def strip_comments_and_strings(text: str) -> str:


### PR DESCRIPTION
## Summary
- Part B of #104: hand-fix remaining ruff/mypy findings, register pinned `ruff` 0.16.1 + `mypy` 2.3.0 hooks, document local commands in CONTRIBUTING, and add `.git-blame-ignore-revs` naming the **#128 squash SHA** (`1864baf`).
- Completes the two-PR split from the [#104 design addendum](https://github.com/liatrio-labs/claude-code-gauntlet/issues/104#issuecomment-5172603407): mechanical churn was PR-A; hand authorship stays attributable here.
- Hooks register only now that the tree is clean under the locked config.

## Test plan
- [x] `ruff check` / `ruff format --check` / `mypy` clean
- [x] `pre-commit run --all-files` green (includes new hooks)
- [x] `pytest tests/` + `pytest bench/tests/` + node workflow tests + bundle freshness
- [x] Parity fixtures as committed
- [x] `.git-blame-ignore-revs` contains only `1864baf336b57d4c27e5c7ab981c0832b66a93c9`
- [ ] CI green

Closes #104.


Made with [Cursor](https://cursor.com)