### PR TITLE
ci: publish OpenSSF Scorecard after supply-chain hardening

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,39 @@
+# OpenSSF Scorecard — signal only, never a required status check (#107).
+name: Scorecard
+
+on:
+  schedule:
+    - cron: "17 5 * * 1"
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,6 +34,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3.37.6
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -2,8 +2,14 @@
 
 [![CI](https://github.com/liatrio-labs/claude-code-gauntlet/actions/workflows/ci.yml/badge.svg)](https://github.com/liatrio-labs/claude-code-gauntlet/actions/workflows/ci.yml)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/liatrio-labs/claude-code-gauntlet/badge)](https://securityscorecards.dev/viewer/?uri=github.com/liatrio-labs/claude-code-gauntlet)
 
 Adversarial multi-agent code review for [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Your PR runs a gauntlet: parallel concern-specialized reviewers find issues, then every finding must survive deterministic verification, skeptical validation, and a blind challenge before it reaches you. *Formerly published as **deep-review**.*
+
+> **Scorecard note:** Branch-Protection and Code-Review score low by design.
+> Required approving reviews stay at 0 because a single maintainer cannot
+> self-approve, and an always-bypass Integration actor (Octo STS) lets
+> semantic-release push from CI. Raising either into a “fix” deadlocks merges.
 
 ## How it reviews
 

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -56,6 +56,7 @@ overrides:
       - dedup
       - GitOps
       - newlines
+      - Octo
       - reranking
 
   - filename: CONTRIBUTING.md


### PR DESCRIPTION
## Summary
- Closes #107 (after #106): Scorecard on weekly cron + push to `main`, SARIF to code scanning, `publish_results: true`, README badge with Branch-Protection **and** Code-Review low-by-design note.
- Not added to required status checks; `tests/test_contribution_surface.py` still green.

## Test plan
- [x] `pre-commit run --all-files` (zizmor includes new workflow)
- [x] `python -m pytest tests/test_contribution_surface.py -q`
- [x] Full suites green
- [ ] Post-merge: first Scorecard run green; SARIF in Security tab; badge resolves


Made with [Cursor](https://cursor.com)