### PR TITLE
docs: pin delivery vs report finding vocabularies (#64)

### DIFF
--- a/skills/code-gauntlet/references/delivery-guide.md
+++ b/skills/code-gauntlet/references/delivery-guide.md
@@ -59,6 +59,12 @@ python3 {plugin_root}/scripts/post_review.py <findings_json_path>
 
 > `suggested_fix_code` below is caller-supplied only — no review-pipeline agent emits it and no dispatch schema declares it. `post_review.py` still renders it when present, for callers that construct their own post-review JSON.
 
+> `post_review.py` reads the **v2-aliased** field names (`body`, `line`, `end_line`).
+> The persist boundary adds these aliases alongside the canonical names
+> (`description`, `line_start`, `line_end`) — a union schema; existing keys are
+> never overwritten. Report markdown uses the canonical names — see
+> `report-format.md`.
+
 ```json
 {
     "review_body": "Executive summary comment with finding counts (post_review.py appends the footer)",
@@ -69,7 +75,7 @@ python3 {plugin_root}/scripts/post_review.py <findings_json_path>
             "end_line": 45,
             "severity": "critical|high|medium|low",
             "title": "Finding title",
-            "body": "Detailed description (note: delivery schema uses 'body', not 'description' — the orchestrator maps description→body when constructing delivery JSON)",
+            "body": "Detailed explanation and context",
             "suggestion": "prose fix advice (optional; renders as a **Suggested fix:** block)",
             "claude_md_rule": "the cited project rule (optional; renders as **Cited rule:**)",
             "spec_text": "the contradicted spec text (optional; renders as **Cited rule:** when there is no claude_md_rule)",
@@ -93,7 +99,7 @@ python3 {plugin_root}/scripts/post_review.py <findings_json_path>
   - `end_line` — optional; enables multi-line comments on GitHub
   - `severity` — emoji selected from: critical, high, medium, low
   - `title` — one-line finding summary
-  - `body` — explanation and context
+  - `body` — explanation and context (delivery alias of canonical `description`; see boundary note above)
   - `suggestion` — optional prose fix advice, rendered under a **Suggested fix:** heading. Carried on every finding the pipeline produces (canonical schema), so the delivery JSON should pass it straight through.
   - `claude_md_rule` / `spec_text` — optional; whichever is present renders as a single **Cited rule:** line, `claude_md_rule` winning when both are. These are how a convention or intent finding shows the reviewer the rule it is measured against.
   - `suggested_fix_code` — optional code block rendered as GitHub/GitLab suggestion; caller-supplied only, never populated by the review pipeline

--- a/skills/code-gauntlet/references/report-format.md
+++ b/skills/code-gauntlet/references/report-format.md
@@ -80,6 +80,9 @@ Per-dimension fields are optional and never nullable (a not-applicable value is 
 
 ## Full Report Template
 
+This template interpolates **canonical** finding fields (`description`, `line_start`, …).
+Delivery JSON and the Inline PR Comment Format below use the v2 aliases (`body`, `line`, …).
+
 ```markdown
 # Code Gauntlet: {title}
 

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -39,6 +39,20 @@ from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
 
+import sys
+
+sys.path.insert(0, str(REPO))
+
+from scripts.filter_findings import _FIELD_RENAMES  # noqa: E402
+
+DELIVERY_GUIDE = REPO / "skills/code-gauntlet/references/delivery-guide.md"
+
+# Key-form scans for the Example-workflow bash fence. Left-boundary on body so
+# 'review_body' does not false-positive; description requires a JSON/Python key
+# colon so the Bash( description="..." ) kwarg at the fence header stays green.
+_BODY_KEY = re.compile(r"(?<![a-zA-Z_])['\"]body['\"]\s*:")
+_DESCRIPTION_KEY = re.compile(r"['\"]description['\"]\s*:")
+
 # `origin` is the one canonical field NO agent emits — scripts/verify_findings.py stamps it
 # during blame classification. Every other declared canonical field must appear in every
 # discovery contract's output block. Adding a name here is a deliberate, reviewable act:
@@ -228,6 +242,45 @@ def claude_md_bullet(anchor):
             f"expected exactly one agents/AGENTS.md line containing {anchor!r}, found {len(lines)}"
         )
     return lines[0]
