### PR TITLE
ci: harden Actions supply chain (SHA pins, Dependabot, zizmor)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -12,7 +12,7 @@
 #
 # Runner prerequisites (bench/run.py's prereq check fails fast with a fix
 # message if any of these are missing):
-#   - `claude` CLI on PATH — installed below via the official install script.
+#   - `claude` CLI on PATH — installed below via pinned npm.
 #   - `gh` CLI authenticated — satisfied via GH_TOKEN using the default
 #     GITHUB_TOKEN (no extra secret needed).
 #   - `uv` on PATH — installed below via astral-sh/setup-uv, used to run the
@@ -63,8 +63,9 @@ jobs:
 
       - name: Install Claude Code CLI
         run: |
-          curl -fsSL https://claude.ai/install.sh | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          npm install -g @anthropic-ai/claude-code@2.1.221
+          echo "$(npm prefix -g)/bin" >> "$GITHUB_PATH"
+          claude --version
 
       - name: Write bench/.env
         env:

--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -34,6 +34,10 @@ name: Bench Smoke (live)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   smoke:
     name: Run Smoke-Tier Benchmark
@@ -45,15 +49,17 @@ jobs:
       actions: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
 
       - name: Install Claude Code CLI
         run: |
@@ -68,7 +74,7 @@ jobs:
 
       - name: Restore bare mirrors
         id: mirrors-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: bench/workspace/mirrors
           # v2: invalidate any v1 entries that may have been saved mid-failure.
@@ -101,14 +107,14 @@ jobs:
           always()
           && steps.mirrors-cache.outputs.cache-hit != 'true'
           && steps.smoke-run.outcome == 'success'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: bench/workspace/mirrors
           key: bench-mirrors-${{ runner.os }}-${{ hashFiles('bench/golden/shas.json') }}-v2
 
       - name: Upload run artifacts
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: bench-smoke-runs
           path: bench/workspace/runs/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run Linting
@@ -14,10 +17,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -48,10 +53,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -82,7 +89,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Download and verify Biome
         env:
@@ -116,10 +125,12 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           # Exact patch: coverage percentages move across Node builds; 24.18.0 is
           # the sandboxed runtime / reference build this repo develops against.
@@ -154,10 +165,12 @@ jobs:
         python-version: ["3.11", "3.12"]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install pytest + coverage (gate leg)
         if: matrix.python-version == '3.12'
         run: |
-          pip install "pip>=25.1"
+          pip install pip==26.2
           pip install --group dev
 
       - name: Run pytest with coverage gate
@@ -185,7 +185,7 @@ jobs:
       - name: Install pytest + coverage (gate leg)
         if: matrix.python-version == '3.12'
         run: |
-          pip install "pip>=25.1"
+          pip install pip==26.2
           pip install --group dev
 
       - name: Run bench self-tests with coverage gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install pre-commit
-        run: pip install pre-commit
+        run: pip install pre-commit==4.6.1
 
       - name: Run pre-commit hooks
         run: pre-commit run --all-files

--- a/.github/workflows/labels-verify.yml
+++ b/.github/workflows/labels-verify.yml
@@ -23,10 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  pull-requests: write
+  statuses: write
+
 jobs:
   lint-pr-title:
     runs-on: ubuntu-latest
@@ -11,7 +15,7 @@ jobs:
       pull-requests: write
       statuses: write
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         id: lint_pr_title
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,7 +39,7 @@ jobs:
             didn't match the configured pattern. Please ensure that the subject
             doesn't start with an uppercase character.
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: always() && (steps.lint_pr_title.outputs.error_message != null)
         with:
           header: pr-title-lint-error
@@ -60,7 +64,7 @@ jobs:
 
             Please update your PR title and the check will run automatically.
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ steps.lint_pr_title.outputs.error_message == null }}
         with:
           header: pr-title-lint-error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install python-semantic-release
-        run: pip install "python-semantic-release>=10.0.0,<11.0.0"
+        run: pip install python-semantic-release==10.6.1
 
       - name: Semantic Release
         id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
       group: semantic-release-${{ github.ref }}
       cancel-in-progress: false
     steps:
