### PR TITLE
fix(verify): quote argv tokens in pinned executor commands (#75)

### DIFF
--- a/agents/executor.md
+++ b/agents/executor.md
@@ -16,7 +16,7 @@ summarize, fix, or re-run.
 
 1. Run the command in the dispatch prompt exactly as written: a single pinned
    `python3 <script> <flags>` invocation whose tokens are bare words, except that a
-   path may arrive already single-quoted. Do not add flags, redirections, pipes, env
+   token may arrive already single-quoted. Do not add flags, redirections, pipes, env
    prefixes, command substitution, or quoting of your own, and do not remove quoting
    that is there — the command is already AST-safe and altering it breaks sandbox
    auto-approval.

--- a/agents/executor.md
+++ b/agents/executor.md
@@ -15,9 +15,11 @@ summarize, fix, or re-run.
 ## Protocol
 
 1. Run the command in the dispatch prompt exactly as written: a single pinned
-   `python3 <script> <flags>` invocation of plain word tokens. Do not add flags,
-   redirections, pipes, env prefixes, command substitution, or quoting of your own —
-   the command is already AST-safe and altering it breaks sandbox auto-approval.
+   `python3 <script> <flags>` invocation whose tokens are bare words, except that a
+   path may arrive already single-quoted. Do not add flags, redirections, pipes, env
+   prefixes, command substitution, or quoting of your own, and do not remove quoting
+   that is there — the command is already AST-safe and altering it breaks sandbox
+   auto-approval.
    The scripts you are given are:
    - `scripts/verify_findings.py --input ... --output ... --nonce ...` — writes its
      result to the `--output` file.

--- a/scripts/assemble_artifacts.py
+++ b/scripts/assemble_artifacts.py
@@ -5,9 +5,10 @@ assemble_artifacts.py — derive the projected code-gauntlet artifacts on disk.
 Usage:
     python3 assemble_artifacts.py --plan <path>
 
-A single invocation of plain word tokens only (CLAUDE.md AST-safe emission: no
-command substitution, heredocs, env prefixes, or shell operators), so the
-executor agent can run it inside a sandbox-auto-approved Bash call.
+A single invocation whose tokens are AST-safe (CLAUDE.md AST-safe emission: no
+command substitution, heredocs, env prefixes, or shell operators), each
+single-quoted only as the token needs it, so the executor agent can run it
+inside a sandbox-auto-approved Bash call.
 
 Why this script exists (issue #38, D3)
 --------------------------------------

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -2303,11 +2303,11 @@ function validateArgs(args) {
       errors.push(`${field} must not contain a control character`);
       continue;
     }
-    // headShaShort is interpolated bare into the verify executor's --head-sha argv
-    // (verifyCommand joins tokens with spaces into a shell-run string). Whitespace alone
-    // is not enough — `;`, `$`, backticks and friends would still reach the shell. A real
-    // short SHA never needs those characters (unlike path fields / issue #75), so apply
-    // the same AST-safe charset NONCE_RE already enforces above.
+    // headShaShort reaches the verify executor's --head-sha argv (verifyCommand). Path
+    // fields are quoted at that construction site (issue #75) because a legitimate path
+    // may hold a space; a real short SHA never needs one, and never needs `;`, `$` or a
+    // backtick either — so the waist keeps it to the same AST-safe charset NONCE_RE
+    // already enforces above, and the command carries it as a bare word.
     if (field === 'headShaShort' && !NONCE_RE.test(v)) {
       errors.push(`headShaShort must match ${NONCE_RE} (AST-safe, non-splitting — interpolated into the verify command argv)`);
     }
@@ -3731,11 +3731,29 @@ function trustSlice(env, { nonce, headShaShort, n, ids, expectedInputChecksum })
   return { ok: true };
 }
 
-// The pinned command: a single `python3 <script> --flags...` invocation of plain word
-// tokens only (CLAUDE.md AST-safe emission — no command substitution, heredocs, env
-// prefix, or shell operators). Per-slice input/output paths are sha-scoped and index-
-// suffixed; verifyStage materializes the slice inputs via the artifact-writer (see
-// materializeVerifySlices) before dispatch, then the executor reads the slice output.
+// shellWord(tok) -> the token as ONE shell word. A token of ordinary path characters is
+// returned bare, so an ordinary command is byte-identical to a plain `parts.join(' ')`;
+// anything else is POSIX single-quoted, which keeps the command AST-safe (a single-quoted
+// token is one `raw_string` node to tree-sitter-bash — no expansion, no operator, and
+// nothing the sandbox's auto-approval parse does not recognise). The charset is
+// shlex.quote's: deliberately conservative, since every character outside it only costs a
+// pair of quotes. `'\''` closes, escapes, and reopens for an embedded single quote.
+const SHELL_SAFE_RE = /^[A-Za-z0-9_%+=:,.\/@-]+$/;
+function shellWord(tok) {
+  // null/undefined/'' contribute an empty string, exactly as Array.join did: an absent
+  // optional field must not materialize a literal `undefined` or a stray `''` in argv.
+  if (tok == null) return '';
+  const s = String(tok);
+  if (s === '' || SHELL_SAFE_RE.test(s)) return s;
+  return `'${s.replaceAll("'", `'\\''`)}'`;
+}
+
+// The pinned command: a single `python3 <script> --flags...` invocation whose tokens are
+// AST-safe (CLAUDE.md AST-safe emission — no command substitution, heredocs, env prefix,
+// or shell operators), each shellWord-quoted so a path bearing a space stays ONE argv word
+// (issue #75). Per-slice input/output paths are sha-scoped and index-suffixed; verifyStage
+// materializes the slice inputs via the artifact-writer (see materializeVerifySlices)
+// before dispatch, then the executor reads the slice output.
 //
 // `sliceNonce` is THREADED IN, never re-derived: it is the same value verifySliceWithRetry
 // hands trustSlice as the expected receipt nonce, so argv and the trust check cannot
@@ -3756,7 +3774,7 @@ function verifyCommand(inp, i, sliceNonce) {
     '--base-branch', v.baseBranch || 'main',
   ];
   if (v.diffPath) parts.push('--diff-file', v.diffPath);
-  return parts.join(' ');
+  return parts.map(shellWord).join(' ');
 }
 
 // What the executor is asked for is now a PREFIX of the output document, not the whole of
@@ -5452,11 +5470,12 @@ const ASSEMBLE_RECEIPT_SCHEMA = {
   },
 };
 
-// The pinned command: a single `python3 <script> --plan <plan>` invocation of plain
-// word tokens only (CLAUDE.md AST-safe emission — no command substitution, heredocs,
-// env prefix, or shell operators), exactly like verifyCommand.
+// The pinned command: a single `python3 <script> --plan <plan>` invocation whose tokens are
+// AST-safe (CLAUDE.md AST-safe emission — no command substitution, heredocs, env prefix, or
+// shell operators), each shellWord-quoted so a path bearing a space stays ONE argv word
+// (issue #75) — exactly like verifyCommand.
 function assemblePrompt(scriptPath, planPath) {
-  return `Run exactly this command, then return its single line of stdout JSON verbatim via the schema:\npython3 ${scriptPath} --plan ${planPath}`;
+  return `Run exactly this command, then return its single line of stdout JSON verbatim via the schema:\npython3 ${shellWord(scriptPath)} --plan ${shellWord(planPath)}`;
 }
 
 // --- Checkpoints ------------------------------------------------------------

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -3733,11 +3733,13 @@ function trustSlice(env, { nonce, headShaShort, n, ids, expectedInputChecksum })
 
 // shellWord(tok) -> the token as ONE shell word. A token of ordinary path characters is
 // returned bare, so an ordinary command is byte-identical to a plain `parts.join(' ')`;
-// anything else is POSIX single-quoted, which keeps the command AST-safe (a single-quoted
-// token is one `raw_string` node to tree-sitter-bash — no expansion, no operator, and
-// nothing the sandbox's auto-approval parse does not recognise). The charset is
+// anything else is POSIX single-quoted, which keeps the command AST-safe: with no embedded
+// single quote the token is one `raw_string` node to tree-sitter-bash — no expansion, no
+// operator, nothing the sandbox's auto-approval parse does not recognise. The charset is
 // shlex.quote's: deliberately conservative, since every character outside it only costs a
-// pair of quotes. `'\''` closes, escapes, and reopens for an embedded single quote.
+// pair of quotes. `'\''` closes, escapes, and reopens for an embedded single quote; that
+// token parses as a `concatenation` rather than a `raw_string`, so auto-approval is not
+// guaranteed on that rare edge (a quote in a repo path) — a correct command is worth more.
 const SHELL_SAFE_RE = /^[A-Za-z0-9_%+=:,.\/@-]+$/;
 function shellWord(tok) {
   // null/undefined/'' contribute an empty string, exactly as Array.join did: an absent

--- a/workflows/src/args.js
+++ b/workflows/src/args.js
@@ -440,11 +440,11 @@ export function validateArgs(args) {
       errors.push(`${field} must not contain a control character`);
       continue;
     }
-    // headShaShort is interpolated bare into the verify executor's --head-sha argv
-    // (verifyCommand joins tokens with spaces into a shell-run string). Whitespace alone
-    // is not enough — `;`, `$`, backticks and friends would still reach the shell. A real
-    // short SHA never needs those characters (unlike path fields / issue #75), so apply
-    // the same AST-safe charset NONCE_RE already enforces above.
+    // headShaShort reaches the verify executor's --head-sha argv (verifyCommand). Path
+    // fields are quoted at that construction site (issue #75) because a legitimate path
+    // may hold a space; a real short SHA never needs one, and never needs `;`, `$` or a
+    // backtick either — so the waist keeps it to the same AST-safe charset NONCE_RE
+    // already enforces above, and the command carries it as a bare word.
     if (field === 'headShaShort' && !NONCE_RE.test(v)) {
       errors.push(`headShaShort must match ${NONCE_RE} (AST-safe, non-splitting — interpolated into the verify command argv)`);
     }

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -1269,11 +1269,13 @@ function trustSlice(env, { nonce, headShaShort, n, ids, expectedInputChecksum })
 
 // shellWord(tok) -> the token as ONE shell word. A token of ordinary path characters is
 // returned bare, so an ordinary command is byte-identical to a plain `parts.join(' ')`;
-// anything else is POSIX single-quoted, which keeps the command AST-safe (a single-quoted
-// token is one `raw_string` node to tree-sitter-bash — no expansion, no operator, and
-// nothing the sandbox's auto-approval parse does not recognise). The charset is
+// anything else is POSIX single-quoted, which keeps the command AST-safe: with no embedded
+// single quote the token is one `raw_string` node to tree-sitter-bash — no expansion, no
+// operator, nothing the sandbox's auto-approval parse does not recognise. The charset is
 // shlex.quote's: deliberately conservative, since every character outside it only costs a
-// pair of quotes. `'\''` closes, escapes, and reopens for an embedded single quote.
+// pair of quotes. `'\''` closes, escapes, and reopens for an embedded single quote; that
+// token parses as a `concatenation` rather than a `raw_string`, so auto-approval is not
+// guaranteed on that rare edge (a quote in a repo path) — a correct command is worth more.
 const SHELL_SAFE_RE = /^[A-Za-z0-9_%+=:,.\/@-]+$/;
 function shellWord(tok) {
   // null/undefined/'' contribute an empty string, exactly as Array.join did: an absent

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -1267,11 +1267,29 @@ function trustSlice(env, { nonce, headShaShort, n, ids, expectedInputChecksum })
   return { ok: true };
 }
 
-// The pinned command: a single `python3 <script> --flags...` invocation of plain word
-// tokens only (CLAUDE.md AST-safe emission — no command substitution, heredocs, env
-// prefix, or shell operators). Per-slice input/output paths are sha-scoped and index-
-// suffixed; verifyStage materializes the slice inputs via the artifact-writer (see
-// materializeVerifySlices) before dispatch, then the executor reads the slice output.
+// shellWord(tok) -> the token as ONE shell word. A token of ordinary path characters is
+// returned bare, so an ordinary command is byte-identical to a plain `parts.join(' ')`;
+// anything else is POSIX single-quoted, which keeps the command AST-safe (a single-quoted
+// token is one `raw_string` node to tree-sitter-bash — no expansion, no operator, and
+// nothing the sandbox's auto-approval parse does not recognise). The charset is
+// shlex.quote's: deliberately conservative, since every character outside it only costs a
+// pair of quotes. `'\''` closes, escapes, and reopens for an embedded single quote.
+const SHELL_SAFE_RE = /^[A-Za-z0-9_%+=:,.\/@-]+$/;
+function shellWord(tok) {
+  // null/undefined/'' contribute an empty string, exactly as Array.join did: an absent
+  // optional field must not materialize a literal `undefined` or a stray `''` in argv.
+  if (tok == null) return '';
+  const s = String(tok);
+  if (s === '' || SHELL_SAFE_RE.test(s)) return s;
+  return `'${s.replaceAll("'", `'\\''`)}'`;
+}
+
+// The pinned command: a single `python3 <script> --flags...` invocation whose tokens are
+// AST-safe (CLAUDE.md AST-safe emission — no command substitution, heredocs, env prefix,
+// or shell operators), each shellWord-quoted so a path bearing a space stays ONE argv word
+// (issue #75). Per-slice input/output paths are sha-scoped and index-suffixed; verifyStage
+// materializes the slice inputs via the artifact-writer (see materializeVerifySlices)
+// before dispatch, then the executor reads the slice output.
 //
 // `sliceNonce` is THREADED IN, never re-derived: it is the same value verifySliceWithRetry
 // hands trustSlice as the expected receipt nonce, so argv and the trust check cannot
@@ -1292,7 +1310,7 @@ function verifyCommand(inp, i, sliceNonce) {
     '--base-branch', v.baseBranch || 'main',
   ];
   if (v.diffPath) parts.push('--diff-file', v.diffPath);
-  return parts.join(' ');
+  return parts.map(shellWord).join(' ');
 }
 
 // What the executor is asked for is now a PREFIX of the output document, not the whole of