+
+
+def full_report_template_region(text: str) -> str:
+    """Bytes between ## Full Report Template and ## PR Comment Format.
+
+    Heading anchors — not fence-aware. The template fence self-terminates at the
+    first bare fence closer (evidence block), so a fence parse would vacuous-green
+    the alias-absent scan over most of the template.
+    """
+    start = re.search(r"^## Full Report Template\s*$", text, re.MULTILINE)
+    end = re.search(r"^## PR Comment Format\b", text, re.MULTILINE)
+    if start is None or end is None:
+        raise AssertionError(
+            "report-format.md must contain both '## Full Report Template' and "
+            f"'## PR Comment Format' headings — found start={start is not None}, "
+            f"end={end is not None}"
+        )
+    if end.start() <= start.start():
+        raise AssertionError(
+            "## PR Comment Format must appear after ## Full Report Template"
+        )
+    return text[start.end() : end.start()]
+
+
+def delivery_guide_json_object(text: str) -> dict:
+    """The exactly-one json fence in delivery-guide.md, parsed."""
+    blocks = _JSON_BLOCK.findall(text)
+    if len(blocks) != 1:
+        raise AssertionError(
+            "delivery-guide.md must contain exactly one json fence "
+            f"(the findings-schema example); found {len(blocks)}"
+        )
+    try:
+        return json.loads(blocks[0])
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"delivery-guide.md's json fence is not valid JSON ({exc}). "
+            "Never skip a parse failure — silent skip is how this guard stops guarding."
+        ) from exc
 
 
 class TestDimensionsRegistry(unittest.TestCase):
@@ -578,6 +631,101 @@ class TestReportFormatFieldTables(unittest.TestCase):
                 "now declares it — move it into the canonical or per-dimension "
                 "table and instruct it in the agent contracts",
             )
+
+
+class TestDeliveryVocabularySurfaces(unittest.TestCase):
+    """Pin report vs delivery field vocabulary to `_FIELD_RENAMES`.
+
+    `_FIELD_RENAMES` is underscore-private on `scripts.filter_findings`; this
+    import is deliberate — same pattern as other parity pins that reach private
+    script surfaces — so a rename-map change fails this guard for the right
+    reason instead of both docs drifting together away from code.
+
+    Report markdown uses the canonical name; delivery-guide examples document
+    the post_review *read* surface (aliases). The persisted findings.json is a
+    union that also carries canonical names — if deliberately changing the
+    delivery example to show the union, update this pin and the boundary
+    callout together.
+    """
+
+    def setUp(self):
+        self.assertIn(
+            "body",
+            _FIELD_RENAMES,
+            "_FIELD_RENAMES no longer maps 'body' — this guard has nowhere to "
+            "derive the alias pair from",
+        )
+        self.alias = "body"
+        self.canonical = _FIELD_RENAMES["body"]
+
+    def test_full_report_template_uses_canonical_not_alias(self):
+        region = full_report_template_region(REPORT_FORMAT.read_text(encoding="utf-8"))
+        canonical_token = f"{{finding.{self.canonical}}}"
+        alias_token = f"{{finding.{self.alias}}}"
+        self.assertIn(
+            canonical_token,
+            region,
+            f"Full Report Template must interpolate {canonical_token} "
+            f"(canonical name from _FIELD_RENAMES). Inline PR Comment Format is "
+            f"a different, legitimate alias surface — do not 'fix' it into this "
+            f"region.",
+        )
+        self.assertNotIn(
+            alias_token,
+            region,
+            f"Full Report Template must not interpolate {alias_token}; that "
+            f"alias belongs to the delivery / inline-comment read surface",
+        )
+
+    def test_delivery_guide_json_example_uses_alias_not_canonical(self):
+        obj = delivery_guide_json_object(
+            DELIVERY_GUIDE.read_text(encoding="utf-8")
+        )
+        finding = obj["findings"][0]
+        self.assertIn(
+            self.alias,
+            finding,
+            f"delivery-guide findings-schema example must include key "
+            f"{self.alias!r} (post_review read surface)",
+        )
+        self.assertNotIn(
+            self.canonical,
+            finding,
+            f"delivery-guide findings-schema example must not include key "
+            f"{self.canonical!r}. The example documents the read surface "
+            f"(aliases); the persisted union also carries canonical names — if "
+            f"deliberately changing the example to show the union, update this "
+            f"pin and the boundary callout together.",
+        )
+
+    def test_delivery_guide_bash_example_uses_alias_not_canonical(self):
+        text = DELIVERY_GUIDE.read_text(encoding="utf-8")
+        # Bound loosely to the Example workflow section so we do not scan the
+        # whole file's English prose; still structural key-form regexes inside.
+        match = re.search(
+            r"\*\*Example workflow:\*\*(.*?)(?=^\*\*Script behavior:\*\*)",
+            text,
+            re.DOTALL | re.MULTILINE,
+        )
+        self.assertIsNotNone(
+            match,
+            "delivery-guide.md is missing the Example workflow / Script "
+            "behavior anchors the loose bash scan needs",
+        )
+        region = match.group(1)
+        self.assertRegex(
+            region,
+            _BODY_KEY,
+            "Example workflow must assign a finding key 'body'/\"body\" "
+            "(alias read surface); regex uses a left boundary so 'review_body' "
+            "does not count",
+        )
+        self.assertIsNone(
+            _DESCRIPTION_KEY.search(region),
+            "Example workflow must not assign a finding key 'description' "
+            f"(canonical belongs to the report surface); matched "
+            f"{_DESCRIPTION_KEY.search(region)!r}",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -34,12 +34,11 @@ edit walks around (see CLAUDE.md, "Do not replace a structural property with a p
 import json
 import re
 import subprocess
+import sys
 import unittest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
-
-import sys
 
 sys.path.insert(0, str(REPO))
 
@@ -275,12 +274,15 @@ def delivery_guide_json_object(text: str) -> dict:
             f"(the findings-schema example); found {len(blocks)}"
         )
     try:
-        return json.loads(blocks[0])
+        obj = json.loads(blocks[0])
     except json.JSONDecodeError as exc:
         raise AssertionError(
             f"delivery-guide.md's json fence is not valid JSON ({exc}). "
             "Never skip a parse failure — silent skip is how this guard stops guarding."
         ) from exc
+    if not isinstance(obj, dict):
+        raise AssertionError("delivery-guide.md JSON fence must contain a JSON object.")
+    return obj
 
 
 class TestDimensionsRegistry(unittest.TestCase):
@@ -678,9 +680,7 @@ class TestDeliveryVocabularySurfaces(unittest.TestCase):
         )
 
     def test_delivery_guide_json_example_uses_alias_not_canonical(self):
