### PR TITLE
test: strengthen overstated claim tests (#109)

### DIFF
--- a/tests/test_materialize_artifacts.py
+++ b/tests/test_materialize_artifacts.py
@@ -27,6 +27,7 @@ Contract under test:
     delivered under another's name.
 """
 
+import io
 import json
 import os
 import shutil
@@ -34,12 +35,13 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, REPO_ROOT)
 
 from scripts.assemble_artifacts import plan_checksum  # noqa: E402
-from scripts.materialize_artifacts import materialize  # noqa: E402
+from scripts.materialize_artifacts import main, materialize  # noqa: E402
 
 SCRIPT = os.path.join(REPO_ROOT, "scripts", "materialize_artifacts.py")
 RECORDER = os.path.join(REPO_ROOT, "workflows", "test", "tools", "emit_task_output.mjs")
@@ -180,6 +182,47 @@ class TestHappyPath(MaterializeTestCase):
         for path, text in first.items():
             self.assertEqual(self.read(path), text)
 
+    def test_materialize_happy_path_returns_a_success_receipt(self):
+        # Direct materialize() on a pristine recorder task takes the success path.
+        # The one-line-receipt guarantee for *unexpected* exceptions lives in main()
+        # (see test_main_unexpected_exception_still_prints_one_line_receipt) — not
+        # here. materialize()'s "Never raises" docstring is false; that scripts/
+        # defect is filed separately under #109's req 8 (do not fix in this PR).
+        receipt = materialize(self.task, None, self.out_dir, environ={})
+        self.assertTrue(receipt["ok"], receipt)
+        self.assertEqual(receipt["channel"], "return")
+
+
+class TestMainUnexpectedFailure(unittest.TestCase):
+    def test_main_unexpected_exception_still_prints_one_line_receipt(self):
+        # main():469 converts an escape from materialize() into a serializable
+        # ok:false receipt. Patch select_source so materialize raises before any
+        # fixture work; do not use run_cli (cannot inject across a process boundary
+        # without touching scripts/).
+        out_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
+        buf = io.StringIO()
+        with patch(
+            "scripts.materialize_artifacts.select_source",
+            side_effect=RuntimeError("injected"),
+        ):
+            with patch("sys.stdout", buf):
+                code = main(
+                    ["--output-dir", out_dir, "--task", "/nonexistent"],
+                )
+        lines = [line for line in buf.getvalue().splitlines() if line.strip()]
+        self.assertEqual(len(lines), 1, buf.getvalue())
+        receipt = json.loads(lines[0])
+        self.assertFalse(receipt["ok"], receipt)
+        self.assertEqual(code, 1)
+        self.assertTrue(
+            any(
+                "materializer failed unexpectedly: RuntimeError: injected" in err
+                for err in receipt["errors"]
+            ),
+            receipt["errors"],
+        )
+
 
 class TestResolution(MaterializeTestCase):
     def test_the_nonce_alone_finds_the_run_when_no_task_id_is_in_hand(self):
@@ -318,13 +361,6 @@ class TestFailureModes(MaterializeTestCase):
         self.assertEqual(code, 1)
         self.assertEqual(receipt["materialized"], [])
         self.assertFalse(os.path.exists(self.artifact("findings")))
-
-    def test_an_unexpected_internal_failure_still_returns_a_receipt(self):
-        # materialize() is the one-line-receipt contract's inner half: main() catches,
-        # but the function itself must never raise into it with the job half done.
-        receipt = materialize(self.task, None, self.out_dir, environ={})
-        self.assertTrue(receipt["ok"], receipt)
-        self.assertEqual(receipt["channel"], "return")
 
 
 class TestOtherChannelsUntouched(MaterializeTestCase):

--- a/tests/test_materialize_artifacts.py
+++ b/tests/test_materialize_artifacts.py
@@ -202,14 +202,16 @@ class TestMainUnexpectedFailure(unittest.TestCase):
         out_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
         buf = io.StringIO()
-        with patch(
-            "scripts.materialize_artifacts.select_source",
-            side_effect=RuntimeError("injected"),
+        with (
+            patch(
+                "scripts.materialize_artifacts.select_source",
+                side_effect=RuntimeError("injected"),
+            ),
+            patch("sys.stdout", buf),
         ):
-            with patch("sys.stdout", buf):
-                code = main(
-                    ["--output-dir", out_dir, "--task", "/nonexistent"],
-                )
+            code = main(
+                ["--output-dir", out_dir, "--task", "/nonexistent"],
+            )
         lines = [line for line in buf.getvalue().splitlines() if line.strip()]
         self.assertEqual(len(lines), 1, buf.getvalue())
         receipt = json.loads(lines[0])

--- a/tests/test_post_review.py
+++ b/tests/test_post_review.py
@@ -1278,7 +1278,7 @@ class TestSkipWarningDiagnostics(unittest.TestCase):
         "scripts.post_review.post_json", return_value={"html_url": "http://example.com"}
     )
     @patch("scripts.post_review.warn")
-    def test_github_skip_no_diag_when_valid_lines_none(
+    def test_github_skip_empty_valid_lines_reports_an_empty_diag_list(
         self, mock_warn, _post, _tool, _sha
     ):
         from scripts.post_review import post_github
@@ -1289,16 +1289,46 @@ class TestSkipWarningDiagnostics(unittest.TestCase):
             "pr_number": 1,
             "findings": [{"file": "src/app.py", "line": 99, "title": "Bug"}],
         }
-        # valid_lines=None means validation was skipped, so is_line_valid returns True
-        # and the skip branch is never entered. An EMPTY mapping is the shape that
-        # reaches the skip branch: validation ran and found nothing for this line.
+        # Empty mapping: validation ran and found nothing for this line → skip + empty diag.
         post_github(data, {})
         mock_warn.assert_called_once()
         msg = mock_warn.call_args[0][0]
         self.assertIn("line not found in diff.", msg)
-        # With an empty mapping the valid-lines list is [] not None, so the diagnostic
-        # is present but empty.
         self.assertIn("Valid lines for this file: []", msg)
+
+    @patch(
+        "scripts.post_review.get_head_sha",
+        return_value="abc1234def5678abc1234def5678abc1234def56",
+    )
+    @patch("scripts.post_review.check_tool")
+    @patch(
+        "scripts.post_review.post_json", return_value={"html_url": "http://example.com"}
+    )
+    @patch("scripts.post_review.warn")
+    def test_github_skip_no_diag_when_valid_lines_none(
+        self, mock_warn, mock_post, _tool, _sha
+    ):
+        from scripts.post_review import post_github
+
+        data = {
+            "owner": "o",
+            "repo": "r",
+            "pr_number": 1,
+            "findings": [{"file": "src/app.py", "line": 99, "title": "Bug"}],
+        }
+        # valid_lines=None: validation skipped → is_line_valid returns True → finding posts.
+        post_github(data, None)
+        mock_post.assert_called_once()
+        payload = mock_post.call_args[0][1]
+        self.assertEqual(len(payload["comments"]), 1)
+        self.assertEqual(payload["comments"][0]["path"], "src/app.py")
+        self.assertEqual(payload["comments"][0]["line"], 99)
+        for call in mock_warn.call_args_list:
+            self.assertNotIn(
+                "Valid lines for this file:",
+                call[0][0],
+                "None must not emit a valid-lines diagnostic",
+            )
 
     @patch(
         "scripts.post_review.get_head_sha",

--- a/tests/test_verify_findings.py
+++ b/tests/test_verify_findings.py
@@ -593,9 +593,7 @@ class TestVerifyFactual(unittest.TestCase):
                 self.assertTrue(result)
                 self.assertTrue(finding["factual_verification"]["verified"])
 
-            git_grep_calls = [
-                c for c in captured if c["cmd"][:2] == ["git", "grep"]
-            ]
+            git_grep_calls = [c for c in captured if c["cmd"][:2] == ["git", "grep"]]
             self.assertEqual(
                 git_grep_calls,
                 [],

--- a/tests/test_verify_findings.py
+++ b/tests/test_verify_findings.py
@@ -570,14 +570,18 @@ class TestVerifyFactual(unittest.TestCase):
             os.unlink(tmppath)
 
     def test_symbol_in_code_at_lines_fast_path(self):
-        """A symbol present at the cited lines verifies cleanly."""
+        """Symbol present at cited lines must skip git grep for that symbol."""
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
             f.write("def calculate_total():\n    return 42\n")
             tmppath = f.name
         try:
-            with patch("scripts.verify_findings.run") as mock_run:
-                # grep returns a match for any symbol queried
-                mock_run.return_value = ("match.py:1:found\n", "", 0)
+            captured = []
+
+            def mock_run(cmd, check=False, timeout=None, cwd=None):
+                captured.append({"cmd": cmd, "cwd": cwd})
+                return ("match.py:1:found\n", "", 0)
+
+            with patch("scripts.verify_findings.run", side_effect=mock_run):
                 finding = {
                     "file": tmppath,
                     "line_start": 1,
@@ -588,6 +592,16 @@ class TestVerifyFactual(unittest.TestCase):
                 result = verify_factual(finding)
                 self.assertTrue(result)
                 self.assertTrue(finding["factual_verification"]["verified"])
+
+            git_grep_calls = [
+                c for c in captured if c["cmd"][:2] == ["git", "grep"]
+            ]
+            self.assertEqual(
+                git_grep_calls,
+                [],
+                "fast path must not invoke git grep when the symbol is already "
+                f"in the cited lines; got {git_grep_calls!r}",
+            )
         finally:
             os.unlink(tmppath)
 


### PR DESCRIPTION
## Summary

Closes #109 (Wave 2 of #101). This test-only PR makes each selected test name match its assertion and adds targeted regression coverage where the contract is worth pinning. There is zero `scripts/` diff versus `main`; the adjacent implementation/documentation defect is tracked in #141.

## Decisions (req 1)

| Test | Decision | What landed |
| --- | --- | --- |
| `test_materialize_happy_path_returns_a_success_receipt` (formerly `…internal_failure…`) | **Keep as reworded** | Honest happy-path name/comment; unexpected-exception handling is pinned separately at `main()` |
| `test_main_unexpected_exception_still_prints_one_line_receipt` | **Strengthen (new)** | In-process `select_source` raise must yield one-line `ok:false` receipt and exit 1 |
| `test_symbol_in_code_at_lines_fast_path` | **Strengthen** | Assert zero `git grep` calls when the symbol is already in cited lines |
| `test_github_skip_empty_valid_lines_reports_an_empty_diag_list` | **Keep behavior, honest rename** | Empty mapping means skip plus an empty valid-lines diagnostic |
| `test_github_skip_no_diag_when_valid_lines_none` | **Strengthen (new sibling)** | `None` means validation skipped, so the finding posts without a valid-lines diagnostic |

The GitLab skip diagnostic test is outside this GitHub-specific claim correction and remains unchanged.

Deferred deliberately: `_minimal_receipt_line` / the `main()` serialization fallback at `:484`; this PR does not half-cover that separate fallback.

## Mutation proofs (req 5–6)

### `main()` unexpected exception (`:469`)

Mutation: unwrap the `main()` try/except around `materialize(...)`, leaving `:484` intact.

**Red:**
```text
FAILED tests/test_materialize_artifacts.py::TestMainUnexpectedFailure::test_main_unexpected_exception_still_prints_one_line_receipt
E RuntimeError: injected
1 failed in 0.06s
```

**Green after revert:**
```text
tests/test_materialize_artifacts.py::TestMainUnexpectedFailure::test_main_unexpected_exception_still_prints_one_line_receipt PASSED
1 passed in 0.01s
```

### `verify_findings` cited-lines fast path (`:749`)

Mutation: delete `if symbol in code_at_lines: continue`.

**Red:**
```text
AssertionError: Lists differ: [{'cmd': ['git', 'grep', '-l', 'calculate_total'], ...}] != []
FAILED tests/test_verify_findings.py::TestVerifyFactual::test_symbol_in_code_at_lines_fast_path
1 failed in 0.05s
```

**Green after revert:**
```text
tests/test_verify_findings.py::TestVerifyFactual::test_symbol_in_code_at_lines_fast_path PASSED
1 passed in 0.03s
```

### `post_review` `valid_lines=None` (`:407`, `:458`)

Mutation: treat `None` like `{}` in both `is_line_valid` and `valid_lines_for_file`.

**Red:**
```text
E AssertionError: 0 != 1
FAILED tests/test_post_review.py::TestSkipWarningDiagnostics::test_github_skip_no_diag_when_valid_lines_none
1 failed in 0.04s
```

**Green after revert:**
```text
test_github_skip_no_diag_when_valid_lines_none PASSED
test_github_skip_empty_valid_lines_reports_an_empty_diag_list PASSED
2 passed in 0.02s
```

## `scripts/` follow-up (req 8)

Filed #141 (`area:scripts`): `materialize()` says it “Never raises,” but unexpected exceptions can escape to `main()`. The issue includes the empirical escape proof; this PR intentionally changes no production code.

## Verification (req 9)

- `python -m pytest tests/ -q` — **1120 passed, 428 subtests passed** (baseline: 1118 passed, 428 subtests)
- `python -m pytest bench/tests/ -q` — **529 passed, 22 subtests passed**
- `node --test workflows/test/*.test.js` — **608 passed, 0 failed**
- `node workflows/build.js && git diff --exit-code workflows/pipeline.js` — **passed; generated bundle unchanged**
- `pre-commit run --all-files` — **all 14 hooks passed**

Measurement tier: suites-only.

Made with [Cursor](https://cursor.com)