### PR TITLE
fix(discover): close the finding item schema to undeclared fields (#53)

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -64,7 +64,8 @@ obvious from the diff alone; the full engineering rules live in `AGENTS.md`.
   `TextEncoder`, `URL`, `setTimeout`, `process` and `console` exist under `node --test` but not in
   the workflow sandbox, so a reference passes every test and throws on first live dispatch.
 - **A new finding field must appear in `workflows/src/registry.js`.** A field declared only in an
-  agent contract is dropped silently by StructuredOutput on every run.
+  agent contract is rejected at dispatch by the closed item schema (`additionalProperties: false`)
+  — schema retries, then a terminal agent failure that degrades the dimension.
 - **Instruction files are loaded on every turn.** Flag additions to `CLAUDE.md` or `AGENTS.md`
   that are derivable from the code, already stated in a comment at the site, or that record
   history, version numbers, or past incidents.

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -7,9 +7,9 @@ Subagent contracts. Each `.md` is a system prompt with enforced YAML frontmatter
 - **LSP-first investigation.** Agents prefer `goToDefinition` / `findReferences` / `hover`, with
   Grep as fallback.
 - **A finding field is one entry in `workflows/src/registry.js` plus the owning agent's output
-  block.** A field no schema declares is **dropped silently** — StructuredOutput returns only
-  declared properties — so a field a contract instructs but the registry does not declare never
-  reaches merge, on every run. `tests/test_dimensions_registry.py` fails the build when the two drift.
+  block.** A field no schema declares is **rejected at dispatch** — the item schema is closed
+  (`additionalProperties: false`, issue #53) — so emitting it burns schema retries and, persisted,
+  fails the agent. `tests/test_dimensions_registry.py` fails the build when the two drift.
 - **Declared-but-optional fields are not nullable.** A not-applicable value is *omitted*, never
   `null`; the platform types each property to a single type and a null burns retries.
 - **`required` is one flat list shared by every dimension.** A field a contract calls required for

--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -11,9 +11,9 @@ Subagent contracts. Each `.md` is a system prompt with enforced YAML frontmatter
 - **LSP-first investigation.** Agents prefer `goToDefinition` / `findReferences` / `hover`, with
   Grep as fallback.
 - **A finding field is one entry in `workflows/src/registry.js` plus the owning agent's output
-  block.** A field no schema declares is **dropped silently** — StructuredOutput returns only
-  declared properties — so a field a contract instructs but the registry does not declare never
-  reaches merge, on every run. `tests/test_dimensions_registry.py` fails the build when the two drift.
+  block.** A field no schema declares is **rejected at dispatch** — the item schema is closed
+  (`additionalProperties: false`, issue #53) — so emitting it burns schema retries and, persisted,
+  fails the agent. `tests/test_dimensions_registry.py` fails the build when the two drift.
 - **Declared-but-optional fields are not nullable.** A not-applicable value is *omitted*, never
   `null`; the platform types each property to a single type and a null burns retries.
 - **`required` is one flat list shared by every dimension.** A field a contract calls required for

--- a/skills/code-gauntlet/references/report-format.md
+++ b/skills/code-gauntlet/references/report-format.md
@@ -34,7 +34,7 @@ For self-hosted instances, replace the hostname with the one detected from the g
 
 ## Finding Fields Reference
 
-The pipeline's declaration lives in `workflows/src/registry.js`. A field this table lists but the registry does not declare is dropped silently before any stage sees it — which is why `tests/test_dimensions_registry.py` pins this table, the registry, and the agent contracts to each other.
+The pipeline's declaration lives in `workflows/src/registry.js`. A field this table lists but the registry does not declare is rejected at the dispatch boundary (the item schema is closed — `additionalProperties: false`) before any stage sees it — which is why `tests/test_dimensions_registry.py` pins this table, the registry, and the agent contracts to each other.
 
 ### Canonical fields — every finding, every dimension
 

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -7,10 +7,13 @@ nine dimension names in agents/AGENTS.md, the field lists there,
 and `references/report-format.md`'s Finding Fields Reference tables. A fourth — the seven
 discovery agents' `.md` output contracts — tells the models what to emit.
 
-Every one of those can drift from the registry silently, and drift is not cosmetic here:
-StructuredOutput returns ONLY declared properties, so a field an agent contract instructs but
-the registry does not declare is discarded the instant the agent answers, before merge,
-verify, filter, challenge or report ever see it. That is issue #47 — `suggestion` and
+Every one of those can drift from the registry silently, and drift is not cosmetic here: the
+discovery item schema is CLOSED (`additionalProperties: false`, issue #53), so a field an agent
+contract instructs but the registry does not declare is a schema violation the platform rejects
+— the agent burns retries and, if it keeps emitting the field, returns nothing and its whole
+dimension degrades. Before #53 the same drift was silent instead: the undeclared field was
+simply discarded the instant the agent answered. Either way it never reaches merge, verify,
+filter, challenge or report. That is issue #47 — `suggestion` and
 `claude_md_rule` (instructed by all 7 contracts), `spec_text` (intent) and
 `criticality`/`failure_scenario` (test_coverage) were instructed for the life of the v3
 pipeline and declared by nothing, so `report-format.md` marked `suggestion` **required** while
@@ -332,8 +335,9 @@ class TestContractSchemaLockstep(unittest.TestCase):
     """The issue #47 guard: what a contract instructs and what the schema declares agree."""
 
     def test_every_instructed_field_is_schema_declared(self):
-        # The #47 direction. An instructed-but-undeclared field is dropped by
-        # StructuredOutput the instant the agent answers — silently, on every run.
+        # The #47 direction. Since #53 closed the item schema, an instructed-but-undeclared
+        # field is REJECTED at the dispatch boundary on every run: schema retries, and a
+        # model that keeps emitting it fails the agent and degrades the dimension.
         offenders = {}
         for agent_type, declared in declared_by_agent().items():
             name = agent_name(agent_type)
@@ -343,8 +347,9 @@ class TestContractSchemaLockstep(unittest.TestCase):
         self.assertEqual(
             offenders,
             {},
-            "agent contracts instruct fields no schema declares — they will be "
-            "dropped at the StructuredOutput boundary. Declare them in "
+            "agent contracts instruct fields no schema declares — the CLOSED item "
+            "schema rejects them at the dispatch boundary, costing schema retries and "
+            "risking a terminal agent failure that degrades the dimension. Declare them in "
             f"workflows/src/registry.js (canonical or the owning dimension's "
             f"schemaExtra): {offenders}",
         )

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -1773,11 +1773,11 @@ const FINDING_PROP_TYPES = {
 };
 
 // The subset findingItemSchema marks `required`. Deliberately NOT extended by this fix:
-// `required` is ONE flat list shared by every dimension's dispatch schema and by the verify
-// echo (which carries findings from all agents mixed together), so a field that is required
-// for one dimension — claude_md_rule for convention, spec_text for intent, criticality and
-// failure_scenario for test_coverage — cannot be marked required here without making it
-// required for all nine. Those stay contract-required/schema-optional, enforced by the agent
+// `required` is ONE flat list shared by every agent's dispatch schema (all nine dimensions —
+// a multi-dimension agent's findings arrive mixed in one dispatch), so a field that is
+// required for one dimension — claude_md_rule for convention, spec_text for intent,
+// criticality and failure_scenario for test_coverage — cannot be marked required here
+// without making it required for all nine. Those stay contract-required/schema-optional, enforced by the agent
 // .md prose, the same bucket hidden_errors and invalid_state_example already sit in. Adding a
 // per-dimension `requiredExtra` mechanism is tracked separately; do not fake it by appending
 // a single-dimension field to this array.
@@ -1785,9 +1785,11 @@ const FINDING_REQUIRED = ['id', 'file', 'line_start', 'title', 'description', 's
 
 // `schemaExtra` declares the per-dimension finding fields BEYOND the canonical schema above —
 // the extras each agent's .md output contract actually emits (findingItemSchema in stages.js
-// unions them onto that agent's discovery item schema, and the verify echo item schema unions
-// them ALL). Each row MUST match its contract (agents/<agent>.md output block) or the executor
-// drops the field when transcribing findings "verbatim via the schema": bug -> hidden_errors,
+// unions them onto that agent's discovery item schema — the only boundary that carries finding
+// items by value; the verify executor echoes per-id deltas, never findings). Each row MUST
+// match its contract (agents/<agent>.md output block): the item schema is CLOSED
+// (`additionalProperties: false`), so an extra a contract instructs but no row declares is
+// rejected at dispatch and costs a schema retry: bug -> hidden_errors,
 // security -> attack_vector, cross_file_impact -> affected_consumers (ARRAY), intent ->
 // spec_text, test_coverage -> criticality (NUMBER, a 1-10 impact scale distinct from
 // confidence's 0-100 certainty) + failure_scenario, type_design -> invalid_state_example,
@@ -2764,11 +2766,23 @@ function agentActive(spec, agentFlags) {
 // descriptions for every downstream stage (validate/filter/challenge) and false-firing the
 // filter's short-description injection guard on high-confidence findings.
 //
-// An UNDECLARED property is dropped by the same mechanism, silently and by design — which is
-// why FINDING_PROP_TYPES and every dimension's `schemaExtra` live together in registry.js and
-// are pinned against the agent .md output contracts by tests/test_dimensions_registry.py
-// (issue #47: `suggestion`/`claude_md_rule`/`spec_text`/`criticality`/`failure_scenario` were
-// instructed by the contracts, declared by nothing, and dropped at this boundary on every run).
+// An UNDECLARED property is REJECTED at dispatch, not silently dropped: `additionalProperties:
+// false` makes a field no one declared a schema violation the platform retries, rather than
+// pass-through tolerated at random (issue #53 watched one undeclared field survive 0/8, then
+// 8/8, then 5/5 across three PRs of a single smoke — permitted, never a contract). Closing the
+// item schema is safe because the declaration is complete and STAYS complete: every field an
+// agent contract instructs is one entry in FINDING_PROP_TYPES or a dimension's `schemaExtra` in
+// registry.js, and tests/test_dimensions_registry.py fails the build when the declared set
+// drifts from what the .md contracts instruct (declared − instructed == {origin}), so the
+// closed schema cannot reject a field a contract asks for (issue #47: `suggestion`/
+// `claude_md_rule`/`spec_text`/`criticality`/`failure_scenario` were instructed by the
+// contracts, declared by nothing, and dropped at this boundary on every run). The blast radius
+// is ONE boundary — this item schema reaches only the per-agent discovery dispatch
+// (findingSchema below); verify echoes per-id deltas, validate per-id confidence adjustments,
+// challenge a score, none of them finding items. `agent`, the one field whose undeclared
+// survival ever mattered (the filter's cross-agent dedup keyed on it), is not emitted by
+// discovery at all: discover() stamps it in code after StructuredOutput returns and
+// joinVerifyDeltas deletes it — both deterministic.
 // Entries are EITHER a type-name shorthand string ({ k: 'string' } -> { type:'string' }) OR a
 // full JSON-Schema fragment used verbatim (how array-valued fields like cross_file_refs and
 // affected_consumers are declared); the shorthand keeps the common case terse while the
@@ -2780,7 +2794,7 @@ function findingItemSchema(schemaExtra) {
   for (const [k, t] of Object.entries({ ...FINDING_PROP_TYPES, ...(schemaExtra || {}) })) {
     props[k] = typeof t === 'string' ? { type: t } : t;
   }
-  return { type: 'object', properties: props, required: FINDING_REQUIRED };
+  return { type: 'object', properties: props, required: FINDING_REQUIRED, additionalProperties: false };
 }
 
 // Canonical finding schema (per-dimension schemaExtra unioned on top), wrapped in the
@@ -3577,10 +3591,10 @@ function verifySliceWriterPrompt(entries) {
 // verify_findings.py's build_deltas() emits exactly this shape in exactly this order.
 //
 // The rebuild therefore also makes the proof BLIND to any key outside DELTA_KEYS. That is
-// deliberate and not a hole: an undeclared key does not survive StructuredOutput, and
-// joinVerifyDeltas copies only DELTA_VALUE_KEYS, so a key the proof ignores is a key
-// nothing reads. Covering it would buy no protection and would cost the order- and
-// noise-tolerance that keeps a harmless echo quirk from degrading a slice.
+// deliberate and not a hole: joinVerifyDeltas copies only DELTA_VALUE_KEYS, so a key the
+// proof ignores is a key nothing reads — and VERIFY_SCHEMA is deliberately OPEN, so an
+// undeclared key genuinely can arrive. Covering it would buy no protection and would cost
+// the order- and noise-tolerance that keeps a harmless echo quirk from degrading a slice.
 function canonicalDeltas(ids, byId) {
   return ids.map((id) => {
     const src = byId.get(id) || {};

--- a/workflows/src/registry.js
+++ b/workflows/src/registry.js
@@ -66,11 +66,11 @@ export const FINDING_PROP_TYPES = {
 };
 
 // The subset findingItemSchema marks `required`. Deliberately NOT extended by this fix:
-// `required` is ONE flat list shared by every dimension's dispatch schema and by the verify
-// echo (which carries findings from all agents mixed together), so a field that is required
-// for one dimension — claude_md_rule for convention, spec_text for intent, criticality and
-// failure_scenario for test_coverage — cannot be marked required here without making it
-// required for all nine. Those stay contract-required/schema-optional, enforced by the agent
+// `required` is ONE flat list shared by every agent's dispatch schema (all nine dimensions —
+// a multi-dimension agent's findings arrive mixed in one dispatch), so a field that is
+// required for one dimension — claude_md_rule for convention, spec_text for intent,
+// criticality and failure_scenario for test_coverage — cannot be marked required here
+// without making it required for all nine. Those stay contract-required/schema-optional, enforced by the agent
 // .md prose, the same bucket hidden_errors and invalid_state_example already sit in. Adding a
 // per-dimension `requiredExtra` mechanism is tracked separately; do not fake it by appending
 // a single-dimension field to this array.
@@ -78,9 +78,11 @@ export const FINDING_REQUIRED = ['id', 'file', 'line_start', 'title', 'descripti
 
 // `schemaExtra` declares the per-dimension finding fields BEYOND the canonical schema above —
 // the extras each agent's .md output contract actually emits (findingItemSchema in stages.js
-// unions them onto that agent's discovery item schema, and the verify echo item schema unions
-// them ALL). Each row MUST match its contract (agents/<agent>.md output block) or the executor
-// drops the field when transcribing findings "verbatim via the schema": bug -> hidden_errors,
+// unions them onto that agent's discovery item schema — the only boundary that carries finding
+// items by value; the verify executor echoes per-id deltas, never findings). Each row MUST
+// match its contract (agents/<agent>.md output block): the item schema is CLOSED
+// (`additionalProperties: false`), so an extra a contract instructs but no row declares is
+// rejected at dispatch and costs a schema retry: bug -> hidden_errors,
 // security -> attack_vector, cross_file_impact -> affected_consumers (ARRAY), intent ->
 // spec_text, test_coverage -> criticality (NUMBER, a 1-10 impact scale distinct from
 // confidence's 0-100 certainty) + failure_scenario, type_design -> invalid_state_example,

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -300,11 +300,23 @@ export function agentActive(spec, agentFlags) {
 // descriptions for every downstream stage (validate/filter/challenge) and false-firing the
 // filter's short-description injection guard on high-confidence findings.
 //
-// An UNDECLARED property is dropped by the same mechanism, silently and by design — which is
-// why FINDING_PROP_TYPES and every dimension's `schemaExtra` live together in registry.js and
-// are pinned against the agent .md output contracts by tests/test_dimensions_registry.py
-// (issue #47: `suggestion`/`claude_md_rule`/`spec_text`/`criticality`/`failure_scenario` were
-// instructed by the contracts, declared by nothing, and dropped at this boundary on every run).
+// An UNDECLARED property is REJECTED at dispatch, not silently dropped: `additionalProperties:
+// false` makes a field no one declared a schema violation the platform retries, rather than
+// pass-through tolerated at random (issue #53 watched one undeclared field survive 0/8, then
+// 8/8, then 5/5 across three PRs of a single smoke — permitted, never a contract). Closing the
+// item schema is safe because the declaration is complete and STAYS complete: every field an
+// agent contract instructs is one entry in FINDING_PROP_TYPES or a dimension's `schemaExtra` in
+// registry.js, and tests/test_dimensions_registry.py fails the build when the declared set
+// drifts from what the .md contracts instruct (declared − instructed == {origin}), so the
+// closed schema cannot reject a field a contract asks for (issue #47: `suggestion`/
+// `claude_md_rule`/`spec_text`/`criticality`/`failure_scenario` were instructed by the
+// contracts, declared by nothing, and dropped at this boundary on every run). The blast radius
+// is ONE boundary — this item schema reaches only the per-agent discovery dispatch
+// (findingSchema below); verify echoes per-id deltas, validate per-id confidence adjustments,
+// challenge a score, none of them finding items. `agent`, the one field whose undeclared
+// survival ever mattered (the filter's cross-agent dedup keyed on it), is not emitted by
+// discovery at all: discover() stamps it in code after StructuredOutput returns and
+// joinVerifyDeltas deletes it — both deterministic.
 // Entries are EITHER a type-name shorthand string ({ k: 'string' } -> { type:'string' }) OR a
 // full JSON-Schema fragment used verbatim (how array-valued fields like cross_file_refs and
 // affected_consumers are declared); the shorthand keeps the common case terse while the
@@ -316,7 +328,7 @@ function findingItemSchema(schemaExtra) {
   for (const [k, t] of Object.entries({ ...FINDING_PROP_TYPES, ...(schemaExtra || {}) })) {
     props[k] = typeof t === 'string' ? { type: t } : t;
   }
-  return { type: 'object', properties: props, required: FINDING_REQUIRED };
+  return { type: 'object', properties: props, required: FINDING_REQUIRED, additionalProperties: false };
 }
 
 // Canonical finding schema (per-dimension schemaExtra unioned on top), wrapped in the
@@ -1113,10 +1125,10 @@ function verifySliceWriterPrompt(entries) {
 // verify_findings.py's build_deltas() emits exactly this shape in exactly this order.
 //
 // The rebuild therefore also makes the proof BLIND to any key outside DELTA_KEYS. That is
-// deliberate and not a hole: an undeclared key does not survive StructuredOutput, and
-// joinVerifyDeltas copies only DELTA_VALUE_KEYS, so a key the proof ignores is a key
-// nothing reads. Covering it would buy no protection and would cost the order- and
-// noise-tolerance that keeps a harmless echo quirk from degrading a slice.
+// deliberate and not a hole: joinVerifyDeltas copies only DELTA_VALUE_KEYS, so a key the
+// proof ignores is a key nothing reads — and VERIFY_SCHEMA is deliberately OPEN, so an
+// undeclared key genuinely can arrive. Covering it would buy no protection and would cost
+// the order- and noise-tolerance that keeps a harmless echo quirk from degrading a slice.
 function canonicalDeltas(ids, byId) {
   return ids.map((id) => {
     const src = byId.get(id) || {};

--- a/workflows/test/finding_schema.test.js
+++ b/workflows/test/finding_schema.test.js
@@ -92,15 +92,51 @@ test('every declared field reaches the dispatch with the registry-declared type'
 
 test('required is the flat FINDING_REQUIRED — no per-dimension extra sneaks into it', async () => {
   const schemas = await discoverySchemas();
-  // A field required for ONE dimension cannot be marked required here: `required` is shared
-  // by every dispatch AND by the verify echo, which carries all agents' findings mixed
-  // together, so marking (say) criticality required would reject every non-test finding.
+  // A field required for ONE dimension cannot be marked required here: `required` is the one
+  // flat list shared by every agent's dispatch schema, so marking (say) criticality required
+  // would reject every non-test finding at its own dispatch.
   const extras = new Set(DIMENSIONS.flatMap((d) => Object.keys(d.schemaExtra || {})));
   for (const spec of agentSpecs()) {
     const { required } = schemas[spec.agentType].properties.findings.items;
     assert.deepEqual(required, FINDING_REQUIRED, `${spec.agentType}: required list drifted`);
     for (const field of required) {
       assert.ok(!extras.has(field), `${field} is a per-dimension extra and must not be required`);
+    }
+  }
+});
+
+test('every discovery dispatch closes the finding item schema to undeclared fields', async () => {
+  // Issue #53 requirement 3. Before this, an undeclared property was permitted-but-unenforced
+  // pass-through: the same field survived 0/8, 8/8 and 5/5 across three PRs of one smoke.
+  // `additionalProperties: false` replaces that coin flip with a rejection the platform retries.
+  const schemas = await discoverySchemas();
+  for (const spec of agentSpecs()) {
+    assert.equal(
+      schemas[spec.agentType].properties.findings.items.additionalProperties,
+      false,
+      `${spec.agentType}: the finding item schema must be closed to undeclared fields`,
+    );
+  }
+});
+
+test('a CLOSED item schema declares every field it requires — no unsatisfiable schema', async () => {
+  // `required` and `additionalProperties: false` are only safe TOGETHER. A required name that
+  // `properties` does not declare is satisfiable while the schema is open (the value arrives as
+  // an additional property) and UNSATISFIABLE once it is closed — every finding an agent emits
+  // violates the schema, the platform retries to the cap, and the dimension degrades. Nothing
+  // else in this file pins required ⊆ properties, and the first test's derived-set equality
+  // cannot: it compares properties against the registry, never against FINDING_REQUIRED. Both
+  // legs are asserted here, on the same schema object, so the pair cannot drift apart.
+  const schemas = await discoverySchemas();
+  for (const spec of agentSpecs()) {
+    const items = schemas[spec.agentType].properties.findings.items;
+    assert.equal(items.additionalProperties, false, `${spec.agentType}: item schema is not closed`);
+    for (const field of items.required) {
+      assert.ok(
+        field in items.properties,
+        `${spec.agentType}: required "${field}" is not declared in properties — a CLOSED schema ` +
+          'that requires an undeclared field can never be satisfied',
+      );
     }
   }
 });


### PR DESCRIPTION
Closes #53 (scoped by roadmap #101 to **requirement 3 only** — requirements 1/2 were resolved structurally by the harness-return persist architecture and their durable remainder is scoped under #50(b); requirement 4's retry-once floor is untouched by this diff).

## Decision (requirement 3): close the schema

`findingItemSchema()` now declares `additionalProperties: false`, so a discovery agent emitting a field no one declared is rejected by the platform's schema validator instead of passing through when it happens to feel like it. Issue #53 watched the same undeclared field survive 0/8, then 8/8, then 5/5 across three PRs of a single smoke — permitted-but-unenforced pass-through, never a contract.

Closing is safe now, and was not before:

- **The lockstep guarantee exists.** `FINDING_PROP_TYPES` + `FINDING_REQUIRED` + per-dimension `schemaExtra` all live in `workflows/src/registry.js`, and `tests/test_dimensions_registry.py` fails the build when the declared set drifts from what the agent .md contracts instruct (declared − instructed == {origin}). A closed schema therefore cannot reject a contract-instructed field.
- **The recall-sensitive dependency is gone.** The old hazard was `agent`: the filter's cross-agent dedup (`filterFindings.dedupCrossAgent`, re-run by `applyChallenges`) keyed on it, and it rode a verify echo that transcribed findings by value. Since PR #83 the verify executor returns per-id DELTAS — findings are rebuilt from the dispatched set at the join and `agent` is deleted there deterministically. Discovery agents never emit `agent` at all; it is stamped in code after StructuredOutput returns.
- **One boundary.** `findingItemSchema` feeds only the per-agent discovery dispatch (`findingSchema`). VALIDATE_SCHEMA returns per-id confidence adjustments, CHALLENGE_SCHEMA a score, VERIFY_SCHEMA a receipt plus deltas — none carries finding items. VERIFY_SCHEMA's receipt stays deliberately open for forward-compat and is untouched.

This is the mechanism instead of the instruction: undeclared-field emission becomes structurally impossible rather than stochastically tolerated.

Also corrects the comments that recorded the superseded truth: three stale pre-#83 clauses in `registry.js` ("the verify echo item schema unions them ALL"; "the executor drops the field when transcribing findings verbatim via the schema"; the FINDING_REQUIRED note's justification-by-verify-echo, echoed in a `finding_schema.test.js` comment), a false premise in `stages.js` `canonicalDeltas` ("an undeclared key does not survive StructuredOutput" — VERIFY_SCHEMA is deliberately open, so it can; the paragraph stands on `DELTA_VALUE_KEYS` alone), and three places in `tests/test_dimensions_registry.py` that told whoever trips the lockstep guard the undeclared field would be silently dropped. It is now rejected at dispatch.

## Tests

Two new pins in `workflows/test/finding_schema.test.js`:

- every discovery dispatch's item schema has `additionalProperties === false`
- a CLOSED schema declares every field it requires — `required ⊆ properties` was pinned nowhere, and a required-but-undeclared name is satisfiable while the schema is open and UNSATISFIABLE once it is closed (every emission would violate the schema and degrade the dimension)

**Mutation catalogue (all red):** removing `additionalProperties` fails the first; flipping it to `true` fails the first; adding a name to `FINDING_REQUIRED` that no property declares fails only the second.

## Verification

All gates green on this branch: JS 659/659 with coverage 98.71 / 84.07 / 98.18 vs floors 98 / 83.3 / 97.2 plus the presence check; `pytest tests/` 1280 passed @ 92.86% (floor 91.8); `bench/tests/` 537 passed @ 88.35% (floor 87); bundle byte-identical to a fresh build; `pre-commit run --all-files` green. Measurement note: JS branch coverage reads 84.07 vs main's last CI 84.23 — comment-shape churn, still 0.77 pp above the 83.3 floor, so no floor change is owed under the policy.

## Known risk → Smoke A watch item

`additionalProperties: false` is the FIRST use of a closed object in any dispatched schema in this repo, and the item schema pairs it with a PARTIAL required list (`FINDING_REQUIRED` is 8 of ~14 properties). Under a strict structured-output validator of the OpenAI kind — which rejects a closed schema that does not list every property in `required` — the failure would not be the extra retry it looks like: all seven discovery dispatches would fail schema validation before dispatch, every agent would return null, and `discover()` would degrade all nine dimensions. Suites cannot exercise the live platform validator, so this ships suites-only per roadmap #101 with the Smoke A watch item stated at that stake: **ALL SEVEN DISCOVERY AGENTS DISPATCH SUCCESSFULLY — zero null agents, zero degraded dimensions.** A wholesale discovery failure is the thing being watched for, not merely extra schema retries.

## Coordination (roadmap #101 Wave 3)

Lands alongside the sibling branch for #75 (`fix/75-verify-command-quoting`). Both edit `workflows/src/stages.js` but in different functions — #75 in `verifyCommand`/`assemblePrompt`, this PR in `findingItemSchema`/`canonicalDeltas` — and every other source file is single-owner; the generated `workflows/pipeline.js` bundle is the only shared surface. A trial merge of both final heads onto main is clean: 666/666 JS tests, 1280 pytest, and the merged bundle is byte-identical to a fresh `node workflows/build.js`. Suggested order: #75 first, then this PR. **After rebasing onto the merged #75: re-run `node workflows/build.js` and commit the regenerated bundle rather than trusting the textual auto-merge of `pipeline.js`, and re-run `pytest tests/ -q` — #75 edits `agents/executor.md` while this PR tightens `tests/test_dimensions_registry.py`'s contract scan (combined tree measured green here; re-verify after rebase).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PiWyAeUdUpC8X9DTYjV9ti

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> First closed object schema in dispatched workflows pairs partial `required` with `additionalProperties: false`; if the live validator is stricter than tests assume, all discovery agents could fail before dispatch (called out in the PR as Smoke A watch).
> 
> **Overview**
> Closes **#53 requirement 3** by making discovery finding items a **closed JSON Schema**: `findingItemSchema()` in `workflows/src/stages.js` (and the bundled `pipeline.js` / `registry.js` comments) now sets **`additionalProperties: false`**, so extra fields from agents are **schema violations** (retries / possible dimension failure) instead of silently passing through StructuredOutput.
> 
> **Docs and comments** across `REVIEW.md`, `agents/AGENTS.md`, `report-format.md`, and `tests/test_dimensions_registry.py` now describe **rejection at dispatch** rather than silent drops. Stale notes about verify echo unioning finding schemas or undeclared keys being stripped by StructuredOutput are corrected (verify uses **open** delta schemas; discovery is the only finding-by-value boundary).
> 
> **Tests** add pins in `workflows/test/finding_schema.test.js`: every discovery dispatch has `additionalProperties === false`, and **`required` ⊆ `properties`** so a closed schema cannot require undeclared names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e205731c5a5034d0c5f458621c9815f22b44e0f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->