-        obj = delivery_guide_json_object(
-            DELIVERY_GUIDE.read_text(encoding="utf-8")
-        )
+        obj = delivery_guide_json_object(DELIVERY_GUIDE.read_text(encoding="utf-8"))
         finding = obj["findings"][0]
         self.assertIn(
             self.alias,

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -681,7 +681,17 @@ class TestDeliveryVocabularySurfaces(unittest.TestCase):
 
     def test_delivery_guide_json_example_uses_alias_not_canonical(self):
         obj = delivery_guide_json_object(DELIVERY_GUIDE.read_text(encoding="utf-8"))
-        finding = obj["findings"][0]
+        self.assertIn(
+            "findings",
+            obj,
+            "delivery-guide findings-schema example must include a 'findings' array",
+        )
+        findings = obj["findings"]
+        self.assertTrue(
+            isinstance(findings, list) and findings,
+            "delivery-guide findings-schema example's 'findings' must be a non-empty array",
+        )
+        finding = findings[0]
         self.assertIn(
             self.alias,
             finding,


### PR DESCRIPTION
## Summary
- Frame report-facing canonical finding fields separately from delivery-facing alias fields, while keeping the delivery JSON example parseable.
- Pin the report template, delivery JSON, and delivery Bash example to the `body` → `description` pair from `_FIELD_RENAMES`.
- Make the delivery-guide JSON helper assert that its parsed fence is an object, satisfying the repository lint/type gate.

Closes #64

## Measurement
Suites-only per #101 per-PR rule; no escalation condition applies.

## Design notes
- The delivery guide documents the post-review read surface; persisted `findings.json` is the union of alias and canonical fields.
- The deliberate private `_FIELD_RENAMES` import makes rename-map changes fail this parity guard instead of allowing docs to drift together.
- The report-template check slices by the `Full Report Template` and `PR Comment Format` headings; it intentionally leaves the Inline PR Comment Format untouched.

## Mutation protocol
- [x] Flipped the full-report-template interpolation from canonical `description` to alias `body` and observed the guard fail.
- [x] Flipped the delivery JSON key from alias `body` to canonical `description` and observed the guard fail.
- [x] Flipped the delivery Bash key from alias `body` to canonical `description` and observed the guard fail.
- [x] Restored all three mutations and confirmed the suites pass.
- [x] Eyeballed the heading-anchor slice around `Full Report Template` and `PR Comment Format`.

## Test plan
- [x] `python -m pytest tests/ -q` — 1126 passed, 428 subtests passed
- [x] `python -m pytest bench/tests/ -q` — 529 passed, 22 subtests passed
- [x] `node --test workflows/test/*.test.js` — 608 passed
- [x] `node workflows/build.js && git diff --exit-code workflows/pipeline.js`
- [x] `pre-commit run --all-files`

## Follow-up
After merge, check off #64 on #101 Wave 2.

Made with [Cursor](https://cursor.com)