### PR TITLE
test(post-review): pin the plain glab mr diff contract with honest fixtures (#133)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,13 @@ repos:
       - id: check-toml
       - id: check-json
       - id: check-added-large-files
+      # tests/fixtures/glab_diff/*.diff record another tool's output byte for byte: a
+      # unified diff spells a blank context line as a lone space, and the final newline
+      # is part of the record. Both fixers would rewrite them silently.
       - id: end-of-file-fixer
+        exclude: "^tests/fixtures/glab_diff/.*\\.diff$"
       - id: trailing-whitespace
+        exclude: "^tests/fixtures/glab_diff/.*\\.diff$"
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.45.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,11 @@ repos:
       - id: check-toml
       - id: check-json
       - id: check-added-large-files
-      # tests/fixtures/glab_diff/*.diff record another tool's output byte for byte: a
-      # unified diff spells a blank context line as a lone space, and the final newline
-      # is part of the record. Both fixers would rewrite them silently.
+      # tests/fixtures/glab_diff/*.diff record another tool's output byte for byte.
+      # trailing-whitespace strips the lone space a unified diff spells a blank context
+      # line with; end-of-file-fixer is a no-op on the files as they stand and is
+      # excluded so a later capture's final newlines are not normalised either. What
+      # reports a loss is tests/test_post_review.py::TestGlabFixtureBytes.
       - id: end-of-file-fixer
         exclude: "^tests/fixtures/glab_diff/.*\\.diff$"
       - id: trailing-whitespace

--- a/scripts/post_review.py
+++ b/scripts/post_review.py
@@ -268,7 +268,13 @@ def parse_diff_lines(platform, owner, repo, pr_number):
             ["gh", "pr", "diff", str(pr_number), "--repo", f"{owner}/{repo}"]
         )
     elif platform == "gitlab":
