### PR TITLE
ci: gate workflows JS on checksum-pinned Biome lint (#105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,40 @@ jobs:
           COVERAGE_FILE="$(mktemp -d)/.coverage" python -m pytest tests/ -q \
             --cov=scripts --cov=.github --cov-fail-under=91.7
 
+  js-lint:
+    name: Run Workflow JS Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Download and verify Biome
+        env:
+          # Biome pin is manual — Dependabot cannot see a raw binary URL.
+          # To bump: identify the new release asset id, then:
+          #   gh api repos/biomejs/biome/releases/assets/<id> --jq .digest
+          # Update BIOME_VERSION, URL, and BIOME_SHA256 together. Do not add
+          # package.json / lockfile to get auto-bumps; that reopens #105.
+          BIOME_VERSION: "2.5.6"
+          BIOME_SHA256: "3cc9a0c3fa26ac26a89e8a3b203c010c9ae88e36f69a2679e79981f267ce9d57"
+        run: |
+          set -euo pipefail
+          url="https://github.com/biomejs/biome/releases/download/@biomejs/biome@${BIOME_VERSION}/biome-linux-x64"
+          out="${RUNNER_TEMP}/biome"
+          curl -fsSL "$url" -o "$out"
+          echo "${BIOME_SHA256}  ${out}" | sha256sum -c -
+          chmod +x "$out"
+          echo "BIOME=${out}" >> "$GITHUB_ENV"
+
+      # cwd is workflows/ because --config-path from the repo root trips Biome 2.5.6's nested-root-configuration detection.
+      - name: Lint workflows JS
+        working-directory: workflows
+        run: |
+          set -euo pipefail
+          "${BIOME}" check --error-on-warnings .
+
   workflow-tests:
     name: Run Workflow JS Tests
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,9 @@ takes coordinated edits across N files, fix the shape rather than documenting th
 
 - No `package.json`, lockfile, or `node_modules` is tracked in the repository.
 - The shipped pipeline runtime (`workflows/src`, `workflows/pipeline.js`) has zero
-  npm dependencies — Node builtins and language globals only.
+  dependencies — language globals plus the host-injected `agent`/`parallel`/
+  `pipeline`/`args` only. No import survives into the bundle (`build.js` strips
+  import lines); see `workflows/AGENTS.md` for the sandbox surface.
 - Pinned static binaries in CI are permitted (e.g. Biome for the `js-lint` job).
   Bumps are manual and deliberate; do not add a package manifest to get Dependabot
   coverage for those pins.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,17 @@ wrong — change the shape.
 **Extending should cost one edit.** A new dimension, field, or agent belongs in one place. If it
 takes coordinated edits across N files, fix the shape rather than documenting the ritual.
 
+## Tooling boundary (no npm in the tree)
+
+- No `package.json`, lockfile, or `node_modules` is tracked in the repository.
+- The shipped pipeline runtime (`workflows/src`, `workflows/pipeline.js`) has zero
+  npm dependencies — Node builtins and language globals only.
+- Pinned static binaries in CI are permitted (e.g. Biome for the `js-lint` job).
+  Bumps are manual and deliberate; do not add a package manifest to get Dependabot
+  coverage for those pins.
+- This does not forbid npm on the CI runner (`validate.yml` already installs the
+  Claude Code CLI globally).
+
 ## Scripts
 
 - **stdlib-only Python.** No pip dependencies in shipped `scripts/` runtime —

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -80,7 +80,7 @@ CODEX_CAP_BYTES = 32_768
 # 3.12 CI reading of 92.69, per the floor policy in the same paragraph) — a floor whose
 # stated provenance no longer matches its value is exactly the unverifiable claim the
 # repo's own rules prohibit.
-AGENTS_SET_BUDGET_BYTES = 17_513
+AGENTS_SET_BUDGET_BYTES = 18_916
 CLAUDE_MD_MAX_BYTES = 856
 
 # Root CLAUDE.md is a pointer, not a document. The line cap is a shape bound and keeps its
@@ -397,6 +397,7 @@ class TestClaimsResolve(unittest.TestCase):
         "TextDecoder",
         "package.json",
         "node_modules",
+        "noControlCharactersInRegex",  # Biome rule id in deferred-rules table
     }
 
     def repo_files(self):

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -80,6 +80,8 @@ CODEX_CAP_BYTES = 32_768
 # 3.12 CI reading of 92.69, per the floor policy in the same paragraph) — a floor whose
 # stated provenance no longer matches its value is exactly the unverifiable claim the
 # repo's own rules prohibit.
