### PR TITLE
fix: give Cursor Cloud VMs a build-time toolchain mechanism via .cursor/environment.json (#98)

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "bash .cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Cursor Cloud Build install script (referenced from .cursor/environment.json).
+#
+# Fixes the two VM toolchain traps structurally instead of instructing agents
+# around them (issue #98):
+#   1. The VM's /exec-daemon/node (v22) shadows nvm's Node 24 on PATH, so JS
+#      work fails on confusing feature/syntax errors rather than a clear
+#      version mismatch.
+#   2. pip --user console scripts (pytest, pre-commit) land in ~/.local/bin,
+#      which is not on PATH by default.
+#
+# Runs at Build time on every Build, possibly over previously prepared disk
+# state, so every step must be idempotent. The Build captures disk state, so
+# PATH lines appended to the shell profiles persist into agent sessions.
+set -euo pipefail
+
+PROFILES=("$HOME/.bashrc" "$HOME/.profile")
+
+append_once() {
+  local line="$1" profile
+  for profile in "${PROFILES[@]}"; do
+    grep -qxF "$line" "$profile" 2>/dev/null || printf '%s\n' "$line" >>"$profile"
+  done
+}
+
+# Node 24 (CI pins major 24 in .github/workflows/ci.yml) ahead of /exec-daemon/node.
+export NVM_DIR="$HOME/.nvm"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # nvm.sh is not clean under `set -u`; relax around sourcing it.
+  set +u
+  . "$NVM_DIR/nvm.sh"
+  nvm install 24
+  nvm alias default 24
+  NODE_BIN="$(dirname "$(nvm which default)")"
+  set -u
+  append_once "export PATH=\"$NODE_BIN:\$PATH\""
+fi
+
+# pip --user console scripts (pytest, pre-commit) live in ~/.local/bin.
+append_once 'export PATH="$HOME/.local/bin:$PATH"'
+python3 -m pip install --user --quiet pytest pytest-cov coverage pre-commit
+
+# Fail the Build loudly if an agent shell would still resolve the wrong node.
+resolved="$(bash -ic 'node --version' 2>/dev/null || true)"
+case "$resolved" in
+  v24.*) echo "node on agent PATH: $resolved" ;;
+  *)
+    echo "ERROR: node on agent PATH is '$resolved', expected v24.x" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## What

Resolves the remaining #98 decision: the Cursor Cloud environment caveats deleted (not relocated) by #99 come back as a **mechanism, not prose** — a repo-level `.cursor/environment.json` whose Build-time install script (`.cursor/install.sh`):

- pins Node 24 (nvm install + default alias) and prepends its bin to `~/.bashrc` / `~/.profile`, so `/exec-daemon/node` (v22) no longer shadows it in agent shells
- prepends `~/.local/bin` to PATH and installs the `pip --user` tooling (pytest, pytest-cov, coverage, pre-commit)
- verifies via `bash -ic 'node --version'` and **fails the Build loudly** if an agent shell would still resolve a non-v24 node

Idempotent (append-once profile lines; nvm/pip re-runs are no-ops), per Cursor's install-script contract — it runs on every Build, possibly over prepared disk state. Repo-level `environment.json` is first in Cursor's environment resolution order, so this applies to every Cloud agent on this repo.

## Why this shape

- Options weighed on #98: leave deleted (A), `.cursor/rules` prose (B), maintainer doc (C). Cloud VMs are actively used on this repo, so A re-creates the trap each fresh session; B/C are instructions where a mechanism is available ("build the mechanism, not the instruction"). The Build script *removes* the trap and turns any regression into a hard Build failure instead of burned agent turns.
- No prose returns to `AGENTS.md`: it is a `PROJECT_RULE_FILENAMES` source, so anything there is injected into every review of this repo — the exact problem #98 named.
- `.cursor/` is outside the docs-registry allowlist scope (root md + `docs/`) and outside all coverage scopes; no allowlist or floor changes needed.

## Verification

Suites-only per the #101 per-PR rule (no live code path or machine-parsed string touched; nothing reaching discovery agents changed, so #98's recall-escalation clause is not met). Local: 1147 pytest passed, `pre-commit run --all-files` green, `bash -n` + JSON parse clean. The script's own runtime check happens on the next Cursor Cloud Build.

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HC4cXmMt3DkgBXo5Hgbogn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds Cursor Cloud dev-environment setup under `.cursor/`; no application, auth, or production runtime paths change.
> 
> **Overview**
> Replaces agent-facing prose about Cursor Cloud VM quirks with a **build-time mechanism**: `.cursor/environment.json` runs `.cursor/install.sh` on every Cloud Build.
> 
> The install script **prepends nvm’s Node 24** (aligned with CI’s major 24) ahead of `/exec-daemon/node` v22, **adds `~/.local/bin`** for `pip --user` tools, and **installs** pytest, pytest-cov, coverage, and pre-commit. Profile updates use idempotent append-once lines. The build **exits with an error** if an interactive agent shell would not resolve `node` as v24.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57ef113c8099ccfdd919cc38e364d286d34dc115. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->