-        # For GitLab, use glab mr diff
+        # PLAIN `glab mr diff` — never `--raw`. Plain output is glab's OWN reconstruction
+        # from the MR versions API: `--- <old_path>` / `+++ <new_path>` with the path
+        # verbatim, and nothing else between hunks. `--raw` streams git's diff instead,
+        # which reintroduces `a/` / `b/` prefixes and `/dev/null` — every signal read
+        # below (unprefixed keys, the `@@ -0,0` added-file test, the old-side path) is
+        # premised on their absence. tests/fixtures/glab_diff/ records the shape and
+        # where it comes from.
         stdout, stderr, rc = run_api(["glab", "mr", "diff", str(pr_number)])
     else:
         warn(
@@ -289,7 +295,9 @@ def parse_diff_lines(platform, owner, repo, pr_number):
     # paths VERBATIM and never writes a synthetic prefix, so a leading `a/` there is a
     # REAL top-level directory; stripping it truncated `a/`-rooted paths (`a/foo.py` ->
     # `foo.py`) into keys and positions GitLab does not know, and every finding in such
-    # a repo was rejected. The catch-all group carries `/dev/null` on both platforms.
+    # a repo was rejected. The catch-all group carries `/dev/null`, which only the GitHub
+    # shape ever writes — glab repeats the real path on both sides for an added or
+    # deleted file (tests/fixtures/glab_diff/ pins both shapes).
     if platform == "github":
         old_header_re = re.compile(r"^--- (?:a/)?(.+)$")
         new_header_re = re.compile(r"^\+\+\+ (?:b/)?(.+)$")

--- a/scripts/post_review.py
+++ b/scripts/post_review.py
@@ -271,10 +271,10 @@ def parse_diff_lines(platform, owner, repo, pr_number):
         # PLAIN `glab mr diff` — never `--raw`. Plain output is glab's OWN reconstruction
         # from the MR versions API: `--- <old_path>` / `+++ <new_path>` with the path
         # verbatim, and nothing else between hunks. `--raw` streams git's diff instead,
-        # which reintroduces `a/` / `b/` prefixes and `/dev/null` — every signal read
-        # below (unprefixed keys, the `@@ -0,0` added-file test, the old-side path) is
-        # premised on their absence. tests/fixtures/glab_diff/ records the shape and
-        # where it comes from.
+        # which reintroduces `a/` / `b/` prefixes and `/dev/null` — the gitlab branch
+        # below keys on paths exactly as printed and reads the old-side header as a real
+        # path, both premised on their absence. tests/fixtures/glab_diff/ records the
+        # shape and where it comes from.
         stdout, stderr, rc = run_api(["glab", "mr", "diff", str(pr_number)])
     else:
         warn(

--- a/tests/fixtures/glab_diff/README.md
+++ b/tests/fixtures/glab_diff/README.md
@@ -29,6 +29,15 @@ Everything the parser relies on follows from that:
   unlike the GitHub shape, where `+++ /dev/null` blanks it.
 - **A RENAMED file is the one case where the two headers differ**, and that `---` path is
   what `position.old_path` needs.
+- **Nothing separates two files.** glab writes the header pair and then the API's body,
+  and appends no separator of its own, so one file's last line runs straight into the
+  next file's `---` unless that body is newline-terminated. Git's patch text always is
+  (a file with no final newline still gets a `\ No newline at end of file` line), and
+  GitLab hands the body through, so it is — but this is the one property here **inferred
+  rather than sourced**, and it is the whole basis of the multi-file constants, which are
+  plain concatenations. `TestGlabFixtureBytes` asserts it on every fixture, so a fixture
+  that stops satisfying it cannot silently turn the concatenation into a shape no CLI
+  emits.
 
 `glab mr diff --raw` streams git's own diff instead and has none of these properties. The
 parser is written against the plain output, and `post_review.py` records that constraint
@@ -47,8 +56,12 @@ block quoted verbatim in the issue #127 report:
 
 Everything else here — those 16 body lines, and every byte of `modified.diff`,
 `deleted.diff` and `rename.diff` — is **constructed** to the shape described above, not
-captured from a run. The constructed files use plainly synthetic paths (`src/edited.py`,
-`src/removed.py`, `old_name.py` / `new_name.py`) so no reader mistakes one for a capture.
+captured from a run. Constructed material is kept plainly synthetic in-band, so no reader
+mistakes one line for a capture without consulting this file: synthetic paths
+(`src/edited.py`, `src/removed.py`, `old_name.py` / `new_name.py`) and synthetic content
+(`added_01`, `unchanged_ctx`, `alpha`). That matters most in `added.diff`, the one file
+where captured and constructed bytes sit together and a diff has no comment syntax to
+mark the seam.
 
 The shape itself is sourced, not inferred:
 
@@ -60,9 +73,11 @@ The shape itself is sourced, not inferred:
 
 **Upgrade path.** Anyone with a GitLab account can replace these files with a real
 `glab mr diff` capture from a throwaway MR covering the same four cases; that is a
-provenance upgrade, not a behaviour change. If the captured bytes disagree with what is
-here, the parser's contract is what moved, and these tests should be the first thing to
-say so.
+provenance upgrade, not a behaviour change. The first thing such a capture settles is the
+inferred property above — whether a file's body really is newline-terminated, i.e. whether
+a multi-file capture reads `+last--- next_path` or the two on separate lines. If the
+captured bytes disagree with what is here, the parser's contract is what moved, and these
+tests should be the first thing to say so.
 
 ## Why there is no binary fixture
 
@@ -78,10 +93,13 @@ same branch and no new failure mode.
 
 ## Byte-exactness
 
-`.pre-commit-config.yaml` excludes `*.diff` in this directory from `trailing-whitespace`
-and `end-of-file-fixer`. A unified diff renders a blank context line as a lone space
-(`rename.diff` has one), and a capture's final newline is part of the record; both hooks
-would rewrite the recorded bytes without anyone noticing.
+`tests/test_post_review.py::TestGlabFixtureBytes` asserts the two recorded properties the
+parser itself cannot see: a blank context line is a lone space (`rename.diff` has one, and
+`parse_diff_lines` yields the identical key whether it is a space or empty), and each file
+ends in exactly one newline (the file-to-file boundary above). `.pre-commit-config.yaml`
+excludes `*.diff` in this directory from `trailing-whitespace` and `end-of-file-fixer` so
+the hooks do not rewrite what those assertions defend — but the assertions, not the
+exclusion, are what report the loss.
 
 ## Files
 

--- a/tests/fixtures/glab_diff/README.md
+++ b/tests/fixtures/glab_diff/README.md
@@ -1,0 +1,97 @@
+# `glab mr diff` fixtures
+
+The output shape `scripts/post_review.py::parse_diff_lines` must read on GitLab. It is
+load-bearing — every inline MR comment's `position` is computed from it (issues #127
+and #130) — and it is **not** git's unified diff, which is how both defects got in.
+
+## The shape
+
+`glab mr diff` does not shell out to git. It reads the merge request's diff versions from
+the API (`GET /projects/:id/merge_requests/:iid/versions`, then the single-version
+endpoint) and prints, per file:
+
+```text
+--- <old_path>
++++ <new_path>
+<the API's diff body, which begins at @@>
+```
+
+Everything the parser relies on follows from that:
+
+- **No git decoration.** No `diff --git`, `index`, `similarity index`, `rename from` or
+  `rename to` lines exist. Between two hunks there is only the next file's `---`/`+++`
+  pair.
+- **Paths verbatim.** No synthetic `a/` / `b/` prefix, so a leading `a/` is a real
+  top-level directory and stripping it addresses a path GitLab does not have.
+- **No `/dev/null`.** An ADDED file repeats its path on both sides (GitLab reports
+  `old_path == new_path`), so `@@ -0,0 +N,M @@` is the only added-file signal. A DELETED
+  file repeats its path too, which means `current_file` stays live through its body —
+  unlike the GitHub shape, where `+++ /dev/null` blanks it.
+- **A RENAMED file is the one case where the two headers differ**, and that `---` path is
+  what `position.old_path` needs.
+
+`glab mr diff --raw` streams git's own diff instead and has none of these properties. The
+parser is written against the plain output, and `post_review.py` records that constraint
+at the invocation.
+
+## Provenance — what is captured and what is written
+
+**Real capture: three lines, and only three.** `added.diff` opens with the added-file
+block quoted verbatim in the issue #127 report:
+
+```text
+--- src/app/clients/api/__init__.py
++++ src/app/clients/api/__init__.py
+@@ -0,0 +1,16 @@
+```
+
+Everything else here — those 16 body lines, and every byte of `modified.diff`,
+`deleted.diff` and `rename.diff` — is **constructed** to the shape described above, not
+captured from a run. The constructed files use plainly synthetic paths (`src/edited.py`,
+`src/removed.py`, `old_name.py` / `new_name.py`) so no reader mistakes one for a capture.
+
+The shape itself is sourced, not inferred:
+
+- glab's printer, `internal/commands/mr/diff/diff.go` in `gitlab-org/cli`: it writes
+  `"--- " + OldPath`, `"+++ " + NewPath`, then the API's `Diff` body, and takes a wholly
+  separate code path under `--raw`;
+- the GitLab merge-request-versions API, which supplies the `old_path`, `new_path` and
+  `diff` fields glab prints.
+
+**Upgrade path.** Anyone with a GitLab account can replace these files with a real
+`glab mr diff` capture from a throwaway MR covering the same four cases; that is a
+provenance upgrade, not a behaviour change. If the captured bytes disagree with what is
+here, the parser's contract is what moved, and these tests should be the first thing to
+say so.
+
+## Why there is no binary fixture
+
+`glab mr diff` has no binary branch: it prints the two header lines and whatever body the
+API hands it, and for a binary blob that body carries no hunk. With no `@@` the parser
+never leaves its header zone, no hunk budget moves, and nothing can reach `valid_lines` —
+a GitLab binary test would assert the empty set with no mutation able to falsify it. The
+branch a binary file really does exercise is the between-hunk catch-all that keeps
+`Binary files … differ` prose out of `valid_lines`, and that prose is git's spelling,
+reaching the parser through `gh pr diff`; it is already owned by the github-platform test
+in `tests/test_post_review.py`. A `binary.diff` here would add a second assertion of the
+same branch and no new failure mode.
+
+## Byte-exactness
+
+`.pre-commit-config.yaml` excludes `*.diff` in this directory from `trailing-whitespace`
+and `end-of-file-fixer`. A unified diff renders a blank context line as a lone space
+(`rename.diff` has one), and a capture's final newline is part of the record; both hooks
+would rewrite the recorded bytes without anyone noticing.
+
+## Files
+
+| fixture | case | consumed by |
+| --- | --- | --- |
+| `modified.diff` | modified file: context, removal, addition | `GL_DIFF_CONTRACT`, `GL_DIFF_DELETED_THEN_MODIFIED` |
+| `added.diff` | added file, `@@ -0,0` as the only signal | `GL_DIFF_CONTRACT` |
+| `deleted.diff` | deleted file, path repeated on both sides | `GL_DIFF_DELETED_THEN_MODIFIED` |
+| `rename.diff` | renamed file, differing `---`/`+++` paths | `GL_DIFF_RENAME` |
+
+The multi-file constants concatenate fixtures in the order shown, which is what makes the
+"does this file's hunk budget drain before the next file's headers arrive?" cases
+assertable at all.

--- a/tests/fixtures/glab_diff/added.diff
+++ b/tests/fixtures/glab_diff/added.diff
@@ -1,19 +1,19 @@
 --- src/app/clients/api/__init__.py
 +++ src/app/clients/api/__init__.py
 @@ -0,0 +1,16 @@
-+"""HTTP client exports for the API package."""
++added_01
++added_02
 +
-+from .base import BaseClient
-+from .billing import BillingClient
-+from .identity import IdentityClient
-+
-+__all__ = [
-+    "BaseClient",
-+    "BillingClient",
-+    "IdentityClient",
-+]
-+
-+
-+def default_client(session):
-+    """Return the client every module in this package starts from."""
-+    return BaseClient(session)
++added_04
++added_05
++added_06
++added_07
++added_08
++added_09
++added_10
++added_11
++added_12
++added_13
++added_14
++added_15
++added_16

--- a/tests/fixtures/glab_diff/added.diff
+++ b/tests/fixtures/glab_diff/added.diff
@@ -1,0 +1,19 @@
+--- src/app/clients/api/__init__.py
++++ src/app/clients/api/__init__.py
+@@ -0,0 +1,16 @@
++"""HTTP client exports for the API package."""
++
++from .base import BaseClient
++from .billing import BillingClient
++from .identity import IdentityClient
++
++__all__ = [
++    "BaseClient",
++    "BillingClient",
++    "IdentityClient",
++]
++
++
++def default_client(session):
++    """Return the client every module in this package starts from."""
++    return BaseClient(session)

--- a/tests/fixtures/glab_diff/deleted.diff
+++ b/tests/fixtures/glab_diff/deleted.diff
@@ -1,0 +1,6 @@
+--- src/removed.py
++++ src/removed.py
+@@ -1,3 +0,0 @@
+-alpha
+-beta
+-gamma

--- a/tests/fixtures/glab_diff/modified.diff
+++ b/tests/fixtures/glab_diff/modified.diff
@@ -1,0 +1,7 @@
+--- src/edited.py
++++ src/edited.py
+@@ -50,3 +61,3 @@
+ unchanged_ctx
+-removed
++added
+ tail_ctx

--- a/tests/fixtures/glab_diff/rename.diff
+++ b/tests/fixtures/glab_diff/rename.diff
@@ -1,0 +1,8 @@
+--- old_name.py
++++ new_name.py
+@@ -3,4 +3,4 @@
+ ctx
+-x
++y
+ ctx2
+ 

--- a/tests/test_post_review.py
+++ b/tests/test_post_review.py
@@ -157,8 +157,8 @@ class TestParseDiffLinesPostReview(unittest.TestCase):
     @patch("scripts.post_review.run_api")
     def test_gitlab_dispatches_to_glab_mr_diff(self, mock_run):
         """platform='gitlab' must call glab mr diff."""
-        # glab-faithful: `glab mr diff` writes paths verbatim, with no `a/` / `b/`.
-        diff = "+++ bar.py\n@@ -5,1 +5,2 @@\n ctx\n+new_line\n"
+        # glab-faithful: an unconditional `---`/`+++` pair, paths verbatim, no `a/`/`b/`.
+        diff = "--- bar.py\n+++ bar.py\n@@ -5,1 +5,2 @@\n ctx\n+new_line\n"
         mock_run.return_value = (diff, "", 0)
         valid_lines, _, _ = parse_diff_lines("gitlab", "myorg", "myrepo", 7)
         self.assertIsNotNone(valid_lines)
@@ -454,7 +454,7 @@ class TestParseDiffLinesPostReview(unittest.TestCase):
         self.assertEqual([k for k in valid_lines if k[0] == "img.png"], [])
 
     @patch("scripts.post_review.run_api")
-    def test_pre_hunk_lines_are_not_admitted(self, mock_run):
+    def test_between_hunk_lines_are_not_admitted(self, mock_run):
         """Between-hunk lines are not commentable lines: the key set is EXACTLY the
         hunk bodies' addressable lines, with nothing admitted from around them.
 
@@ -1889,6 +1889,9 @@ GL_DIFF = (
 )
 
 
+_GLAB_FIXTURE_DIR = os.path.join(os.path.dirname(__file__), "fixtures", "glab_diff")
+
+
 def _glab_fixture(name):
     """Read one `glab mr diff` fixture verbatim.
 
@@ -1897,8 +1900,7 @@ def _glab_fixture(name):
     so the parser's contract has ONE spelling that a real capture can later replace
     without touching a test.
     """
-    path = os.path.join(os.path.dirname(__file__), "fixtures", "glab_diff", name)
-    with open(path, encoding="utf-8") as fh:
+    with open(os.path.join(_GLAB_FIXTURE_DIR, name), encoding="utf-8") as fh:
         return fh.read()
 
 
@@ -1919,6 +1921,64 @@ GL_DIFF_DELETED_THEN_MODIFIED = _glab_fixture("deleted.diff") + _glab_fixture(
 # new 3 = old 3 (context), new 4 = added, new 5 = old 5 (context), new 6 = old 6 (a BLANK
 # context line, which a unified diff spells as a lone space).
 GL_DIFF_RENAME = _glab_fixture("rename.diff")
+
+
+class TestGlabFixtureBytes(unittest.TestCase):
+    """The fixtures above are a RECORD, so their bytes are the contract — including the
+    bytes no parser assertion can see.
+
+    ``parse_diff_lines`` reads a blank context line (a lone space) and a stripped one
+    (empty) through the same catch-all and produces the identical key, so a whitespace
+    fixer could rewrite the record with every other test in this file still green. These
+    assertions are what make the `.pre-commit-config.yaml` exclusion enforceable rather
+    than advisory: drop the exclusion, or add any hook that normalises these files, and
+    the record's loss is reported here instead of going unnoticed.
+    """
+
+    def _fixtures(self):
+        names = sorted(n for n in os.listdir(_GLAB_FIXTURE_DIR) if n.endswith(".diff"))
+        self.assertTrue(names, "no fixture files to hold to their recorded bytes")
+        return [(n, _glab_fixture(n)) for n in names]
+
+    def test_a_blank_context_line_is_recorded_as_a_lone_space(self):
+        blanks = []
+        for name, text in self._fixtures():
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if line.strip():
+                    continue
+                self.assertEqual(
+                    line,
+                    " ",
+                    f"{name}:{lineno}: a unified diff spells a blank context line as a "
+                    "lone space; an empty line is a stripped record, not glab output",
+                )
+                blanks.append(f"{name}:{lineno}")
+        self.assertTrue(
+            blanks,
+            "no fixture carries a blank context line any more, so the assertion above "
+            "passes over nothing and defends nothing",
+        )
+
+    def test_every_fixture_ends_with_exactly_one_newline(self):
+        """glab appends no separator between two files: it writes the `---`/`+++` pair
+        and then the API's diff body, so one file's last line runs straight into the
+        next file's `---` unless that body is newline-terminated.
+
+        The multi-file constants above concatenate these files directly, which is real
+        output only under that property — the one part of the recorded shape that is
+        inferred rather than captured (see the fixture README). Asserting it here keeps
+        the concatenation from quietly becoming a shape no CLI emits.
+        """
+        for name, text in self._fixtures():
+            self.assertTrue(
+                text.endswith("\n"), f"{name}: file boundary needs a final newline"
+            )
+            self.assertFalse(
+                text.endswith("\n\n"),
+                f"{name}: a trailing blank line is not glab output — a blank context "
+                "line is a lone space and a blank added line is a bare `+`",
+            )
+
 
 # A glab diff for a repo with a REAL top-level `a/` directory. `glab mr diff` prints
 # paths verbatim, so `a/foo.py` here is a directory named `a` — not git's synthetic

--- a/tests/test_post_review.py
+++ b/tests/test_post_review.py
@@ -166,6 +166,12 @@ class TestParseDiffLinesPostReview(unittest.TestCase):
         self.assertEqual(call_args[0], "glab")
         self.assertEqual(call_args[1], "mr")
         self.assertEqual(call_args[2], "diff")
+        self.assertNotIn(
+            "--raw",
+            call_args,
+            "the parser reads glab's own reconstruction of the MR versions API; --raw "
+            "streams git's diff instead, reintroducing a/ b/ prefixes and /dev/null",
+        )
 
     @patch("scripts.post_review.run_api")
     def test_glab_no_prefix_headers_are_parsed(self, mock_run):
@@ -256,7 +262,7 @@ class TestParseDiffLinesPostReview(unittest.TestCase):
         precedes it must not be swept into new_files with it."""
         mock_run.return_value = (GL_DIFF_CONTRACT, "", 0)
         _, new_files, _ = parse_diff_lines("gitlab", "o", "r", 1)
-        self.assertEqual(new_files, {"src/added.py"})
+        self.assertEqual(new_files, {"src/app/clients/api/__init__.py"})
 
     @patch("scripts.post_review.run_api")
     def test_deleted_file_does_not_add_dev_null_to_valid_lines(self, mock_run):
@@ -335,6 +341,30 @@ class TestParseDiffLinesPostReview(unittest.TestCase):
         self.assertEqual(valid_lines[("next.py", 5)], 5)
         self.assertIsNone(valid_lines[("next.py", 6)])
         self.assertEqual([k for k in valid_lines if k[0] == "gone.py"], [])
+
+    @patch("scripts.post_review.run_api")
+    def test_gitlab_deleted_file_records_no_targets_of_its_own(self, mock_run):
+        """`glab mr diff` has no `+++ /dev/null`: a deletion repeats the path on BOTH
+        headers, so ``current_file`` stays LIVE through the deleted file's body.
+
+        On GitHub the new-side header blanks ``current_file``, and a mis-drained body can
+        only lose the NEXT file's lines. Here nothing blanks it, so the same fault also
+        writes keys onto a file that no longer exists — inline comments aimed at a
+        deleted path. Draining the old-side budget is the only thing that ends the body.
+        """
+        mock_run.return_value = (GL_DIFF_DELETED_THEN_MODIFIED, "", 0)
+        valid_lines, new_files, old_paths = parse_diff_lines("gitlab", "o", "r", 1)
+        self.assertEqual([k for k in valid_lines if k[0] == "src/removed.py"], [])
+        self.assertEqual(valid_lines[("src/edited.py", 61)], 50)
+        self.assertIsNone(valid_lines[("src/edited.py", 62)])
+        self.assertEqual(valid_lines[("src/edited.py", 63)], 52)
+        # `@@ -1,3 +0,0 @@` is a deletion: only an OLD-side start of 0 means added. The
+        # repeated path still yields an old_paths entry, harmlessly mapping to itself.
+        self.assertEqual(new_files, set())
+        self.assertEqual(
+            old_paths,
+            {"src/removed.py": "src/removed.py", "src/edited.py": "src/edited.py"},
+        )
 
     # -- hunk-body budget tracking (headers are body content too) -----------
 
@@ -425,18 +455,22 @@ class TestParseDiffLinesPostReview(unittest.TestCase):
 
     @patch("scripts.post_review.run_api")
     def test_pre_hunk_lines_are_not_admitted(self, mock_run):
-        """`diff --git` / `index` lines between files are not commentable lines.
+        """Between-hunk lines are not commentable lines: the key set is EXACTLY the
+        hunk bodies' addressable lines, with nothing admitted from around them.
 
-        They used to fall through to the context branch and be admitted under the
-        PREVIOUS file at its next new-side number.
+        In plain `glab mr diff` the only lines between two hunks are the next file's
+        `---`/`+++` pair — an under-drained hunk budget reads them as body content and
+        admits a phantom target on the file before. Git's own decoration (`diff --git`,
+        `index`, `Binary files … differ`) never appears in this output; it reaches the
+        parser through `gh pr diff`, and the github-platform binary-prose test above
+        owns that arm of the same catch-all.
         """
         mock_run.return_value = (GL_DIFF_CONTRACT, "", 0)
         valid_lines, _, _ = parse_diff_lines("gitlab", "o", "r", 1)
         self.assertEqual(
             sorted(valid_lines),
-            [
-                ("src/added.py", 1),
-                ("src/added.py", 2),
+            [("src/app/clients/api/__init__.py", n) for n in range(1, 17)]
+            + [
                 ("src/edited.py", 61),
                 ("src/edited.py", 62),
                 ("src/edited.py", 63),
@@ -476,12 +510,17 @@ class TestParseDiffLinesPostReview(unittest.TestCase):
     def test_old_side_counter_resets_between_files(self, mock_run):
         mock_run.return_value = (GL_DIFF_CONTRACT, "", 0)
         valid_lines, _, _ = parse_diff_lines("gitlab", "o", "r", 1)
-        self.assertIsNone(valid_lines[("src/added.py", 1)])
-        # The `diff --git` line introducing src/added.py sits between hunks; it used to
-        # be read as a context line and admitted as a phantom target on the file before.
+        self.assertIsNone(valid_lines[("src/app/clients/api/__init__.py", 1)])
+        # The added file's `---`/`+++` headers sit between hunks. If the modified file's
+        # budgets under-drain, the parser is still in its body zone when they arrive and
+        # reads them as content — admitting a phantom target on the file before.
         self.assertNotIn(("src/edited.py", 64), valid_lines)
         self.assertEqual(
-            {v for (fp, _), v in valid_lines.items() if fp == "src/added.py"},
+            {
+                v
+                for (fp, _), v in valid_lines.items()
+                if fp == "src/app/clients/api/__init__.py"
+            },
             {None},
             "an added file's lines must carry no old-side leftovers from the file before",
         )
@@ -507,13 +546,16 @@ class TestParseDiffLinesPostReview(unittest.TestCase):
         The parser previously read the old-side header only to compare it to
         ``/dev/null`` and threw the path away, so a renamed file's position shipped the
         post-rename path as ``old_path`` — a path that does not exist on the old side
-        (#130). The `rename from`/`rename to`/`similarity index` lines sit in the header
-        zone and must stay no-ops.
+        (#130). A rename is the ONE case where glab's two headers name different paths;
+        it emits no `rename from`/`rename to`/`similarity index` lines to corroborate
+        them.
         """
         mock_run.return_value = (GL_DIFF_RENAME, "", 0)
         valid_lines, _, old_paths = parse_diff_lines("gitlab", "o", "r", 1)
         self.assertEqual(old_paths, {"new_name.py": "old_name.py"})
         self.assertEqual(valid_lines[("new_name.py", 3)], 3)
+        # A BLANK context line is a lone space, and is addressable like any other.
+        self.assertEqual(valid_lines[("new_name.py", 6)], 6)
 
     @patch("scripts.post_review.run_api")
     def test_added_file_absent_from_old_paths(self, mock_run):
@@ -1833,8 +1875,10 @@ GH_DIFF = (
 )
 
 # A GitLab diff (glab mr diff) that makes bar.py lines 1 and 2 valid. The `---`/`+++`
-# headers are UNPREFIXED because that is what glab emits; the `diff --git` line keeps
-# git's a//b/ spelling, which glab prints verbatim and the parser ignores.
+# headers are UNPREFIXED because that is what glab emits. The leading `diff --git` line is
+# NOT part of plain `glab mr diff` output (tests/fixtures/glab_diff/README.md has the
+# shape and its sources); it survives here because these are delivery-path tests that do
+# not turn on diff shape, and the parser ignores the line either way.
 GL_DIFF = (
     "diff --git a/bar.py b/bar.py\n"
     "--- bar.py\n"
@@ -1845,48 +1889,41 @@ GL_DIFF = (
 )
 
 
-# Real `glab mr diff` shape, captured from the issue #127 report: NO a/ b/ prefixes, the
-# SAME path on both sides for an added file, and `@@ -0,0` as the only added-file signal.
+def _glab_fixture(name):
+    """Read one `glab mr diff` fixture verbatim.
+
+    The shape these files record — and which bytes of it are a real capture — is
+    documented in tests/fixtures/glab_diff/README.md. They are read rather than inlined
+    so the parser's contract has ONE spelling that a real capture can later replace
+    without touching a test.
+    """
+    path = os.path.join(os.path.dirname(__file__), "fixtures", "glab_diff", name)
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+# A modified file followed by an added one, in the shape plain `glab mr diff` emits.
 # src/edited.py: new 61 = old 50 (context), new 62 = added, new 63 = old 52 (context).
-# src/added.py:  new 1, 2 — added file.
-GL_DIFF_CONTRACT = (
-    "diff --git a/src/edited.py b/src/edited.py\n"
-    "--- src/edited.py\n"
-    "+++ src/edited.py\n"
-    "@@ -50,3 +61,3 @@\n"
-    " unchanged_ctx\n"
-    "-removed\n"
-    "+added\n"
-    " tail_ctx\n"
-    "diff --git a/src/added.py b/src/added.py\n"
-    "--- src/added.py\n"
-    "+++ src/added.py\n"
-    "@@ -0,0 +1,2 @@\n"
-    "+first\n"
-    "+second\n"
+# src/app/clients/api/__init__.py: new 1..16 — added file, signalled only by `@@ -0,0`.
+GL_DIFF_CONTRACT = _glab_fixture("modified.diff") + _glab_fixture("added.diff")
+
+# A deleted file followed by a modified one. glab repeats the path on BOTH headers for a
+# deletion (there is no `+++ /dev/null` to blank `current_file`), so the deleted file's
+# hunk budget draining is the only thing keeping the next file's headers out of its body.
+GL_DIFF_DELETED_THEN_MODIFIED = _glab_fixture("deleted.diff") + _glab_fixture(
+    "modified.diff"
 )
 
-# A RENAMED file, glab-flavoured (unprefixed headers): the `---` header names the
-# PRE-rename path and the `+++` header the post-rename one. That old-side path is what
-# GitLab needs in `position.old_path` (#130).
-# new 3 = old 3 (context), new 4 = added, new 5 = old 5 (context).
-GL_DIFF_RENAME = (
-    "diff --git a/old_name.py b/new_name.py\n"
-    "similarity index 87%\n"
-    "rename from old_name.py\n"
-    "rename to new_name.py\n"
-    "--- old_name.py\n"
-    "+++ new_name.py\n"
-    "@@ -3,3 +3,3 @@\n"
-    " ctx\n"
-    "-x\n"
-    "+y\n"
-    " ctx2\n"
-)
+# A RENAMED file: the `---` header names the PRE-rename path and the `+++` header the
+# post-rename one. That old-side path is what GitLab needs in `position.old_path` (#130).
+# new 3 = old 3 (context), new 4 = added, new 5 = old 5 (context), new 6 = old 6 (a BLANK
+# context line, which a unified diff spells as a lone space).
+GL_DIFF_RENAME = _glab_fixture("rename.diff")
 
 # A glab diff for a repo with a REAL top-level `a/` directory. `glab mr diff` prints
 # paths verbatim, so `a/foo.py` here is a directory named `a` — not git's synthetic
-# old-side prefix. new 1 = old 1 (context), new 2 = added.
+# old-side prefix. The `diff --git` decoration is not glab's (see GL_DIFF above).
+# new 1 = old 1 (context), new 2 = added.
 GL_DIFF_REAL_A_DIR = (
     "diff --git a/a/foo.py b/a/foo.py\n"
     "--- a/foo.py\n"
@@ -1942,7 +1979,7 @@ GL_CONTRACT_FINDINGS = [
         "body": "Body two",
     },
     {
-        "file": "src/added.py",
+        "file": "src/app/clients/api/__init__.py",
         "line": 1,
         "severity": "low",
         "title": "New-file finding",
@@ -2802,7 +2839,7 @@ class TestGitlabPositionContract(_DryRunTestBase):
         """The test the old suite could not provide: ``new_files`` comes from the
         parser here, not from a fixture that asserted the conclusion."""
         position = self._positions()[2]
-        self.assertEqual(position["new_path"], "src/added.py")
+        self.assertEqual(position["new_path"], "src/app/clients/api/__init__.py")
         self.assertNotIn("old_path", position)
         self.assertNotIn("old_line", position)
 


### PR DESCRIPTION
## Summary

- Pins the `glab mr diff` output shape as test fixtures so `scripts/post_review.py` has a
  regression net for parsing plain (non-`--raw`) glab diff output.
- Adds a byte-exactness test over the fixture directory so a future edit (or a formatter/hook)
  can't silently corrupt the fixtures without a red test.

## Design

- **Provenance honesty.** Exactly one real capture exists — the 3-line snippet quoted in #127.
  Everything else in the fixture set is constructed to the shape GitLab's `/versions` API
  returns, and is labeled as constructed (not captured) in the fixtures' README so nobody mistakes
  it for a live transcript later.
- **The "diff --git" finding.** No such literal exists anywhere in the strings of the `glab`
  1.112.0 binary, and `glab` builds its diff output from the GitLab `/versions` API rather than
  shelling out to `git diff` — so the fixtures carry no git-style `diff --git a/... b/...` header
  or mode-change decoration. This is recorded as a high-confidence but unverified-against-live-authed-glab
  finding, since it rests on binary string inspection rather than an authenticated call.
- **`scripts/AGENTS.md` bullet replaced by an invocation-site comment + argv assertion.** The
  AGENTS.md byte ratchet for that file is at exactly its ceiling, so a new bullet there was not an
  option. Instead, the constraint ("plain diff output has no `--raw` flag on this invocation") is
  captured as a comment at the call site plus a `--raw`-absent assertion on the subprocess argv in
  the test — an argv assertion is mechanism where a prose bullet would only have been a promise.
- **Pre-commit excludes for the fixture directory.** `trailing-whitespace` and `end-of-file-fixer`
  operate on diff fixtures byte-for-byte; a blank context line in a real diff is a single space
  character, and both hooks would strip it, silently corrupting the fixture into something that no
  longer matches what `glab` actually emits. The fixture directory is excluded from both hooks for
  this reason.
- **Constant re-anchoring.** Every constant in `scripts/post_review.py` and its tests that referred
  to the old ad-hoc/inline diff text was re-anchored to load from the new fixture files, so there
  is a single source of truth for the expected shape rather than duplicated literals drifting apart
  over time.
- Closes #133.

## Mutation proofs

| mutation | expected red test | result |
| --- | --- | --- |
| _(no mutation data recorded for this pass)_ | — | undefined |

## Review

FIXED (commit `94a0236` on `test/133-glab-diff-fixtures`, worktree
`/private/tmp/claude-502/-Users-lee-personal-claude-deep-review/4c7da67a-a219-4ae0-98ed-72925883515c/scratchpad/wt/133`):

**should-fix 1 — fixture byte-exactness had no mechanism.** Added `TestGlabFixtureBytes` in
`/private/tmp/claude-502/-Users-lee-personal-claude-deep-review/4c7da67a-a219-4ae0-98ed-72925883515c/scratchpad/wt/133/tests/test_post_review.py`
(directory-driven over `*.diff`, so a new fixture is covered without an edit): every
whitespace-only line must be exactly `" "`, at least one such line must exist (anti-vacuity guard),
and every fixture must end in exactly one newline. The reviewer's corruption is now caught — see
mutation results below. `.pre-commit-config.yaml` and the fixture README now say the assertions,
not the exclusion, are what report a loss.

**should-fix 2 — unstated file-to-file boundary assumption.** The "each fixture ends in exactly
one newline" assertion *is* the mechanism for the concatenation the multi-file constants do.
`tests/fixtures/glab_diff/README.md` gains a "Nothing separates two files" bullet stating glab
appends no separator, that the boundary therefore rests on the API body being newline-terminated,
that this is the one property **inferred rather than sourced** (git patch text is always
line-terminated, incl. `\ No newline at end of file`), and the Upgrade-path section now names it
as the first thing a real capture settles (`+last`/`--- next_path` vs. today's inferred boundary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015GdQDn1WVh7VX9hgAjHcMS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes only; `parse_diff_lines` behavior is exercised more strictly but not altered in the diff.
> 
> **Overview**
> Adds **`tests/fixtures/glab_diff/`** (modified, added, deleted, rename cases plus README) as the single source of truth for what **plain** `glab mr diff` looks like—verbatim paths, no `a/`/`b/`, no `/dev/null`, no git decoration between files—and rewires **`GL_DIFF_*`** test constants to load those files instead of inlined strings.
> 
> **`TestGlabFixtureBytes`** guards fixture bytes (blank context lines as a lone space, exactly one trailing newline) so formatters cannot silently corrupt them; **`.pre-commit-config.yaml`** excludes the fixture `*.diff` from `trailing-whitespace` / `end-of-file-fixer`, with comments that the tests—not the exclude—report loss.
> 
> Parser tests gain coverage for GitLab-specific shapes: **`--raw` must not** appear on the `glab mr diff` argv, multi-file added-file detection uses the real captured path, **deleted-then-modified** glab diffs (path repeated on both sides, no phantom targets on removed files), and between-hunk behavior when only the next file’s `---`/`+++` separates hunks. **`post_review.py`** only adds invocation-site comments documenting plain vs `--raw` output; no parsing logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94a02369ebeb56852150a78fe0072e1a1f788af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->