+# Raised 17_513 -> 18_916 (2026-08-04, #105): workflows/AGENTS.md JS lint
+# section (Biome pin, formatter-off rationale) and deferred-rules table.
 AGENTS_SET_BUDGET_BYTES = 18_916
 CLAUDE_MD_MAX_BYTES = 856
 

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -82,7 +82,9 @@ CODEX_CAP_BYTES = 32_768
 # repo's own rules prohibit.
 # Raised 17_513 -> 18_916 (2026-08-04, #105): workflows/AGENTS.md JS lint
 # section (Biome pin, formatter-off rationale) and deferred-rules table.
-AGENTS_SET_BUDGET_BYTES = 18_916
+# Raised 18_916 -> 19_079 (2026-08-04, #105): reword tooling-boundary bullet —
+# shipped runtime is language globals + host-injected args only, not Node builtins.
+AGENTS_SET_BUDGET_BYTES = 19_079
 CLAUDE_MD_MAX_BYTES = 856
 
 # Root CLAUDE.md is a pointer, not a document. The line cap is a shape bound and keeps its

--- a/tests/test_contribution_surface.py
+++ b/tests/test_contribution_surface.py
@@ -925,6 +925,7 @@ REQUIRED_PR_CHECK_CONTEXTS = (
     "Run Tests (3.10)",
     "Run Tests (3.11)",
     "Run Tests (3.12)",
+    "Run Workflow JS Lint",
     "Run Workflow JS Tests",
     "Run Bench Self-Tests (3.11)",
     "Run Bench Self-Tests (3.12)",

--- a/workflows/AGENTS.md
+++ b/workflows/AGENTS.md
@@ -17,6 +17,26 @@ The v3 review pipeline. `pipeline.js` is invoked by the skill through the `Workf
 - **No wall-clock.** Timestamps arrive through the args waist (`generatedAt`); environment values
   are read by the skill and passed in `policy`.
 
+## JS lint (CI)
+
+CI job `js-lint` runs Biome 2.5.6 against this directory via `workflows/biome.json`
+(lint-only). Formatter is **off**: default `lineWidth: 80` would wrap long
+`import … from` lines and break `build.js`'s single-line import `strip()` regex,
+failing `tests/test_bundle_fresh.py`. `noRestrictedGlobals` applies to `src/`
+only; `test/**` and `build.js` override it (they legitimately use `process` /
+`console`).
+
+Deferred rules (measured 2026-07-30, HEAD `ebf399d`) — hit counts are why they
+stay off so a later re-evaluation need not re-derive them:
+
+| Rule | Hits | Why deferred |
+| --- | --- | --- |
+| `useOptionalChain` | 51 | Style churn; no reliability delta |
+| `noUnusedFunctionParameters` | 55 | Dominated by positional mock callback params in tests |
+| `noAssignInExpressions` | 7 | Six are intentional `args.js` pattern |
+| `noControlCharactersInRegex` | 2 | Intentional U+0000/U+001F sanitization in `args.js` |
+| `organizeImports` | 24 | Assist/format-adjacent; out of scope with formatter off |
+
 ## The bundle
 
 - `pipeline.js` is **generated** — never hand-edit it. Source is `src/*.js`, which may use ESM

--- a/workflows/CLAUDE.md
+++ b/workflows/CLAUDE.md
@@ -21,6 +21,26 @@ The v3 review pipeline. `pipeline.js` is invoked by the skill through the `Workf
 - **No wall-clock.** Timestamps arrive through the args waist (`generatedAt`); environment values
   are read by the skill and passed in `policy`.
 
+## JS lint (CI)
+
+CI job `js-lint` runs Biome 2.5.6 against this directory via `workflows/biome.json`
+(lint-only). Formatter is **off**: default `lineWidth: 80` would wrap long
+`import … from` lines and break `build.js`'s single-line import `strip()` regex,
+failing `tests/test_bundle_fresh.py`. `noRestrictedGlobals` applies to `src/`
+only; `test/**` and `build.js` override it (they legitimately use `process` /
+`console`).
+
+Deferred rules (measured 2026-07-30, HEAD `ebf399d`) — hit counts are why they
+stay off so a later re-evaluation need not re-derive them:
+
+| Rule | Hits | Why deferred |
+| --- | --- | --- |
+| `useOptionalChain` | 51 | Style churn; no reliability delta |
+| `noUnusedFunctionParameters` | 55 | Dominated by positional mock callback params in tests |
+| `noAssignInExpressions` | 7 | Six are intentional `args.js` pattern |
+| `noControlCharactersInRegex` | 2 | Intentional U+0000/U+001F sanitization in `args.js` |
+| `organizeImports` | 24 | Assist/format-adjacent; out of scope with formatter off |
+
 ## The bundle
 
 - `pipeline.js` is **generated** — never hand-edit it. Source is `src/*.js`, which may use ESM

--- a/workflows/biome.json
+++ b/workflows/biome.json
@@ -1,0 +1,67 @@
+{
+  "root": true,
+  "formatter": {
+    "enabled": false
+  },
+  "assist": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": false,
+      "correctness": {
+        "noUnusedVariables": "error",
+        "noUndeclaredVariables": "error"
+      },
+      "complexity": {
+        "noUselessCatch": "error"
+      },
+      "suspicious": {
+        "noPrototypeBuiltins": "error"
+      },
+      "style": {
+        "noRestrictedGlobals": {
+          "level": "error",
+          "options": {
+            "deniedGlobals": {
+              "structuredClone": "Sandbox-absent; use deepClone. See workflows/AGENTS.md.",
+              "Buffer": "Sandbox-absent. See workflows/AGENTS.md.",
+              "TextEncoder": "Sandbox-absent. See workflows/AGENTS.md.",
+              "TextDecoder": "Sandbox-absent. See workflows/AGENTS.md.",
+              "URL": "Sandbox-absent. See workflows/AGENTS.md.",
+              "setTimeout": "Sandbox-absent. See workflows/AGENTS.md.",
+              "setInterval": "Sandbox-absent. See workflows/AGENTS.md.",
+              "clearTimeout": "Sandbox-absent. See workflows/AGENTS.md.",
+              "queueMicrotask": "Sandbox-absent. See workflows/AGENTS.md.",
+              "process": "Sandbox-absent. See workflows/AGENTS.md.",
+              "console": "Sandbox-absent. See workflows/AGENTS.md."
+            }
+          }
+        }
+      }
+    }
+  },
+  "javascript": {
+    "globals": ["args", "agent", "parallel", "pipeline"]
+  },
+  "files": {
+    "includes": [
+      "**/*.js",
+      "!pipeline.js",
+      "!src/pipeline_entry.js"
+    ]
+  },
+  "overrides": [
+    {
+      "includes": ["test/**", "build.js"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noRestrictedGlobals": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -1129,7 +1129,7 @@ function tryParseJsonAt(text, start) {
         const candidate = text.slice(start, i + 1);
         try {
           return JSON.parse(candidate);
-        } catch (e) {
+        } catch {
           return null;
         }
       }
@@ -2124,7 +2124,7 @@ function unwrapWaist(raw) {
     if (isPlainObject(value)) return { waist: value, terminal: value };
     if (typeof value !== 'string' || depth === MAX_JSON_UNWRAP) break;
     let next;
-    try { next = JSON.parse(value); } catch (e) { break; }
+    try { next = JSON.parse(value); } catch { break; }
     value = next;
   }
   return { waist: null, terminal: value };
@@ -2703,7 +2703,7 @@ async function summarize(ctx, input) {
     });
     if (!result) return { summary: '', gaps: ['summarize failed'] };
     return { summary: result.summary || '', gaps: [] };
-  } catch (e) {
+  } catch {
     return { summary: '', gaps: ['summarize failed'] };
   }
 }
