### PR TITLE
fix(agents): conditional complete-read shared-context bullet (#123)

### DIFF
--- a/agents/bug-detector.md
+++ b/agents/bug-detector.md
@@ -231,7 +231,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/challenger.md
+++ b/agents/challenger.md
@@ -44,7 +44,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/change-summarizer.md
+++ b/agents/change-summarizer.md
@@ -39,7 +39,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -165,7 +165,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/conventions-and-intent.md
+++ b/agents/conventions-and-intent.md
@@ -223,7 +223,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/cross-file-impact.md
+++ b/agents/cross-file-impact.md
@@ -162,7 +162,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -206,7 +206,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/test-analyzer.md
+++ b/agents/test-analyzer.md
@@ -146,7 +146,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/type-design-analyzer.md
+++ b/agents/type-design-analyzer.md
@@ -168,7 +168,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/agents/validator.md
+++ b/agents/validator.md
@@ -60,7 +60,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/skills/code-gauntlet/references/complete-read-contract.md
+++ b/skills/code-gauntlet/references/complete-read-contract.md
@@ -53,7 +53,7 @@ A `Read` can return only PART of a file and tell you nothing about it. There is 
 truncation notice, and a partial result looks exactly like a complete file. One `Read`
 is never proof you have the whole file.
 
-- **The shared context file is mandatory reading in full.** When your dispatch prompt
+- **When your dispatch prompt names a shared context file, it is mandatory reading in full.** When your dispatch prompt
   lists the `Read` calls that cover it, make every one of them. When it instead states
   a line count, read until you reach that line. When it gives neither, keep issuing
   `Read` with `offset` set past the last line you received until a call returns no

--- a/tests/test_agent_contracts.py
+++ b/tests/test_agent_contracts.py
@@ -243,13 +243,16 @@ class TestCompleteReadContract(unittest.TestCase):
     def test_the_block_states_the_three_load_bearing_facts(self):
         # Requirement 2: the fix must not depend on the Read tool emitting a truncation
         # notice — none of the 7 profiled first-reads carried one. Assert the block says
-        # so explicitly, names the shared context file, and calls out the silent-failure
-        # consequence. Worded against the canonical source only; the byte-identity test
-        # above propagates it to all 10 copies.
+        # so explicitly, names the shared context file in conditional form, and calls out
+        # the silent-failure consequence. Worded against the canonical source only; the
+        # byte-identity test above propagates it to all 10 copies.
         block = _canonical_complete_read_block()
         self.assertIn("no", block.lower())
         self.assertIn("truncation notice", block)
-        self.assertIn("shared context file is mandatory reading in full", block)
+        self.assertIn(
+            "When your dispatch prompt names a shared context file, it is mandatory reading in full",
+            block,
+        )
         self.assertIn("silent failure", block)
         self.assertIn("offset", block)
 


### PR DESCRIPTION
## Summary
- Rewrites the complete-read contract's first bullet as a pure conditional so it is inert for the structurally blind challenger and unchanged in duty for the nine shared-context agents.
- Keeps one canonical block + byte-identity across all 10 copies; updates the wording pin in `TestCompleteReadContract`.

## Test plan
- [x] `python -m pytest tests/test_agent_contracts.py::TestCompleteReadContract -q`
- [x] Mutation: absolute bullet in canon alone → pin test red
- [x] Mutation: divergent challenger copy → byte-identity test red

Closes #123

Made with [Cursor](https://cursor.com)