-      - uses: octo-sts/action@v1.1.1
+      - uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
         id: octo-sts
         with:
           scope: ${{ github.repository }}
           identity: main-semantic-release
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -53,7 +53,7 @@ jobs:
             "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Claude Code
-        run: npm install -g @anthropic-ai/claude-code
+        run: npm install -g @anthropic-ai/claude-code@2.1.221
 
       - name: Validate plugin manifest
         run: claude plugin validate .

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,9 @@ jobs:
     name: Validate plugin.json
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,15 @@
+# Require hash pins for every uses: (explicit; also zizmor 1.28 default).
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "*": hash-pin
+  # adhoc-packages: intentional CI-runner installs pinned to exact versions
+  # in workflow YAML (no package.json/lockfile by design — see AGENTS.md
+  # tooling boundary). Ignore only these exact package installation lines.
+  adhoc-packages:
+    ignore:
+      # The benchmark smoke job installs the exactly pinned Claude Code CLI.
+      - bench-smoke.yml:66
+      # The validation job installs the exactly pinned Claude Code CLI.
+      - validate.yml:21

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,6 +83,15 @@ repos:
         files: ^(CLAUDE\.md|AGENTS\.md|[^/]+/(AGENTS|CLAUDE)\.md|scripts/sync_agent_rules\.py)$
         pass_filenames: false
 
+      - id: zizmor
+        name: audit GitHub Actions workflows with zizmor
+        entry: zizmor
+        language: python
+        additional_dependencies: ["zizmor==1.28.0"]
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+        args: [".github/workflows"]
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.1
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,9 @@ pre-commit run ruff-check --all-files
 pre-commit run ruff-format --all-files
 pre-commit run mypy --all-files
 
+# Audit GitHub Actions workflows
+pre-commit run zizmor --all-files
+
 # Optional: ignore mass mechanical reflows in git blame
 git config blame.ignoreRevsFile .git-blame-ignore-revs
 
@@ -164,6 +167,7 @@ This will:
 - Fix Markdown formatting issues
 - Spell-check public-facing documentation
 - Scan for committed secrets
+- Audit GitHub Actions workflows for unsafe configuration, including non-hash-pinned actions
 - Validate the commit message format (on commit)
 
 Live bench smoke and paired measurements are **not** contributor gates — see

--- a/bench/MEASUREMENT.md
+++ b/bench/MEASUREMENT.md
@@ -142,6 +142,13 @@ but an interrupted/partial populate cannot freeze a broken set under that key.
 Several GB per upstream; a cache hit avoids cold clones; a miss remains
 correct but slower. GitHub evicts caches after 7 days of no access.
 
+Claude Code CLI is installed in that workflow via a pinned
+`npm install -g @anthropic-ai/claude-code@<version>` (same pin as
+`validate.yml`). Revisit the pin when preparing each smoke checkpoint
+(Smoke A / Smoke B / later) and record the CLI version alongside the
+smoke result in the ledger — Dependabot does not see `run:` package
+installs.
+
 ## Named mini subset
 
 Registered as `"mini"` in [`golden/subsets.json`](golden/subsets.json) — the


### PR DESCRIPTION
## Summary
- Closes #106: SHA-pin every `uses:` (checkout/setup-python → v6), `persist-credentials: false`, top-level `permissions:` on ci/bench-smoke/pr-title-lint, exact package pins, smoke CLI via pinned npm, Dependabot `github-actions` weekly group, zizmor hash-pin gate in pre-commit.
- actionlint omitted per requirement 13 escape hatch (recorded on the issue).
- Evidence-correction comment posted on #106 for refreshed counts.

## Test plan
- [x] `pre-commit run --all-files` (incl. zizmor exit 0)
- [x] Mutation: tag pin → zizmor red → restored
- [x] `python -m pytest tests/ -q`
- [x] `python -m pytest bench/tests/ -q`
- [x] `node --test workflows/test/*.test.js`
- [x] `node workflows/build.js && git diff --exit-code workflows/pipeline.js`
- [ ] Owner: Dependabot security updates enabled in Settings (req 14)
- [ ] Post-merge: first push to main cuts a release (req 16)


Made with [Cursor](https://cursor.com)