@@ -4148,7 +4148,7 @@ function unwrapWrappedReport(s) {
   let parsed;
   try {
     parsed = JSON.parse(trimmed);
-  } catch (e) {
+  } catch {
     return s; // not JSON at all — ordinary markdown that happens to start with a brace
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return s;

--- a/workflows/src/args.js
+++ b/workflows/src/args.js
@@ -235,7 +235,7 @@ function unwrapWaist(raw) {
     if (isPlainObject(value)) return { waist: value, terminal: value };
     if (typeof value !== 'string' || depth === MAX_JSON_UNWRAP) break;
     let next;
-    try { next = JSON.parse(value); } catch (e) { break; }
+    try { next = JSON.parse(value); } catch { break; }
     value = next;
   }
   return { waist: null, terminal: value };

--- a/workflows/src/mergeFindings.js
+++ b/workflows/src/mergeFindings.js
@@ -128,7 +128,7 @@ function tryParseJsonAt(text, start) {
         const candidate = text.slice(start, i + 1);
         try {
           return JSON.parse(candidate);
-        } catch (e) {
+        } catch {
           return null;
         }
       }

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -228,7 +228,7 @@ export async function summarize(ctx, input) {
     });
     if (!result) return { summary: '', gaps: ['summarize failed'] };
     return { summary: result.summary || '', gaps: [] };
-  } catch (e) {
+  } catch {
     return { summary: '', gaps: ['summarize failed'] };
   }
 }
