### PR TITLE
fix(scripts): make materialize() self-guarding so its never-raises contract is true (#141)

### DIFF
--- a/docs/duplication-register.md
+++ b/docs/duplication-register.md
@@ -40,7 +40,8 @@ reconcile to 116 pairs plus the eight tool-invisible relationships.
 
 ## Individually classified rows
 
-Thirty-six rows: 27 `intentional-and-documented`, 9 `intentional-but-undocumented`, 0 `accidental`.
+Thirty-seven rows: 28 `intentional-and-documented`, 9 `intentional-but-undocumented`, 0
+`accidental`.
 
 | Pair | Classification | Reason | Doc ref |
 | --- | --- | --- | --- |
@@ -80,6 +81,7 @@ Thirty-six rows: 27 `intentional-and-documented`, 9 `intentional-but-undocumente
 | `bench/report.html:32-52` ↔ `:54-74` | intentional-and-documented | Regenerated from `bench/report.py` in #110; its two dark-mode blocks now derive from `_DARK_VIZ_VARS`. | [#110](https://github.com/liatrio-labs/claude-code-gauntlet/issues/110) |
 | `workflows/src/stages.js:608-614` ↔ `:1275-1281` ↔ `:1439-1445` | intentional-but-undocumented | Declined in #110: only 2 of the ~6 lines are identical across the 8 sites; the remainder is per-stage extraction and defaults, and each parse is independently tested. Revisit only if a ninth stage or a change to the shared 2-line parse itself lands. | [#110](https://github.com/liatrio-labs/claude-code-gauntlet/issues/110) |
 | `tests/test_assemble_artifacts.py:503-513` ↔ `:1158-1168` | intentional-and-documented | Consolidated behind `assert_assemble_hard_failure` in #110. | [#110](https://github.com/liatrio-labs/claude-code-gauntlet/issues/110) |
+| `scripts/assemble_artifacts.py:658-676` (`assemble`) ↔ `scripts/materialize_artifacts.py:409-429` (`materialize`) | intentional-and-documented | The public wrapper whose only body is the last-resort guard over a private worker. Below the 60-token threshold, so jscpd missed it. Not shared: each side builds its own `_receipt` shape and names its own script in the error, and the guard belongs to whichever function promises the receipt. | `scripts/AGENTS.md:23-25` |
 
 ## Grouped patterns
 

--- a/scripts/materialize_artifacts.py
+++ b/scripts/materialize_artifacts.py
@@ -369,8 +369,8 @@ def _receipt(ok, source, scanned, materialized, assemble_receipt, gaps, errors):
     }
 
 
-def materialize(task, nonce, output_dir, environ=None):
-    """Do the whole job and return the receipt dict. Never raises."""
+def _materialize(task, nonce, output_dir, environ=None):
+    """Write what the run returned, derive the projections, return the receipt."""
     environ = os.environ if environ is None else environ
     errors = []
     gaps = []
@@ -404,6 +404,29 @@ def materialize(task, nonce, output_dir, environ=None):
         )
         return _receipt(False, source, scanned, materialized, receipt, gaps, errors)
     return _receipt(not gaps, source, scanned, materialized, receipt, gaps, errors)
+
+
+def materialize(task, nonce, output_dir, environ=None):
+    """_materialize, with a last-resort guard so the caller ALWAYS gets a receipt.
+
+    Same shape and same reason as assemble_artifacts.py's assemble(): the guard
+    belongs to the function that promises a receipt, not to one caller of it, so
+    every caller — main(), a test, a future importer — gets the promise. Every
+    expected failure is already a receipt above; this catches the unexpected one
+    and still reports it honestly as ok:false.
+    """
+    try:
+        return _materialize(task, nonce, output_dir, environ)
+    except Exception as exc:  # noqa: BLE001 - the one-line-receipt contract
+        return _receipt(
+            False,
+            None,
+            0,
+            [],
+            None,
+            [],
+            [f"materializer failed unexpectedly: {type(exc).__name__}: {exc}"],
+        )
 
 
 def _minimal_receipt_line(exc):
@@ -464,18 +487,7 @@ def main(argv=None, environ=None):
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
     if not args.task and not args.nonce:
         parser.error("give --task, --nonce, or both — there is nothing to resolve")
-    try:
-        receipt = materialize(args.task, args.nonce, args.output_dir, environ)
-    except Exception as exc:  # noqa: BLE001 - the one-line-receipt contract
-        receipt = _receipt(
-            False,
-            None,
-            0,
-            [],
-            None,
-            [],
-            [f"materializer failed unexpectedly: {type(exc).__name__}: {exc}"],
-        )
+    receipt = materialize(args.task, args.nonce, args.output_dir, environ)
     try:
         line = escape_lone_surrogates(
             json.dumps(receipt, ensure_ascii=False, allow_nan=False)

--- a/tests/test_materialize_artifacts.py
+++ b/tests/test_materialize_artifacts.py
@@ -188,56 +188,55 @@ class TestHappyPath(MaterializeTestCase):
         self.assertTrue(receipt["ok"], receipt)
         self.assertEqual(receipt["channel"], "return")
 
+
+# What the last-resort guard returns, whole: main()'s stdout line is this dict
+# serialized, so a field left unasserted is a stdout line that can change silently.
+UNEXPECTED_RECEIPT = {
+    "ok": False,
+    "channel": "return",
+    "source": None,
+    "scanned": 0,
+    "materialized": [],
+    "assemble": None,
+    "gaps": [],
+    "errors": ["materializer failed unexpectedly: RuntimeError: injected"],
+}
+
+
+class TestUnexpectedFailure(unittest.TestCase):
+    """The guard at both ends: materialize() builds the receipt for every caller,
+    main() prints it."""
+
+    def setUp(self):
+        self.out_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.out_dir, ignore_errors=True)
+
+    def raising_source(self):
+        # Raise inside the first call materialize() makes, before any fixture work;
+        # run_cli cannot inject across a process boundary without touching scripts/.
+        return patch(
+            "scripts.materialize_artifacts.select_source",
+            side_effect=RuntimeError("injected"),
+        )
+
     def test_materialize_converts_an_unexpected_exception_into_a_receipt(self):
         # materialize() promises a receipt to EVERY caller, not just to main(), so
         # the guard is asserted where it lives. Without this, moving the guard back
         # into main() would leave the docstring's promise untested and false again.
-        with patch(
-            "scripts.materialize_artifacts.select_source",
-            side_effect=RuntimeError("injected"),
-        ):
-            receipt = materialize(self.task, None, self.out_dir, environ={})
-        self.assertFalse(receipt["ok"], receipt)
-        self.assertTrue(
-            any(
-                "materializer failed unexpectedly: RuntimeError: injected" in err
-                for err in receipt["errors"]
-            ),
-            receipt["errors"],
-        )
+        with self.raising_source():
+            receipt = materialize("/nonexistent", None, self.out_dir, environ={})
+        self.assertEqual(receipt, UNEXPECTED_RECEIPT)
 
-
-class TestMainUnexpectedFailure(unittest.TestCase):
     def test_main_unexpected_exception_still_prints_one_line_receipt(self):
-        # materialize()'s own guard is what converts an escape into a serializable
-        # ok:false receipt; main() prints it. Patch select_source so it raises before
-        # any fixture work; do not use run_cli (cannot inject across a process
-        # boundary without touching scripts/).
-        out_dir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
         buf = io.StringIO()
-        with (
-            patch(
-                "scripts.materialize_artifacts.select_source",
-                side_effect=RuntimeError("injected"),
-            ),
-            patch("sys.stdout", buf),
-        ):
+        with self.raising_source(), patch("sys.stdout", buf):
             code = main(
-                ["--output-dir", out_dir, "--task", "/nonexistent"],
+                ["--output-dir", self.out_dir, "--task", "/nonexistent"],
             )
         lines = [line for line in buf.getvalue().splitlines() if line.strip()]
         self.assertEqual(len(lines), 1, buf.getvalue())
-        receipt = json.loads(lines[0])
-        self.assertFalse(receipt["ok"], receipt)
+        self.assertEqual(json.loads(lines[0]), UNEXPECTED_RECEIPT)
         self.assertEqual(code, 1)
-        self.assertTrue(
-            any(
-                "materializer failed unexpectedly: RuntimeError: injected" in err
-                for err in receipt["errors"]
-            ),
-            receipt["errors"],
-        )
 
 
 class TestResolution(MaterializeTestCase):

--- a/tests/test_materialize_artifacts.py
+++ b/tests/test_materialize_artifacts.py
@@ -184,21 +184,35 @@ class TestHappyPath(MaterializeTestCase):
 
     def test_materialize_happy_path_returns_a_success_receipt(self):
         # Direct materialize() on a pristine recorder task takes the success path.
-        # The one-line-receipt guarantee for *unexpected* exceptions lives in main()
-        # (see test_main_unexpected_exception_still_prints_one_line_receipt) — not
-        # here. materialize()'s "Never raises" docstring is false; that scripts/
-        # defect is filed separately under #109's req 8 (do not fix in this PR).
         receipt = materialize(self.task, None, self.out_dir, environ={})
         self.assertTrue(receipt["ok"], receipt)
         self.assertEqual(receipt["channel"], "return")
 
+    def test_materialize_converts_an_unexpected_exception_into_a_receipt(self):
+        # materialize() promises a receipt to EVERY caller, not just to main(), so
+        # the guard is asserted where it lives. Without this, moving the guard back
+        # into main() would leave the docstring's promise untested and false again.
+        with patch(
+            "scripts.materialize_artifacts.select_source",
+            side_effect=RuntimeError("injected"),
+        ):
+            receipt = materialize(self.task, None, self.out_dir, environ={})
+        self.assertFalse(receipt["ok"], receipt)
+        self.assertTrue(
+            any(
+                "materializer failed unexpectedly: RuntimeError: injected" in err
+                for err in receipt["errors"]
+            ),
+            receipt["errors"],
+        )
+
 
 class TestMainUnexpectedFailure(unittest.TestCase):
     def test_main_unexpected_exception_still_prints_one_line_receipt(self):
-        # main():469 converts an escape from materialize() into a serializable
-        # ok:false receipt. Patch select_source so materialize raises before any
-        # fixture work; do not use run_cli (cannot inject across a process boundary
-        # without touching scripts/).
+        # materialize()'s own guard is what converts an escape into a serializable
+        # ok:false receipt; main() prints it. Patch select_source so it raises before
+        # any fixture work; do not use run_cli (cannot inject across a process
+        # boundary without touching scripts/).
         out_dir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
         buf = io.StringIO()


### PR DESCRIPTION
## Summary

`materialize()` in `scripts/materialize_artifacts.py` documented a never-raises contract in its
docstring but had no mechanism enforcing it. This PR makes the contract structurally true by
giving `materialize()` the same public-wrapper/private-worker shape already used by
`assemble_artifacts.py`'s `assemble()`.

## Design

- **Structure parity with `assemble_artifacts.py`.** `assemble()` already self-guards by wrapping
  a private `_assemble()` worker in a `try/except` at the public boundary. `materialize()` gets the
  identical shape: a thin public `materialize()` that calls a private `_materialize()` worker inside
  a `try/except`, converting any unexpected exception into the same structured failure result the
  docstring already promised. The mechanism the docstring claimed now exists.
- **Byte-identical CLI proof for the unexpected-failure path.** `main()`'s stdout and exit code for
  an unexpected failure were measured before and after the change and confirmed byte-identical —
  the fix changes only where the guard lives, not what callers observe.
- **Rejected alternatives:**
  - *Reword the docstring to admit callers must guard it themselves.* Rejected as prose over
    mechanism — the exact design smell AGENTS.md names ("Add more text" is a design smell; change
    the shape, not the words).
  - *Add a guard at each call site inside the four processing stages.* Rejected because there are
    four stages plus unguarded code running between them; a per-stage guard leaves gaps and the
    never-raises contract stays false for the code between stages.
- **Test-comment hygiene.** The stale `#109` deferral block and the outdated `main():469` comment
  both asserted mechanisms that no longer exist once the self-guard lands; both are removed/corrected
  so no comment describes a state the code has moved past.
- Closes #141.

## Mutation proofs

| mutation | expected red test | result |
| --- | --- | --- |
| remove the `try/except` wrapper around `_materialize()` in `materialize()` | `TestUnexpectedFailure` direct-call and `main()` stdout tests | red — uncaught exception propagates, receipt comparison fails |
| change the guard to catch a narrower exception type | `TestUnexpectedFailure` direct-call test (unexpected exception must still be caught) | red — exception escapes, test fails |
| alter any field in the unexpected-failure receipt (e.g. `ok`, error message shape) | `TestUnexpectedFailure` byte-identity comparison against `UNEXPECTED_RECEIPT` | red — receipt mismatch |

## Review

FIXED (commit `430cdde` on `fix/141-materialize-self-guard`, worktree `/private/tmp/claude-502/-Users-lee-personal-claude-deep-review/4c7da67a-a219-4ae0-98ed-72925883515c/scratchpad/wt/141`)

1. **should-fix — guard receipt was five-sevenths unasserted** (`tests/test_materialize_artifacts.py`). The two unexpected-failure tests now compare the WHOLE receipt against one module-level literal `UNEXPECTED_RECEIPT` — the exact byte-identity baseline the fix was measured against — instead of `ok` plus an error substring. Applied at both ends: the direct `materialize()` call and `main()`'s parsed stdout line, so the spec's HARD REQUIREMENT (main's stdout byte-identical to pre-fix) is now locked by a test rather than by a hand-run.
2. **nit — misleading class placement** (trivial, fixed): the new test was a member of `TestHappyPath` and inherited `MaterializeTestCase.setUp`, spawning the Node recorder for a fixture it never reads. Both unexpected-failure tests now live in `TestUnexpectedFailure` (renamed from `TestMainUnexpectedFailure`, which no external reference names) with a `tempfile.mkdtemp` setUp and a shared `raising_source()` patcher. The recorder subprocess is gone from that path.
3. **nit — missing duplication-register row** (trivial, fixed): `docs/duplication-register.md` gains a row for `scripts/assemble_artifacts.py:658-676` (`assemble`) ↔ `scripts/materialize_artifacts.py:409-429` (`materialize`), classified `intentional-and-documented` with doc ref `scripts/AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GdQDn1WVh7VX9hgAjHcMS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of error handling with byte-identical CLI behavior asserted by tests; no auth, data, or pipeline semantics changes.
> 
> **Overview**
> **`materialize()` now enforces its receipt contract at the public boundary**, matching `assemble_artifacts.py`: the former body lives in **`_materialize()`**, and **`materialize()`** wraps it in a last-resort `try/except` that turns unexpected failures into an `ok:false` receipt instead of raising. **`main()`** no longer catches around the worker—it just calls **`materialize()`**, so direct callers and the CLI share the same guarantee.
> 
> Tests lock the unexpected-failure shape with a shared **`UNEXPECTED_RECEIPT`** literal (full dict equality on both **`materialize()`** and **`main()`** stdout), moved into **`TestUnexpectedFailure`** without the happy-path recorder setup. **`docs/duplication-register.md`** documents the intentional **`assemble` ↔ `materialize`** wrapper duplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 430cddebb61123343423978b30b21cdef91cc1a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->