### PR TITLE
refactor(workflows): remove dead resolvePolicy note field (#114)

### DIFF
--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -1848,14 +1848,16 @@ function resolvePolicy(agentType, opts = {}) {
   if (opts.subagentModelEnv) { // sourced from args.policy.subagentModel by the pipeline dispatch sites (see args.js)
     // The override maps through the same full-ID pin: a bare alias pins the plain full ID
     // (it can no longer inherit the session variant — intended; see headless-mode.md).
-    return { model: toModelId(opts.subagentModelEnv), note: 'CLAUDE_CODE_SUBAGENT_MODEL override — model policy bypassed' };
+    // Override provenance is carried structurally by the run envelope's
+    // resolvedPolicy.subagentModel (null = no override), not restated here.
+    return { model: toModelId(opts.subagentModelEnv) };
   }
   const dim = DIMENSIONS.find((d) => d.agentType === agentType);
   // Single benchmarked policy: discovery on sonnet with security-reviewer's opus
   // override, stage agents per STAGE_DEFAULTS. Alternate model modes (fable) are
   // roadmap work (issue #17 V3.2) and land behind their own paired measurement.
   const model = toModelId(dim?.modelOverride || STAGE_DEFAULTS[agentType.split(':').pop()] || 'sonnet');
-  return { model, note: '' };
+  return { model };
 }
 
 // --- args.js ---

--- a/workflows/src/registry.js
+++ b/workflows/src/registry.js
@@ -141,12 +141,14 @@ export function resolvePolicy(agentType, opts = {}) {
   if (opts.subagentModelEnv) { // sourced from args.policy.subagentModel by the pipeline dispatch sites (see args.js)
     // The override maps through the same full-ID pin: a bare alias pins the plain full ID
     // (it can no longer inherit the session variant — intended; see headless-mode.md).
-    return { model: toModelId(opts.subagentModelEnv), note: 'CLAUDE_CODE_SUBAGENT_MODEL override — model policy bypassed' };
+    // Override provenance is carried structurally by the run envelope's
+    // resolvedPolicy.subagentModel (null = no override), not restated here.
+    return { model: toModelId(opts.subagentModelEnv) };
   }
   const dim = DIMENSIONS.find((d) => d.agentType === agentType);
   // Single benchmarked policy: discovery on sonnet with security-reviewer's opus
   // override, stage agents per STAGE_DEFAULTS. Alternate model modes (fable) are
   // roadmap work (issue #17 V3.2) and land behind their own paired measurement.
   const model = toModelId(dim?.modelOverride || STAGE_DEFAULTS[agentType.split(':').pop()] || 'sonnet');
-  return { model, note: '' };
+  return { model };
 }

--- a/workflows/test/registry.test.js
+++ b/workflows/test/registry.test.js
@@ -19,10 +19,14 @@ test('challenger resolves sonnet — the single benchmarked policy; no mode flag
   // A stray legacy frontier flag in opts must be ignored, not resurrect an upgrade path.
   assert.equal(resolvePolicy('code-gauntlet:challenger', { frontier: true, frontierModelId: 'claude-fable-5' }).model, 'claude-sonnet-5');
 });
-test('CLAUDE_CODE_SUBAGENT_MODEL overrides everything and is flagged', () => {
+test('CLAUDE_CODE_SUBAGENT_MODEL overrides everything', () => {
   const r = resolvePolicy('code-gauntlet:bug-detector', { subagentModelEnv: 'claude-haiku-4-5' });
   assert.equal(r.model, 'claude-haiku-4-5');
-  assert.match(r.note, /CLAUDE_CODE_SUBAGENT_MODEL/);
+});
+test('resolvePolicy returns only { model } — provenance lives in resolvedPolicy.subagentModel (#114)', () => {
+  // Both branches: the env-override return and the policy-table return.
+  assert.deepEqual(Object.keys(resolvePolicy('code-gauntlet:bug-detector', { subagentModelEnv: 'claude-haiku-4-5' })), ['model']);
+  assert.deepEqual(Object.keys(resolvePolicy('code-gauntlet:bug-detector', {})), ['model']);
 });
 test('report-writer / artifact-writer suffixes bind to STAGE_DEFAULTS (not the bare "report" key)', () => {
   // The split(':').pop() suffix is the full 'report-writer'/'artifact-writer', so the


### PR DESCRIPTION
## Summary

Resolves the #114 decision: the `note` field is **removed** as dead return shape rather than surfaced.

**Why remove, not surface:** the run envelope already reports override provenance structurally — `resolvedPolicy.subagentModel` is `null` for no override and the pinned model ID when `CLAUDE_CODE_SUBAGENT_MODEL` bypassed policy. The `note` string restated that same fact as prose that no live consumer read (`modelFor` reads only `.model`). Per AGENTS.md, the mechanism (a structural field) beats the instruction (a prose flag), so the prose duplicate goes.

## Changes

- `workflows/src/registry.js`: both `resolvePolicy` return branches now return `{ model }` only, with a comment pointing at the structural provenance field.
- `workflows/test/registry.test.js`: dropped the field-only `note` assertion; added a return-shape test asserting both branches return exactly `['model']`, so the dead field cannot silently reappear. Mutation-verified: reintroducing `note` in either branch fails the suite.
- `workflows/pipeline.js`: regenerated via `node workflows/build.js`, byte-fresh.

## Testing

- JS coverage gate (98/82.3/97 + presence check): pass
- Python suite with `--cov-fail-under=91.7`: 92.48%, 1175 passed
- `pre-commit run --all-files`: pass

Closes #114 (from #37 residue audit R-017)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HC4cXmMt3DkgBXo5Hgbogn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-field removal with no change to model resolution; only `modelFor` consumed `.model` and provenance remains on the run envelope.
> 
> **Overview**
> **`resolvePolicy` now returns only `{ model }`** — the unused `note` string (including the `CLAUDE_CODE_SUBAGENT_MODEL` override message) is dropped from both the env-override and default policy branches in `workflows/src/registry.js`, with comments pointing override provenance at the run envelope’s structural `resolvedPolicy.subagentModel`.
> 
> Tests no longer assert on `note`; a new case locks the return shape to exactly `['model']` on both branches so the field cannot creep back. **`workflows/pipeline.js` is regenerated** from the source change via the build step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b58eb1020f27bc4cb92706361dff48dbf60e38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->