@@ -2988,11 +3006,12 @@ const ASSEMBLE_RECEIPT_SCHEMA = {
   },
 };
 
-// The pinned command: a single `python3 <script> --plan <plan>` invocation of plain
-// word tokens only (CLAUDE.md AST-safe emission — no command substitution, heredocs,
-// env prefix, or shell operators), exactly like verifyCommand.
+// The pinned command: a single `python3 <script> --plan <plan>` invocation whose tokens are
+// AST-safe (CLAUDE.md AST-safe emission — no command substitution, heredocs, env prefix, or
+// shell operators), each shellWord-quoted so a path bearing a space stays ONE argv word
+// (issue #75) — exactly like verifyCommand.
 function assemblePrompt(scriptPath, planPath) {
-  return `Run exactly this command, then return its single line of stdout JSON verbatim via the schema:\npython3 ${scriptPath} --plan ${planPath}`;
+  return `Run exactly this command, then return its single line of stdout JSON verbatim via the schema:\npython3 ${shellWord(scriptPath)} --plan ${shellWord(planPath)}`;
 }
 
 // --- Checkpoints ------------------------------------------------------------

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -488,9 +488,10 @@ test('validateArgs rejects a path-bearing field carrying an embedded control cha
 });
 
 test('validateArgs rejects headShaShort that would split or inject in the verify argv', () => {
-  // headShaShort is joined into a shell-run string by verifyCommand (stages.js). Apply the
-  // same NONCE_RE charset as the nonce — whitespace, shell metacharacters, and anything
-  // outside [A-Za-z0-9._-] must fail at the waist. A real short SHA never needs them.
+  // headShaShort reaches the shell-run string verifyCommand builds (stages.js), where it
+  // is carried as a bare word. Apply the same NONCE_RE charset as the nonce — whitespace,
+  // shell metacharacters, and anything outside [A-Za-z0-9._-] must fail at the waist. A
+  // real short SHA never needs them (unlike a path, which verifyCommand quotes instead).
   for (const bad of ['abc 1234', 'abc;id', 'abc$(id)', 'abc`id`', "abc'x", 'abc|x']) {
     const r = validateArgs({ ...good, headShaShort: bad });
     assert.equal(r.ok, false, `headShaShort=${JSON.stringify(bad)} should be rejected`);

--- a/workflows/test/helpers/shellWords.js
+++ b/workflows/test/helpers/shellWords.js
@@ -1,0 +1,65 @@
+// shellWords.js — read a pinned executor command the way a POSIX shell would.
+//
+// The pinned commands (verifyCommand, assemblePrompt) are strings that Bash will split
+// into argv. Asserting "the path survived" by regex-matching the string proves nothing:
+// `--diff-file /My Documents/d.patch` matches every substring test and still reaches the
+// script as two arguments. So the issue-#75 tests assert on the ARGV a shell would build.
+//
+// This is a deliberate SUBSET of the shell's word-splitting grammar — single quotes,
+// backslash escapes, and unquoted blanks — because that is the whole of what the pinned
+// commands may contain. Anything richer (a double quote, an unterminated quote) throws
+// rather than being silently tolerated: a command that needs more than this subset has
+// already left the AST-safe emission contract.
+
+// shellSplit(cmd) -> the argv array a POSIX shell would pass to execve.
+export function shellSplit(cmd) {
+  const words = [];
+  let cur = null; // null = between words; '' = inside a word that is still empty
+  let i = 0;
+  while (i < cmd.length) {
+    const ch = cmd[i];
+    if (ch === ' ' || ch === '\t') {
+      if (cur !== null) { words.push(cur); cur = null; }
+      i += 1;
+      continue;
+    }
+    if (cur === null) cur = '';
+    if (ch === "'") {
+      const end = cmd.indexOf("'", i + 1);
+      if (end === -1) throw new Error(`unterminated single quote: ${cmd}`);
+      cur += cmd.slice(i + 1, end);
+      i = end + 1;
+      continue;
+    }
+    if (ch === '\\') {
+      if (i + 1 >= cmd.length) throw new Error(`trailing backslash: ${cmd}`);
+      cur += cmd[i + 1];
+      i += 2;
+      continue;
+    }
+    if (ch === '"') throw new Error(`unexpected double quote: ${cmd}`);
+    cur += ch;
+    i += 1;
+  }
+  if (cur !== null) words.push(cur);
+  return words;
+}
+
+// outsideSingleQuotes(cmd) -> everything NOT inside a single-quoted run, quotes dropped.
+// A `$` or a backtick here would be live shell syntax; the same character inside a
+// single-quoted run is an ordinary byte. Tests scan this, never the raw command.
+export function outsideSingleQuotes(cmd) {
+  let out = '';
+  let i = 0;
+  while (i < cmd.length) {
+    if (cmd[i] === "'") {
+      const end = cmd.indexOf("'", i + 1);
+      if (end === -1) throw new Error(`unterminated single quote: ${cmd}`);
+      i = end + 1;
+      continue;
+    }
+    out += cmd[i];
+    i += 1;
+  }
+  return out;
+}

--- a/workflows/test/helpers/shellWords.js
+++ b/workflows/test/helpers/shellWords.js
@@ -45,13 +45,21 @@ export function shellSplit(cmd) {
   return words;
 }
 
-// outsideSingleQuotes(cmd) -> everything NOT inside a single-quoted run, quotes dropped.
-// A `$` or a backtick here would be live shell syntax; the same character inside a
-// single-quoted run is an ordinary byte. Tests scan this, never the raw command.
+// outsideSingleQuotes(cmd) -> everything NOT inside a single-quoted run and not
+// backslash-escaped, quotes dropped. A `$` or a backtick here would be live shell syntax;
+// the same character inside a single-quoted run, or behind a backslash, is an ordinary
+// byte. Tests scan this, never the raw command.
 export function outsideSingleQuotes(cmd) {
   let out = '';
   let i = 0;
   while (i < cmd.length) {
+    // Mirrors shellSplit's backslash arm: `\'` must not be read as opening a quoted run,
+    // which is exactly the `'\''` escape shellWord emits for an embedded single quote.
+    if (cmd[i] === '\\') {
+      if (i + 1 >= cmd.length) throw new Error(`trailing backslash: ${cmd}`);
+      i += 2;
+      continue;
+    }
     if (cmd[i] === "'") {
       const end = cmd.indexOf("'", i + 1);
       if (end === -1) throw new Error(`unterminated single quote: ${cmd}`);

--- a/workflows/test/stages_persist.test.js
+++ b/workflows/test/stages_persist.test.js
@@ -28,6 +28,7 @@ import {
 } from '../src/stages.js';
 import { validateArgs } from '../src/args.js';
 import { makeFinding, validArgs, makeCtx } from './helpers/pipelineMock.js';
+import { shellSplit } from './helpers/shellWords.js';
 
 const OUT_DIR = '/repo/.code-gauntlet';
 const SHA = 'abc1234';
@@ -604,6 +605,19 @@ test('derived path: the executor gets a single pinned python3 command of plain w
   const command = exec.prompt.split('\n').filter((l) => l.startsWith('python3'))[0];
   assert.equal(command.split(' ').length, 4, 'four plain word tokens');
   assert.ok(!/[$`;|&><(){}]/.test(command), `command must be AST-safe: ${command}`);
+});
+
+test('(#75) derived path: a space in the script or plan path still names ONE file per argv word', async () => {
+  // assemblePrompt has verifyCommand's defect and verifyCommand's fix: a space-bearing
+  // {output_dir} used to hand the executor `--plan /My Repo/....json` as two arguments,
+  // and assemble_artifacts.py refused a plan it could not open. Asserted on the argv a
+  // shell would build — a substring match cannot tell one word from two.
+  const outDir = '/My Repo/.code-gauntlet';
+  const script = "/plug in/scripts/o'brien/assemble_artifacts.py";
+  const ctx = persistCtx();
+  await writeArtifacts(ctx, persistInput({ outputDir: outDir, persist: { assembleScriptPath: script } }));
+  const command = ctx.calls[1].prompt.split('\n').pop();
+  assert.deepEqual(shellSplit(command), ['python3', script, '--plan', persistPlanPath(outDir, SHA)]);
 });
 
 test('derived path: the writer payload is dramatically smaller than the legacy by-value one', async () => {

--- a/workflows/test/stages_verify.test.js
+++ b/workflows/test/stages_verify.test.js
@@ -542,6 +542,23 @@ test('(#75) a $ or backtick in baseBranch is quoted, never live shell syntax', a
   assert.doesNotMatch(outsideSingleQuotes(cmd), /[$`]/, `expansion escaped its quotes: ${cmd}`);
 });
 
+test('(#75) an apostrophe path and a $ branch in the SAME command: neither escape leaks live syntax', async () => {
+  // The two escapes interact: the `'\''` a quoted path emits ends and reopens quoted runs,
+  // so a scanner that mis-pairs quotes reads the branch's `$` as live (or throws) even
+  // though both tokens are correctly quoted. Realistic together — /Users/o'brien plus a
+  // legal `feature/$x` refname.
+  const verify = {
+    ...baseInput().verify,
+    diffPath: "/Users/o'brien/out/code-gauntlet diff.patch",
+    baseBranch: 'feature/$x-`y`',
+  };
+  const cmd = await dispatchedCommand(baseInput({ verify }));
+  assert.deepEqual(shellSplit(cmd).slice(-4), [
+    '--base-branch', verify.baseBranch, '--diff-file', verify.diffPath,
+  ]);
+  assert.doesNotMatch(outsideSingleQuotes(cmd), /[$`]/, `expansion escaped its quotes: ${cmd}`);
+});
+
 test('(#75) an absent head SHA contributes an empty token, never the word "undefined"', async () => {
   // Array.join stringifies null/undefined to '' — shellWord must keep that exact
   // semantics, or a missing optional field starts passing a literal `undefined` to argv.

--- a/workflows/test/stages_verify.test.js
+++ b/workflows/test/stages_verify.test.js
@@ -23,6 +23,7 @@ import assert from 'node:assert/strict';
 import { verifyStage, parseWriterPayload, VERIFY_ATTEMPTS_PER_SLICE } from '../src/stages.js';
 import { assertPrompt, assertValidSchema } from './helpers/pipelineMock.js';
 import { deltaEnvelope, deltasFor, ELIMINATION_STAMP, sliceInputRecorder } from './helpers/verifyDelta.js';
+import { outsideSingleQuotes, shellSplit } from './helpers/shellWords.js';
 
 // Platform contract: agent(promptString, opts). The EXECUTOR slice loop is deliberately
 // SEQUENTIAL bare agent() calls (never parallel() — the order pairs receipts to slices),
@@ -470,6 +471,85 @@ test('the executor command is a single AST-safe python3 word-token invocation', 
   // No shell substitution / heredocs / env-prefix (CLAUDE.md AST-safe emission).
   assert.doesNotMatch(cmd, /\$\(|`|<<|\$\{|&&|\|\|/);
   assert.equal(t.agentType, 'code-gauntlet:executor');
+});
+
+// --- Issue #75: the pinned command's tokens are shell WORDS, not space-joined ----------
+//
+// verifyCommand builds argv and hands it to the executor as one string that Bash splits.
+// A path holding a space used to split into two arguments there — `--diff-file /My
+// Documents/d.patch` reached verify_findings.py as `--diff-file /My`, and the slice
+// degraded on an input the caller spelled correctly. Each token is now shellWord-quoted,
+// so these tests assert on the ARGV a shell would build (shellSplit), never on substrings
+// of the command: a substring match cannot tell one word from two.
+
+// The command dispatched for slice `i` is the last line of the executor prompt.
+const commandOf = (call) => call.prompt.split('\n').pop();
+
+async function dispatchedCommand(input) {
+  const ctx = verifyCtx((_t, i) => okEnvelope(input.findings, { nonce: `n-1.${i}` }));
+  await verifyStage(ctx, input);
+  return commandOf(ctx.execCalls()[0]);
+}
+
+test('(#75) ordinary paths stay BYTE-IDENTICAL to the unquoted join — quoting costs nothing by default', async () => {
+  // Every real fixture ({output_dir} paths, hex nonces, --flags, short SHAs, ordinary
+  // branch names) matches the bare charset, so the shipped command must not change at
+  // all. Pinned as an exact string: a regex would not notice a stray pair of quotes.
+  assert.equal(
+    await dispatchedCommand(baseInput()),
+    'python3 /plugin/scripts/verify_findings.py'
+    + ' --input /out/phase4-input-abc123.slice0.json'
+    + ' --output /out/phase4-output-abc123.slice0.json'
+    + ' --nonce n-1.0 --head-sha abc123 --base-branch main'
+    + ' --diff-file /out/code-gauntlet-diff-abc123.patch',
+  );
+});
+
+test('(#75) a space in ANY path field still names ONE file in the executor argv', async () => {
+  const verify = {
+    scriptPath: '/plug in/scripts/verify_findings.py',
+    inputPathBase: '/My Documents/out/phase4-input-abc123',
+    outputPathBase: '/My Documents/out/phase4-output-abc123',
+    baseBranch: 'main',
+    diffPath: '/My Documents/out/code-gauntlet diff.patch',
+  };
+  const cmd = await dispatchedCommand(baseInput({ verify }));
+  assert.deepEqual(shellSplit(cmd), [
+    'python3', verify.scriptPath,
+    '--input', '/My Documents/out/phase4-input-abc123.slice0.json',
+    '--output', '/My Documents/out/phase4-output-abc123.slice0.json',
+    '--nonce', 'n-1.0',
+    '--head-sha', 'abc123',
+    '--base-branch', 'main',
+    '--diff-file', verify.diffPath,
+  ]);
+});
+
+test("(#75) a single quote inside a path round-trips through the '\\'' escape", async () => {
+  const diffPath = "/Users/o'brien/out/code-gauntlet diff.patch";
+  const cmd = await dispatchedCommand(baseInput({ verify: { ...baseInput().verify, diffPath } }));
+  const argv = shellSplit(cmd);
+  assert.equal(argv[argv.length - 1], diffPath);
+  assert.equal(argv[argv.length - 2], '--diff-file');
+});
+
+test('(#75) a $ or backtick in baseBranch is quoted, never live shell syntax', async () => {
+  // git refnames forbid a space but PERMIT `$` and a backtick, so `feature/$x` is a legal
+  // branch that must reach the script literally — and must not reach the shell at all.
+  const baseBranch = 'feature/$x-`y`';
+  const cmd = await dispatchedCommand(baseInput({ verify: { ...baseInput().verify, baseBranch } }));
+  assert.deepEqual(shellSplit(cmd).slice(-4, -2), ['--base-branch', baseBranch]);
+  assert.doesNotMatch(outsideSingleQuotes(cmd), /[$`]/, `expansion escaped its quotes: ${cmd}`);
+});
+
+test('(#75) an absent head SHA contributes an empty token, never the word "undefined"', async () => {
+  // Array.join stringifies null/undefined to '' — shellWord must keep that exact
+  // semantics, or a missing optional field starts passing a literal `undefined` to argv.
+  for (const headShaShort of [undefined, null, '']) {
+    const cmd = await dispatchedCommand(baseInput({ headShaShort }));
+    assert.ok(cmd.includes('--head-sha  --base-branch main'), `${headShaShort}: ${cmd}`);
+    assert.ok(!cmd.includes('undefined') && !cmd.includes('null'), cmd);
+  }
 });
 
 // --- Issue #54: per-slice degradation + the single deterministic retry ------


### PR DESCRIPTION
Closes #75.

## Problem

`verifyCommand` and `assemblePrompt` built the executor's shell command by joining argv tokens with a single space and quoting nothing. A path holding a space split into two arguments when the executor ran it: `--diff-file /My Documents/d.patch` reached `verify_findings.py` as `--diff-file /My`, and the slice degraded on input the caller had spelled correctly. `inputPathBase`, `outputPathBase`, `diffPath`, `scriptPath` and `planPath` are all exposed; `baseBranch` too, since a git refname forbids a space but permits `$` and a backtick (`feature/$x` is a legal branch).

`assemblePrompt` is included because it has verifyCommand's exact defect on `scriptPath`/`planPath` — its own comment already said "exactly like verifyCommand", and one helper fixes both sites.

## Fix

Add `shellWord()` next to `verifyCommand` and map every token through it:

- A token matching shlex.quote's conservative safe charset passes through bare, so **every ordinary command stays byte-identical to the old join** (pinned by an exact-string test).
- Anything else is POSIX single-quoted — AST-safe (one `raw_string` node to tree-sitter-bash: no expansion, no operator), matching the quoting the v2 emission contract already ships through the same sandbox auto-approval gate. A token holding an embedded single quote uses the `'\''` escape, which parses as a `concatenation` — auto-approval is not guaranteed on that rare edge, a deliberate trade for a correct command (stated in the code comment, not asserted away).
- `null`/`undefined`/`''` still contribute an empty string, exactly as `Array.join` did, so an absent optional field cannot materialize a literal `undefined` in argv.

The fix belongs here, not at the args waist: rejecting a space in a path field would newly reject a valid `argsVersion:1` waist, which issue #27 forbids. No waist validation changes. Comments in `stages.js`/`args.js`/`args.test.js`, the `assemble_artifacts.py` docstring, and `agents/executor.md` protocol item 1 were updated so no surface still claims "plain word tokens only"; the executor's do-not-alter instruction now also says "do not remove quoting that is there".

## Tests

Seven new regression tests assert on the **argv a POSIX shell would build** (new `workflows/test/helpers/shellWords.js`: `shellSplit` + `outsideSingleQuotes`), never on substrings — a substring match cannot tell one word from two:

- ordinary paths stay byte-identical to the unquoted join (exact-string pin)
- a space in any path field still names one file per argv word (verify + persist/assemble variants)
- a single quote in a path round-trips through the `'\''` escape
- a `$`/backtick `baseBranch` is quoted, never live shell syntax
- an apostrophe path and a `$` branch in the same command — the two escapes interact, and the scanner must not mis-pair quoted runs
- an absent head SHA contributes an empty token, never the word `undefined`

**Mutation catalogue (all red, run against the live implementation):** reverting to `parts.join(' ')` fails 3 tests; dropping the `'\''` escaping fails 2; reverting the `assemblePrompt` call sites fails the persist test; deleting the scanner's backslash arm fails the combined-escape test. The reviewer independently confirmed four more mutations (null-guard drop, empty-string drop, quoting only `--input`, quoting `scriptPath` but not `planPath`) are all caught.

## Verification

All gates green on this branch: JS 664/664 with coverage 98.71 / 84.13 / 98.18 vs floors 98 / 83.3 / 97.2 plus the presence check; `pytest tests/` 1280 passed @ 92.86% (floor 91.8); `bench/tests/` 537 passed @ 88.35% (floor 87); `node workflows/build.js` leaves the committed bundle byte-identical; `pre-commit run --all-files` green. Suites-only per roadmap #101 (Wave 3 ships behind Smoke A).

## Coordination (roadmap #101 Wave 3)

Lands alongside the sibling branch for #53 (`fix/53-finding-item-schema-closed`). Both edit `workflows/src/stages.js` but in different functions — this PR in `verifyCommand`/`assemblePrompt`, #53 in `findingItemSchema`/`canonicalDeltas` — and every other source file is single-owner; the generated `workflows/pipeline.js` bundle is the only shared surface. A trial merge of both final heads onto main is clean: 666/666 JS tests, 1280 pytest, and the merged bundle is byte-identical to a fresh `node workflows/build.js`. Suggested order: this PR first, then #53. **Whichever merges second: rebase on main, re-run `node workflows/build.js`, and commit the regenerated bundle rather than trusting the textual auto-merge of `pipeline.js`.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiWyAeUdUpC8X9DTYjV9ti

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how verify and persist executor commands are stringified; mistakes could break sandbox auto-approval or slice verification, but behavior for ordinary paths is pinned byte-identical and coverage is strong.
> 
> **Overview**
> Fixes **issue #75**: pinned executor commands no longer split paths (or other argv values) on spaces when Bash runs them.
> 
> **`shellWord()`** is added in `workflows/src/stages.js` (mirrored in `workflows/pipeline.js`). Safe tokens stay bare so typical commands are unchanged; anything else gets POSIX single-quoting (with `'\''` for embedded quotes). **`verifyCommand`** and **`assemblePrompt`** build commands with `parts.map(shellWord).join(' ')` instead of a plain join. **`headShaShort`** stays a bare word with the existing `NONCE_RE` waist guard; comments in `args.js` / tests clarify that paths are quoted at command construction, not rejected in validation.
> 
> **Executor/docs:** `agents/executor.md` and `assemble_artifacts.py` now describe tokens that may already be single-quoted and tell the executor not to strip quoting.
> 
> **Tests:** New `workflows/test/helpers/shellWords.js` (`shellSplit`, `outsideSingleQuotes`) drives issue-#75 regressions in `stages_verify.test.js` and `stages_persist.test.js`—assertions use shell argv, not substring matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 918c8861a9c1de40f2f79e1ba8f2af821fc4dbe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->