@@ -1673,7 +1673,7 @@ function unwrapWrappedReport(s) {
   let parsed;
   try {
     parsed = JSON.parse(trimmed);
-  } catch (e) {
+  } catch {
     return s; // not JSON at all — ordinary markdown that happens to start with a brace
   }
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return s;

--- a/workflows/test/parity.test.js
+++ b/workflows/test/parity.test.js
@@ -238,6 +238,6 @@ for (const c of loadCases('verify_deltas')) {
     // (3) The #25 requirement-1 withholding constraint, pinned on the golden path: no
     // finding joinVerifyDeltas emits may carry `agent`, even though the script's own
     // output (and the dispatched finding, in the extras-survive fixture) may have one.
-    for (const f of joined) assert.ok(!Object.prototype.hasOwnProperty.call(f, 'agent'));
+    for (const f of joined) assert.ok(!Object.hasOwn(f, 'agent'));
   });
 }


### PR DESCRIPTION
## Summary

- Add CI-only Biome 2.5.6 `js-lint` job (`Run Workflow JS Lint`) with SHA-256-pinned `biome-linux-x64` binary in `$RUNNER_TEMP` — no `package.json`, lockfile, or `node_modules`.
- Add `workflows/biome.json` (lint-only, formatter off, explicit ON rules including sandbox `noRestrictedGlobals`) and restate the no-npm / CI-binary boundary in root `AGENTS.md`; deferred-rule hit counts live in `workflows/AGENTS.md`.
- Clean unused catch bindings (`catch {}`) and one `Object.hasOwn` site so the gate is green; freeze the new check name in `REQUIRED_PR_CHECK_CONTEXTS`.

Closes #105 (Wave 2 of #101). Owner decision: option (ii) / Approach 1.

### Invocation note

CI and local verification use `working-directory: workflows` + `biome check --error-on-warnings .`. Biome 2.5.6 rejects `--config-path=workflows` from the repo root (nested-root detection). Comment in `ci.yml` records why.

### Mutation proof (req 7)

During implementation: added a `structuredClone` reference under `workflows/src/`, observed `noRestrictedGlobals` failure, reverted. Not retained as a standing CI self-test.

### Catch bindings / req 8

Live HEAD had four unused `catch (e)` sites (plus one `noPrototypeBuiltins` in tests), all fixed. On Biome 2.5.6, `noUnusedVariables` **does** flag unused catch bindings — they are gate-enforced, not fixed-but-unenforced.

## Owner follow-up (after this PR’s CI shows the new check, or right after merge)

- [ ] Add required status-check context `Run Workflow JS Lint` to ruleset `protect-default-branch` (id 16049246). Do **not** add it before the job exists on a run — open PRs would block on a check that never reports.

## Test plan

- [x] `(cd workflows && biome check --error-on-warnings .)` — 30 files, 0 parse errors, exit 0
- [x] `node workflows/build.js && git diff --exit-code workflows/pipeline.js`
- [x] JS tests with coverage floors + presence check
- [x] `python -m pytest tests/ -q` and `python -m pytest bench/tests/ -q`
- [x] `pre-commit run --all-files`
- [x] No npm artifacts in tree
- [ ] CI job `Run Workflow JS Lint` green on this PR
- [ ] Owner ruleset click (checkbox above)


Made with [Cursor](https://cursor.com)