### PR TITLE
feat(report): generate the Review Dimensions Summary table in code (#89)

### DIFF
--- a/agents/report-writer.md
+++ b/agents/report-writer.md
@@ -16,12 +16,15 @@ you do NOT write files (a separate writer persists artifacts).
 ## Input
 
 The dispatch prompt carries a results JSON object by value:
-`{ summary, findings, unverified, stats }`.
+`{ summary, findings, unverified, stats, dimensionsTable }`.
 
 - `summary` — the semantic change summary.
 - `findings` — the high-confidence bucket (survived verification + blind challenge).
 - `unverified` — the pipeline-degraded bucket (skipped or failed a stage; lower trust).
 - `stats` — per-stage counts.
+- `dimensionsTable` — the complete, pre-rendered Review Dimensions Summary markdown
+  table (computed in code from pipeline stats). Present on segment 0 only — absent on
+  every later segment of a multi-segment report.
 
 Each finding carries the canonical fields (`severity`, `title`, `file`, `line_start`,
 `description`, plus optionally `suggestion` and `claude_md_rule`) and, for intent
@@ -40,11 +43,16 @@ Everything you need is in that object — there is no shared context file to rea
    (`suggestion`). When a finding carries a cited rule (`claude_md_rule`) or contradicted
    spec text (`spec_text`), render that too. These trailing fields are OPTIONAL on a
    finding — render them only when present, never invent or back-fill them (consistent
-   with step 4's "do not invent" rule).
+   with step 5's "do not invent" rule).
 3. **Unverified / pipeline-degraded** — a clearly-labelled secondary section for
    the `unverified` bucket. State plainly that these did not clear the full
    pipeline and carry lower confidence. Never present them as confirmed.
-4. Do not invent findings, severities, or locations not present in the input.
+4. **Review Dimensions Summary** — when `dimensionsTable` is present, place it
+   **verbatim**, unmodified, as the `## Review Dimensions Summary` section (after the
+   main and unverified sections). Never edit, reorder, reclassify, or regenerate its
+   rows — it is pre-computed from pipeline stats, not something you assess. Omit the
+   section entirely when the field is absent (every segment after segment 0).
+5. Do not invent findings, severities, or locations not present in the input.
 
 ## Output
 

--- a/skills/code-gauntlet/references/report-format.md
+++ b/skills/code-gauntlet/references/report-format.md
@@ -212,17 +212,14 @@ Severity has been downgraded one level from the original classification (see the
 
 ## Review Dimensions Summary
 
-{Brief per-dimension summary showing what each agent found or confirmed was clean.}
+This table is generated in code by `dimensionsSummaryTable()` in `workflows/src/stages.js`
+and delivered to you pre-rendered, as the `dimensionsTable` field of the dispatch input.
+Paste it here **verbatim, unmodified** — never reconstruct, reclassify, or edit its rows.
+(The same treatment the footer/marker gets from `scripts/post_review.py`: the code owns
+the content, you place it.) Column reference:
 
 | Dimension | Agent | Findings | Notes |
 |-----------|-------|----------|-------|
-| Correctness & Error Handling | bug-detector | {N issues} | {summary or "Clean"} |
-| Security | security-reviewer | {N issues} | {summary} |
-| Cross-file Impact | cross-file-impact | {N issues} | {summary} |
-| Test Coverage | test-analyzer | {N issues} | {summary} |
-| Conventions & Intent | conventions-and-intent | {N issues} | {summary} |
-| Type Design | type-design-analyzer | {N issues or "Skipped"} | {summary} |
-| Code Simplification | code-simplifier | {N issues or "Skipped"} | {summary} |
 
 ## Review Methodology
 

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -1827,6 +1827,27 @@ const DIMENSIONS = [
 
 const AGENTS = [...new Set(DIMENSIONS.map((d) => d.agentType))];
 
+// Per-agent display label for the Review Dimensions Summary table (issue #89):
+// dimensionsSummaryTable (stages.js) renders ONE row per discovery agent — a
+// multi-dimension agent (conventions-and-intent) gets a single label for its whole
+// aggregated row, not one per dimension — so this is keyed by agentType directly
+// rather than living on DIMENSIONS rows, which would force every one of a
+// multi-dimension agent's rows to repeat the identical value (the trap promptExtra's
+// comment above already documents for a genuinely per-agent value). This map is the
+// single source of truth for the display strings — report-format.md's template
+// deliberately no longer lists them, it tells Phase 8 to paste the rendered table
+// verbatim. Extending: one
+// entry here when AGENTS gains a member — registry.test.js pins the key set to AGENTS.
+const AGENT_LABELS = {
+  'code-gauntlet:bug-detector': 'Correctness & Error Handling',
+  'code-gauntlet:security-reviewer': 'Security',
+  'code-gauntlet:cross-file-impact': 'Cross-file Impact',
+  'code-gauntlet:test-analyzer': 'Test Coverage',
+  'code-gauntlet:conventions-and-intent': 'Conventions & Intent',
+  'code-gauntlet:type-design-analyzer': 'Type Design',
+  'code-gauntlet:code-simplifier': 'Code Simplification',
+};
+
 // The stage agents' models, restating each one's `model:` frontmatter explicitly so a
 // dispatch pins a full model ID instead of inheriting the session variant (see MODEL_IDS
 // below). No entry currently deviates from its frontmatter, and all five match
@@ -4297,6 +4318,113 @@ function selectDelivery(survivors, cap, tier) {
 
 const REPORT_SCHEMA = { type: 'object', properties: { report: { type: 'string' } }, required: ['report'] };
 
+// dimensionsSummaryTable({ dispatched, degraded, findings, unverified }) -> markdown string
+//
+// Computes the Review Dimensions Summary table (report-format.md) in CODE, as a pure
+// function of pipeline stats, instead of asking the Phase 8 model to classify each
+// dimension itself (issue #89). Before this, the table was never rendered at all:
+// reportPrompt never asked for it and reportInput never carried discoverOut.degraded /
+// discoverOut.dispatched. One row per DISCOVERY AGENT (registry AGENTS order), not per
+// dimension — a multi-dimension agent (conventions-and-intent) aggregates all of its
+// dimensions' findings into one row. Output starts at the header row (no leading
+// `## Review Dimensions Summary` heading) — heading placement is the caller's concern.
+//
+// Row classification (N = high-confidence finding count for the agent, M = unverified
+// count, evaluated in this fixed priority order so at most one rule ever fires):
+//   1. not dispatched (scope-skipped, e.g. light-scope agentFlags.deep=false) -> Skipped
+//   2. degraded (one of its dimensions is in `degraded`) with N+M==0 -> agent never
+//      returned usable coverage
+//   3. degraded with N+M>0 -> partial coverage
+//   4. dispatched, not degraded, N+M==0 -> clean run, genuinely zero findings
+//   5. N>0, not degraded -> the normal case; Notes carries a severity breakdown
+//   6. N==0, M>0, not degraded -> every finding this agent produced was routed to the
+//      unverified/pipeline-degraded bucket
+//
+// SEVERITY_ORDER is imported from filterFindings.js (its single owner, per that file's
+// own note — a second top-level declaration collides at bundle time).
+
+// Findings with a missing/unknown `dimension` are silently excluded from every row's
+// count: the discovery contracts pin `dimension` to one of the nine registry names, so
+// an unmapped value here is belt-and-braces, never a live path.
+function dimensionOwnerMap() {
+  const owner = {};
+  for (const d of DIMENSIONS) owner[d.dimension] = d.agentType;
+  return owner;
+}
+
+// "2 high, 1 low" — counted over the agent's HIGH-CONFIDENCE findings only, in a fixed
+// severity order (critical, high, medium, low first; any other value the schema does not
+// forbid — `severity` is declared `string`, not an enum — trails in first-seen order so
+// no finding is silently dropped from the count). Empty string when no finding in the row
+// carries a severity value at all.
+function severityBreakdown(rowFindings) {
+  const counts = new Map();
+  for (const f of rowFindings) {
+    if (!f || !f.severity) continue;
+    counts.set(f.severity, (counts.get(f.severity) || 0) + 1);
+  }
+  if (counts.size === 0) return '';
+  const known = SEVERITY_ORDER.filter((s) => counts.has(s));
+  const rest = [...counts.keys()].filter((s) => !SEVERITY_ORDER.includes(s));
+  return [...known, ...rest].map((s) => `${counts.get(s)} ${s}`).join(', ');
+}
+
+function dimensionsSummaryTable(input) {
+  const inp = input || {};
+  const dispatchedSet = new Set(inp.dispatched || []);
+  const degradedSet = new Set(inp.degraded || []);
+  const owner = dimensionOwnerMap();
+
+  const byAgent = new Map(AGENTS.map((a) => [a, []]));
+  const unverifiedByAgent = new Map(AGENTS.map((a) => [a, []]));
+  for (const f of (inp.findings || [])) {
+    const agentType = owner[f && f.dimension];
+    if (agentType && byAgent.has(agentType)) byAgent.get(agentType).push(f);
+  }
+  for (const f of (inp.unverified || [])) {
+    const agentType = owner[f && f.dimension];
+    if (agentType && unverifiedByAgent.has(agentType)) unverifiedByAgent.get(agentType).push(f);
+  }
+
+  const rows = AGENTS.map((agentType) => {
+    const rowFindings = byAgent.get(agentType);
+    const rowUnverified = unverifiedByAgent.get(agentType);
+    const n = rowFindings.length;
+    const m = rowUnverified.length;
+    const dims = DIMENSIONS.filter((d) => d.agentType === agentType).map((d) => d.dimension);
+    const isDegraded = dims.some((d) => degradedSet.has(d));
+    const isDispatched = dispatchedSet.has(agentType);
+    const label = AGENT_LABELS[agentType] || agentType;
+    const agentShort = agentType.split(':').pop();
+
+    let findingsCell;
+    let notes;
+    if (!isDispatched) {
+      findingsCell = '—';
+      notes = 'Skipped — not dispatched in this run';
+    } else if (isDegraded && n + m === 0) {
+      findingsCell = '—';
+      notes = 'No results — agent did not complete';
+    } else if (isDegraded) {
+      findingsCell = m > 0 ? `${n} (+${m} unverified)` : `${n}`;
+      notes = 'Partial — agent may not have completed';
+    } else if (n + m === 0) {
+      findingsCell = '0';
+      notes = 'Clean — no findings returned';
+    } else if (n > 0) {
+      findingsCell = m > 0 ? `${n} (+${m} unverified)` : `${n}`;
+      notes = severityBreakdown(rowFindings);
+    } else {
+      findingsCell = `0 (+${m} unverified)`;
+      notes = 'Unverified findings only — see secondary section';
+    }
+
+    return `| ${label} | ${agentShort} | ${findingsCell} | ${notes} |`;
+  });
+
+  return ['| Dimension | Agent | Findings | Notes |', '|-----------|-------|----------|-------|', ...rows].join('\n');
+}
+
 // reportStage(ctx, input) -> { report, gaps }
 // Dispatches the report-writer agent to render the review markdown from the
 // high-confidence + unverified buckets (carried BY VALUE in the prompt — the
@@ -4322,22 +4450,30 @@ async function reportStage(ctx, input) {
   const model = modelFor('code-gauntlet:report-writer', policy);
 
   const findings = inp.findings || [];
+  // Computed once over the WHOLE run (not per-chunk) so the table's counts are never
+  // scoped to one segment's slice of findings; threaded to segment 0 only (below).
+  const dimensionsTable = dimensionsSummaryTable({
+    ...(inp.dimensions || {}), findings, unverified: inp.unverified || [],
+  });
   const oversized = JSON.stringify(findings).length > PROMPT_SEGMENT_CHAR_BUDGET;
   if (!oversized) {
-    return dispatchReportSegment(c, model, inp, findings, null);
+    return dispatchReportSegment(c, model, inp, findings, null, dimensionsTable);
   }
 
   // Segment: one dispatch per chunk through parallel(), titled sections joined IN INDEX
   // ORDER. dispatchReportSegment already owns its try/catch and never throws, so no member
   // can be nulled by parallel(); the null branch below is defense-in-depth only.
   const chunks = chunkBySerializedSize(findings, PROMPT_SEGMENT_CHAR_BUDGET);
-  const thunks = chunks.map((chunk, i) => () => dispatchReportSegment(c, model, inp, chunk, { index: i, total: chunks.length }));
+  const thunks = chunks.map((chunk, i) => () => dispatchReportSegment(c, model, inp, chunk, { index: i, total: chunks.length }, dimensionsTable));
   const results = await c.parallel(thunks);
   const parts = [];
   const gaps = [];
   for (let i = 0; i < chunks.length; i += 1) {
     const out = results[i] || {
-      report: minimalReport({ ...inp, findings: chunks[i] }),
+      // Table belongs to segment 0 only, same as the dispatchReportSegment path below —
+      // this null-isolated fallback is defense-in-depth and must honor the same rule so
+      // a member nulled by parallel() cannot duplicate the section into a later segment.
+      report: minimalReport({ ...inp, findings: chunks[i], dimensionsTable: i === 0 ? dimensionsTable : '' }),
       gaps: [`report segment ${i}: dispatch produced no result — assembled a minimal report from pipeline stats`],
     };
     parts.push(`## Report segment ${i + 1} of ${chunks.length}\n\n${out.report}`);
@@ -4348,10 +4484,13 @@ async function reportStage(ctx, input) {
 
 // One report-writer dispatch over `findings` (a whole set or one segment). Owns
 // the try/catch + minimal-section fallback. `seg` (or null) labels the dispatch
-// and tags the gap so a segmented failure is traceable to its chunk.
-async function dispatchReportSegment(c, model, inp, findings, seg) {
+// and tags the gap so a segmented failure is traceable to its chunk. `dimensionsTable`
+// is scoped to segment 0 (or the unsegmented dispatch) here — every downstream read of
+// `segInp.dimensionsTable` (reportPrompt, minimalReport) is a plain truthiness check
+// with no segment-awareness of its own, so the section can never render twice.
+async function dispatchReportSegment(c, model, inp, findings, seg, dimensionsTable) {
   const tag = seg ? ` segment ${seg.index}` : '';
-  const segInp = { ...inp, findings };
+  const segInp = { ...inp, findings, dimensionsTable: (!seg || seg.index === 0) ? dimensionsTable : '' };
   try {
     const result = await c.agent(reportPrompt(segInp, seg), {
       label: seg ? `report-writer-${seg.index}` : 'report-writer',
@@ -4432,6 +4571,10 @@ function minimalReport(inp) {
       lines.push(`- [${(f.severity || 'unknown').toUpperCase()}] ${f.title || f.id || 'finding'} (${f.file || '?'}:${f.line_start != null ? f.line_start : '?'})`);
     }
   }
+  // Present only when the caller scoped it in (segment 0 / unsegmented dispatch — see
+  // dispatchReportSegment) — this fallback survives even when the Phase 8 model itself
+  // never ran, so the table is never lost to a report-writer outage.
+  if (inp.dimensionsTable) lines.push('', '## Review Dimensions Summary', '', inp.dimensionsTable);
   return lines.join('\n');
 }
 
@@ -4448,8 +4591,17 @@ function reportPrompt(inp, seg) {
     findings: inp.findings || [],
     unverified: (!seg || seg.index === 0) ? (inp.unverified || []) : [], // render the unverified bucket once, in segment 0
     stats: inp.stats || {},
+    // Pre-scoped to segment 0 by the caller (dispatchReportSegment) — '' on every later
+    // segment, so this is a plain truthiness check, not a second segment-index test.
+    ...(inp.dimensionsTable ? { dimensionsTable: inp.dimensionsTable } : {}),
   });
-  return `${segLine}Write the code-gauntlet report as markdown for these results. Put high-confidence findings in the main section and unverified/pipeline-degraded findings in a clearly-labelled secondary section. Results JSON:\n${body}\nReturn { report } where report is the full markdown document.`;
+  // Verbatim-paste instruction (issue #89): the table is generated in code, not
+  // classified by this model — pasting it unmodified is what removes the capability to
+  // get the classification wrong. Only present when dimensionsTable is (segment 0).
+  const dimensionsInstruction = inp.dimensionsTable
+    ? ' The `dimensionsTable` field is the complete, pre-rendered Review Dimensions Summary table — paste it verbatim, unmodified, as the "## Review Dimensions Summary" section; never reconstruct, reclassify, or edit its rows.'
+    : '';
+  return `${segLine}Write the code-gauntlet report as markdown for these results. Put high-confidence findings in the main section and unverified/pipeline-degraded findings in a clearly-labelled secondary section.${dimensionsInstruction} Results JSON:\n${body}\nReturn { report } where report is the full markdown document.`;
 }
 
 // --- Persistence: writeArtifacts --------------------------------------------
@@ -5879,6 +6031,12 @@ async function runWith(ctx, rawArgs) {
         filter: filterOut.stats,
         challenge: challengeOut.stats,
       },
+      // discover()'s own fan-out list and degraded-dimensions list (issue #89) — feeds
+      // dimensionsSummaryTable inside reportStage. `dispatched` already excludes any
+      // agent scope-gated out via agentFlags (agentSpecs().filter(agentActive) runs
+      // before discover() builds its spec list), so a light-scope run's skipped agents
+      // are absent from `dispatched`, not merely present-but-empty.
+      dimensions: { dispatched: discoverOut.dispatched || [], degraded: discoverOut.degraded || [] },
       // No context at all (issue #38, R1): the report-writer renders from the by-value
       // { summary, findings, unverified, stats } above and never needs the shared context
       // file. No stage is ever given contextPath; of the prebuilt contextLine, only

--- a/workflows/src/registry.js
+++ b/workflows/src/registry.js
@@ -120,6 +120,27 @@ export const DIMENSIONS = [
 
 export const AGENTS = [...new Set(DIMENSIONS.map((d) => d.agentType))];
 
+// Per-agent display label for the Review Dimensions Summary table (issue #89):
+// dimensionsSummaryTable (stages.js) renders ONE row per discovery agent — a
+// multi-dimension agent (conventions-and-intent) gets a single label for its whole
+// aggregated row, not one per dimension — so this is keyed by agentType directly
+// rather than living on DIMENSIONS rows, which would force every one of a
+// multi-dimension agent's rows to repeat the identical value (the trap promptExtra's
+// comment above already documents for a genuinely per-agent value). This map is the
+// single source of truth for the display strings — report-format.md's template
+// deliberately no longer lists them, it tells Phase 8 to paste the rendered table
+// verbatim. Extending: one
+// entry here when AGENTS gains a member — registry.test.js pins the key set to AGENTS.
+export const AGENT_LABELS = {
+  'code-gauntlet:bug-detector': 'Correctness & Error Handling',
+  'code-gauntlet:security-reviewer': 'Security',
+  'code-gauntlet:cross-file-impact': 'Cross-file Impact',
+  'code-gauntlet:test-analyzer': 'Test Coverage',
+  'code-gauntlet:conventions-and-intent': 'Conventions & Intent',
+  'code-gauntlet:type-design-analyzer': 'Type Design',
+  'code-gauntlet:code-simplifier': 'Code Simplification',
+};
+
 // The stage agents' models, restating each one's `model:` frontmatter explicitly so a
 // dispatch pins a full model ID instead of inheriting the session variant (see MODEL_IDS
 // below). No entry currently deviates from its frontmatter, and all five match

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -16,10 +16,10 @@
 // bucket members without per-bucket gaps, and emits one generic gap if no partial
 // survives, the merge or single-call result is null, or any summarize dispatch throws.
 // No wall-clock, no import at runtime.
-import { DIMENSIONS, AGENTS, resolvePolicy, FINDING_PROP_TYPES, FINDING_REQUIRED } from './registry.js';
+import { DIMENSIONS, AGENTS, AGENT_LABELS, resolvePolicy, FINDING_PROP_TYPES, FINDING_REQUIRED } from './registry.js';
 import { merge } from './mergeFindings.js';
 import { applyValidations, pyIntStrict } from './applyValidations.js';
-import { applyFilterPipeline } from './filterFindings.js';
+import { applyFilterPipeline, SEVERITY_ORDER } from './filterFindings.js';
 import { applyChallenges, rankFindings, deepClone } from './applyChallenges.js';
 import { normalizeArgsReport, nullToleranceGap, nullToleranceRejectedKeys, validateArgs, entryArgs, makeArgsRejectEnvelope, SKILL_RECOVERY_LINE } from './args.js';
 
@@ -1791,6 +1791,113 @@ export function selectDelivery(survivors, cap, tier) {
 
 const REPORT_SCHEMA = { type: 'object', properties: { report: { type: 'string' } }, required: ['report'] };
 
+// dimensionsSummaryTable({ dispatched, degraded, findings, unverified }) -> markdown string
+//
+// Computes the Review Dimensions Summary table (report-format.md) in CODE, as a pure
+// function of pipeline stats, instead of asking the Phase 8 model to classify each
+// dimension itself (issue #89). Before this, the table was never rendered at all:
+// reportPrompt never asked for it and reportInput never carried discoverOut.degraded /
+// discoverOut.dispatched. One row per DISCOVERY AGENT (registry AGENTS order), not per
+// dimension — a multi-dimension agent (conventions-and-intent) aggregates all of its
+// dimensions' findings into one row. Output starts at the header row (no leading
+// `## Review Dimensions Summary` heading) — heading placement is the caller's concern.
+//
+// Row classification (N = high-confidence finding count for the agent, M = unverified
+// count, evaluated in this fixed priority order so at most one rule ever fires):
+//   1. not dispatched (scope-skipped, e.g. light-scope agentFlags.deep=false) -> Skipped
+//   2. degraded (one of its dimensions is in `degraded`) with N+M==0 -> agent never
+//      returned usable coverage
+//   3. degraded with N+M>0 -> partial coverage
+//   4. dispatched, not degraded, N+M==0 -> clean run, genuinely zero findings
+//   5. N>0, not degraded -> the normal case; Notes carries a severity breakdown
+//   6. N==0, M>0, not degraded -> every finding this agent produced was routed to the
+//      unverified/pipeline-degraded bucket
+//
+// SEVERITY_ORDER is imported from filterFindings.js (its single owner, per that file's
+// own note — a second top-level declaration collides at bundle time).
+
+// Findings with a missing/unknown `dimension` are silently excluded from every row's
+// count: the discovery contracts pin `dimension` to one of the nine registry names, so
+// an unmapped value here is belt-and-braces, never a live path.
+function dimensionOwnerMap() {
+  const owner = {};
+  for (const d of DIMENSIONS) owner[d.dimension] = d.agentType;
+  return owner;
+}
+
+// "2 high, 1 low" — counted over the agent's HIGH-CONFIDENCE findings only, in a fixed
+// severity order (critical, high, medium, low first; any other value the schema does not
+// forbid — `severity` is declared `string`, not an enum — trails in first-seen order so
+// no finding is silently dropped from the count). Empty string when no finding in the row
+// carries a severity value at all.
+function severityBreakdown(rowFindings) {
+  const counts = new Map();
+  for (const f of rowFindings) {
+    if (!f || !f.severity) continue;
+    counts.set(f.severity, (counts.get(f.severity) || 0) + 1);
+  }
+  if (counts.size === 0) return '';
+  const known = SEVERITY_ORDER.filter((s) => counts.has(s));
+  const rest = [...counts.keys()].filter((s) => !SEVERITY_ORDER.includes(s));
+  return [...known, ...rest].map((s) => `${counts.get(s)} ${s}`).join(', ');
+}
+
+export function dimensionsSummaryTable(input) {
+  const inp = input || {};
+  const dispatchedSet = new Set(inp.dispatched || []);
+  const degradedSet = new Set(inp.degraded || []);
+  const owner = dimensionOwnerMap();
+
+  const byAgent = new Map(AGENTS.map((a) => [a, []]));
+  const unverifiedByAgent = new Map(AGENTS.map((a) => [a, []]));
+  for (const f of (inp.findings || [])) {
+    const agentType = owner[f && f.dimension];
+    if (agentType && byAgent.has(agentType)) byAgent.get(agentType).push(f);
+  }
+  for (const f of (inp.unverified || [])) {
+    const agentType = owner[f && f.dimension];
+    if (agentType && unverifiedByAgent.has(agentType)) unverifiedByAgent.get(agentType).push(f);
+  }
+
+  const rows = AGENTS.map((agentType) => {
+    const rowFindings = byAgent.get(agentType);
+    const rowUnverified = unverifiedByAgent.get(agentType);
+    const n = rowFindings.length;
+    const m = rowUnverified.length;
+    const dims = DIMENSIONS.filter((d) => d.agentType === agentType).map((d) => d.dimension);
+    const isDegraded = dims.some((d) => degradedSet.has(d));
+    const isDispatched = dispatchedSet.has(agentType);
+    const label = AGENT_LABELS[agentType] || agentType;
+    const agentShort = agentType.split(':').pop();
+
+    let findingsCell;
+    let notes;
+    if (!isDispatched) {
+      findingsCell = '—';
+      notes = 'Skipped — not dispatched in this run';
+    } else if (isDegraded && n + m === 0) {
+      findingsCell = '—';
+      notes = 'No results — agent did not complete';
+    } else if (isDegraded) {
+      findingsCell = m > 0 ? `${n} (+${m} unverified)` : `${n}`;
+      notes = 'Partial — agent may not have completed';
+    } else if (n + m === 0) {
+      findingsCell = '0';
+      notes = 'Clean — no findings returned';
+    } else if (n > 0) {
+      findingsCell = m > 0 ? `${n} (+${m} unverified)` : `${n}`;
+      notes = severityBreakdown(rowFindings);
+    } else {
+      findingsCell = `0 (+${m} unverified)`;
+      notes = 'Unverified findings only — see secondary section';
+    }
+
+    return `| ${label} | ${agentShort} | ${findingsCell} | ${notes} |`;
+  });
+
+  return ['| Dimension | Agent | Findings | Notes |', '|-----------|-------|----------|-------|', ...rows].join('\n');
+}
+
 // reportStage(ctx, input) -> { report, gaps }
 // Dispatches the report-writer agent to render the review markdown from the
 // high-confidence + unverified buckets (carried BY VALUE in the prompt — the
@@ -1816,22 +1923,30 @@ export async function reportStage(ctx, input) {
   const model = modelFor('code-gauntlet:report-writer', policy);
 
   const findings = inp.findings || [];
+  // Computed once over the WHOLE run (not per-chunk) so the table's counts are never
+  // scoped to one segment's slice of findings; threaded to segment 0 only (below).
+  const dimensionsTable = dimensionsSummaryTable({
+    ...(inp.dimensions || {}), findings, unverified: inp.unverified || [],
+  });
   const oversized = JSON.stringify(findings).length > PROMPT_SEGMENT_CHAR_BUDGET;
   if (!oversized) {
-    return dispatchReportSegment(c, model, inp, findings, null);
+    return dispatchReportSegment(c, model, inp, findings, null, dimensionsTable);
   }
 
   // Segment: one dispatch per chunk through parallel(), titled sections joined IN INDEX
   // ORDER. dispatchReportSegment already owns its try/catch and never throws, so no member
   // can be nulled by parallel(); the null branch below is defense-in-depth only.
   const chunks = chunkBySerializedSize(findings, PROMPT_SEGMENT_CHAR_BUDGET);
-  const thunks = chunks.map((chunk, i) => () => dispatchReportSegment(c, model, inp, chunk, { index: i, total: chunks.length }));
+  const thunks = chunks.map((chunk, i) => () => dispatchReportSegment(c, model, inp, chunk, { index: i, total: chunks.length }, dimensionsTable));
   const results = await c.parallel(thunks);
   const parts = [];
   const gaps = [];
   for (let i = 0; i < chunks.length; i += 1) {
     const out = results[i] || {
-      report: minimalReport({ ...inp, findings: chunks[i] }),
+      // Table belongs to segment 0 only, same as the dispatchReportSegment path below —
+      // this null-isolated fallback is defense-in-depth and must honor the same rule so
+      // a member nulled by parallel() cannot duplicate the section into a later segment.
+      report: minimalReport({ ...inp, findings: chunks[i], dimensionsTable: i === 0 ? dimensionsTable : '' }),
       gaps: [`report segment ${i}: dispatch produced no result — assembled a minimal report from pipeline stats`],
     };
     parts.push(`## Report segment ${i + 1} of ${chunks.length}\n\n${out.report}`);
@@ -1842,10 +1957,13 @@ export async function reportStage(ctx, input) {
 
 // One report-writer dispatch over `findings` (a whole set or one segment). Owns
 // the try/catch + minimal-section fallback. `seg` (or null) labels the dispatch
-// and tags the gap so a segmented failure is traceable to its chunk.
-async function dispatchReportSegment(c, model, inp, findings, seg) {
+// and tags the gap so a segmented failure is traceable to its chunk. `dimensionsTable`
+// is scoped to segment 0 (or the unsegmented dispatch) here — every downstream read of
+// `segInp.dimensionsTable` (reportPrompt, minimalReport) is a plain truthiness check
+// with no segment-awareness of its own, so the section can never render twice.
+async function dispatchReportSegment(c, model, inp, findings, seg, dimensionsTable) {
   const tag = seg ? ` segment ${seg.index}` : '';
-  const segInp = { ...inp, findings };
+  const segInp = { ...inp, findings, dimensionsTable: (!seg || seg.index === 0) ? dimensionsTable : '' };
   try {
     const result = await c.agent(reportPrompt(segInp, seg), {
       label: seg ? `report-writer-${seg.index}` : 'report-writer',
@@ -1926,6 +2044,10 @@ function minimalReport(inp) {
       lines.push(`- [${(f.severity || 'unknown').toUpperCase()}] ${f.title || f.id || 'finding'} (${f.file || '?'}:${f.line_start != null ? f.line_start : '?'})`);
     }
   }
+  // Present only when the caller scoped it in (segment 0 / unsegmented dispatch — see
+  // dispatchReportSegment) — this fallback survives even when the Phase 8 model itself
+  // never ran, so the table is never lost to a report-writer outage.
+  if (inp.dimensionsTable) lines.push('', '## Review Dimensions Summary', '', inp.dimensionsTable);
   return lines.join('\n');
 }
 
@@ -1942,8 +2064,17 @@ function reportPrompt(inp, seg) {
     findings: inp.findings || [],
     unverified: (!seg || seg.index === 0) ? (inp.unverified || []) : [], // render the unverified bucket once, in segment 0
     stats: inp.stats || {},
+    // Pre-scoped to segment 0 by the caller (dispatchReportSegment) — '' on every later
+    // segment, so this is a plain truthiness check, not a second segment-index test.
+    ...(inp.dimensionsTable ? { dimensionsTable: inp.dimensionsTable } : {}),
   });
-  return `${segLine}Write the code-gauntlet report as markdown for these results. Put high-confidence findings in the main section and unverified/pipeline-degraded findings in a clearly-labelled secondary section. Results JSON:\n${body}\nReturn { report } where report is the full markdown document.`;
+  // Verbatim-paste instruction (issue #89): the table is generated in code, not
+  // classified by this model — pasting it unmodified is what removes the capability to
+  // get the classification wrong. Only present when dimensionsTable is (segment 0).
+  const dimensionsInstruction = inp.dimensionsTable
+    ? ' The `dimensionsTable` field is the complete, pre-rendered Review Dimensions Summary table — paste it verbatim, unmodified, as the "## Review Dimensions Summary" section; never reconstruct, reclassify, or edit its rows.'
+    : '';
+  return `${segLine}Write the code-gauntlet report as markdown for these results. Put high-confidence findings in the main section and unverified/pipeline-degraded findings in a clearly-labelled secondary section.${dimensionsInstruction} Results JSON:\n${body}\nReturn { report } where report is the full markdown document.`;
 }
 
 // --- Persistence: writeArtifacts --------------------------------------------
@@ -3373,6 +3504,12 @@ export async function runWith(ctx, rawArgs) {
         filter: filterOut.stats,
         challenge: challengeOut.stats,
       },
+      // discover()'s own fan-out list and degraded-dimensions list (issue #89) — feeds
+      // dimensionsSummaryTable inside reportStage. `dispatched` already excludes any
+      // agent scope-gated out via agentFlags (agentSpecs().filter(agentActive) runs
+      // before discover() builds its spec list), so a light-scope run's skipped agents
+      // are absent from `dispatched`, not merely present-but-empty.
+      dimensions: { dispatched: discoverOut.dispatched || [], degraded: discoverOut.degraded || [] },
       // No context at all (issue #38, R1): the report-writer renders from the by-value
       // { summary, findings, unverified, stats } above and never needs the shared context
       // file. No stage is ever given contextPath; of the prebuilt contextLine, only

--- a/workflows/test/pipeline_run.test.js
+++ b/workflows/test/pipeline_run.test.js
@@ -26,6 +26,7 @@ import {
   coarsenLimits, plannedArtifactPaths,
 } from '../src/stages.js';
 import { makeFinding, makeFindings, validArgs, makeCtx } from './helpers/pipelineMock.js';
+import { AGENTS } from '../src/registry.js';
 
 // Node/browser host globals the workflow runtime SANDBOX does not provide (but node:test
 // does). Deleting them makes the pipeline run under sandbox-parity conditions, so a
@@ -876,4 +877,35 @@ test('sweep: bucketed summarize + segmented report emit only contract-valid disp
   await reportStage(rctx, { findings: big, unverified: [], stats: {}, policy: {} });
   assert.deepEqual(rctx.violations, [], `report violations: ${rctx.violations.join('; ')}`);
   assert.ok(rctx.calls.filter((c) => c.label.startsWith('report-writer-')).length > 1);
+});
+
+// Issue #89: discover()'s own dispatched/degraded lists flow through reportInput
+// (stages.js ~3366) into the dimensionsSummaryTable dispatched to the report-writer.
+// makeCtx's default fixture dispatches every one of the 7 AGENTS (agentFlags={}), only
+// bug-detector returns findings (the 2-element makeFindings() set — both survive to
+// challengeOut.findings, confirmed by the happy-path test's `highConfidence === 2`), and
+// no discovery agent throws — so the expected end state is dispatched=AGENTS, degraded=[].
+test('happy path: discoverOut.dispatched/degraded reach the final Review Dimensions Summary table via reportInput', async () => {
+  const args = validArgs();
+  const ctx = makeCtx(args);
+  const out = await runWith(ctx, args);
+  assert.equal(out.ok, true);
+
+  const reportCall = ctx.calls.find((c) => c.label === 'report-writer');
+  assert.ok(reportCall, 'the tiny fixture must dispatch a single unsegmented report-writer call');
+  const m = /Results JSON:\n([\s\S]*)\nReturn \{ report \}/.exec(reportCall.prompt);
+  assert.ok(m, 'the report-writer prompt carries a Results JSON body');
+  const body = JSON.parse(m[1]);
+  assert.ok(body.dimensionsTable, 'dimensionsTable is present on the segment-0 dispatch');
+
+  const rows = body.dimensionsTable.split('\n').slice(2)
+    .map((line) => line.split('|').slice(1, -1).map((c) => c.trim()));
+  assert.equal(rows.length, AGENTS.length);
+  const bugRow = rows.find((r) => r[1] === 'bug-detector');
+  assert.equal(bugRow[2], '2', 'bug-detector reports the 2 seeded findings that survived to delivery');
+  const otherRows = rows.filter((r) => r[1] !== 'bug-detector');
+  assert.ok(
+    otherRows.every((r) => r[2] === '0' && r[3] === 'Clean — no findings returned'),
+    `every other dispatched agent must read Clean/0: ${JSON.stringify(otherRows)}`,
+  );
 });

--- a/workflows/test/registry.test.js
+++ b/workflows/test/registry.test.js
@@ -1,7 +1,7 @@
 // registry.test.js — DIMENSIONS registry + resolvePolicy (S5) unit tests.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { DIMENSIONS, AGENTS, resolvePolicy } from '../src/registry.js';
+import { DIMENSIONS, AGENTS, AGENT_LABELS, resolvePolicy } from '../src/registry.js';
 
 test('7 unique discovery agents', () => { assert.equal(AGENTS.length, 7); });
 test('conventions-and-intent covers 3 dimensions', () => {
@@ -103,4 +103,11 @@ test('promptExtra: security sweep on security-reviewer, typo/naming on bug + con
   for (const dim of ['cross_file_impact', 'test_coverage', 'type_design', 'simplification']) {
     assert.equal(byDim(dim).promptExtra, null);
   }
+});
+
+// Issue #89 sync guard: AGENT_LABELS is keyed by agentType, not by DIMENSIONS row, so
+// nothing else fails the build the day AGENTS gains an 8th member without a matching
+// label — this is the guard that would.
+test('AGENT_LABELS key set is exactly AGENTS — a new agent needs a label too', () => {
+  assert.deepEqual(Object.keys(AGENT_LABELS).sort(), [...AGENTS].sort());
 });

--- a/workflows/test/stages_dimensions.test.js
+++ b/workflows/test/stages_dimensions.test.js
@@ -7,7 +7,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { dimensionsSummaryTable, reportStage } from '../src/stages.js';
-import { AGENTS, AGENT_LABELS, DIMENSIONS } from '../src/registry.js';
+import { AGENTS, AGENT_LABELS } from '../src/registry.js';
 import { makeFinding } from './helpers/pipelineMock.js';
 
 // A rendered table's data rows (skipping the header + separator), each cell trimmed.

--- a/workflows/test/stages_dimensions.test.js
+++ b/workflows/test/stages_dimensions.test.js
@@ -1,0 +1,263 @@
+// stages_dimensions.test.js — dimensionsSummaryTable (issue #89): the Review Dimensions
+// Summary table computed in CODE as a pure function of pipeline stats, instead of asked
+// of the Phase 8 model. Unit tests call dimensionsSummaryTable directly with synthetic
+// inputs and assert exact rendered strings; the reportStage-level tests at the bottom
+// reuse the ctx-mock pattern from pipeline_run.test.js to check the plumbing
+// (reportPrompt / minimalReport) around it.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { dimensionsSummaryTable, reportStage } from '../src/stages.js';
+import { AGENTS, AGENT_LABELS, DIMENSIONS } from '../src/registry.js';
+import { makeFinding } from './helpers/pipelineMock.js';
+
+// A rendered table's data rows (skipping the header + separator), each cell trimmed.
+function tableRows(md) {
+  return md.split('\n').slice(2).map((line) => {
+    const [dimension, agent, findings, notes] = line.split('|').slice(1, -1).map((c) => c.trim());
+    return { dimension, agent, findings, notes };
+  });
+}
+
+const rowIndex = (agentType) => AGENTS.indexOf(agentType);
+
+// --- Shape ---------------------------------------------------------------------
+
+test('header row matches the report-format.md column set exactly', () => {
+  const md = dimensionsSummaryTable({});
+  const lines = md.split('\n');
+  assert.equal(lines[0], '| Dimension | Agent | Findings | Notes |');
+  assert.equal(lines[1], '|-----------|-------|----------|-------|');
+});
+
+test('no leading heading — the table starts at the header row (placement is the caller\'s concern)', () => {
+  const md = dimensionsSummaryTable({});
+  assert.ok(!/^#/.test(md), `table must not open with a heading: ${md.slice(0, 40)}`);
+});
+
+test('one row per registry AGENT, in registry order — derived from AGENTS, nothing hardcoded', () => {
+  const md = dimensionsSummaryTable({});
+  const rows = tableRows(md);
+  assert.equal(rows.length, AGENTS.length);
+  assert.deepEqual(rows.map((r) => r.agent), AGENTS.map((a) => a.split(':').pop()));
+  assert.deepEqual(rows.map((r) => r.dimension), AGENTS.map((a) => AGENT_LABELS[a]));
+});
+
+// --- Classification rules 1-6 ----------------------------------------------------
+
+test('rule 1: not dispatched -> Findings em-dash, "Skipped" note', () => {
+  const md = dimensionsSummaryTable({ dispatched: [], degraded: [], findings: [], unverified: [] });
+  for (const r of tableRows(md)) {
+    assert.equal(r.findings, '—');
+    assert.equal(r.notes, 'Skipped — not dispatched in this run');
+  }
+});
+
+test('rule 2: dispatched + degraded + zero findings -> Findings em-dash, "No results" note', () => {
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: ['bug'], findings: [], unverified: [] });
+  const row = tableRows(md)[rowIndex('code-gauntlet:bug-detector')];
+  assert.equal(row.findings, '—');
+  assert.equal(row.notes, 'No results — agent did not complete');
+});
+
+test('rule 3: degraded but findings survived anyway -> Findings shows the surviving counts, "Partial" note', () => {
+  const findings = [makeFinding('B1', { dimension: 'bug', severity: 'high' })];
+  const unverified = [makeFinding('B2', { dimension: 'bug', severity: 'low' })];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: ['bug'], findings, unverified });
+  const row = tableRows(md)[rowIndex('code-gauntlet:bug-detector')];
+  assert.equal(row.findings, '1 (+1 unverified)');
+  assert.equal(row.notes, 'Partial — agent may not have completed');
+});
+
+test('rule 3: degraded with surviving high-confidence findings and zero unverified -> plain "N", no unverified suffix', () => {
+  const findings = [makeFinding('B1', { dimension: 'bug', severity: 'high' })];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: ['bug'], findings, unverified: [] });
+  const row = tableRows(md)[rowIndex('code-gauntlet:bug-detector')];
+  assert.equal(row.findings, '1');
+  assert.equal(row.notes, 'Partial — agent may not have completed');
+});
+
+test('rule 4: dispatched, not degraded, zero findings -> Findings "0", "Clean" note', () => {
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: [], findings: [], unverified: [] });
+  for (const r of tableRows(md)) {
+    assert.equal(r.findings, '0');
+    assert.equal(r.notes, 'Clean — no findings returned');
+  }
+});
+
+test('rule 5: N findings, not degraded -> Findings "N", Notes is a severity breakdown in fixed order', () => {
+  const findings = [
+    makeFinding('S1', { dimension: 'security', severity: 'high' }),
+    makeFinding('S2', { dimension: 'security', severity: 'critical' }),
+    makeFinding('S3', { dimension: 'security', severity: 'high' }),
+  ];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: [], findings, unverified: [] });
+  const row = tableRows(md)[rowIndex('code-gauntlet:security-reviewer')];
+  assert.equal(row.findings, '3');
+  assert.equal(row.notes, '1 critical, 2 high'); // fixed order, not insertion order
+});
+
+test('rule 5: N findings + M unverified -> Findings "N (+M unverified)"', () => {
+  const findings = [makeFinding('S1', { dimension: 'security', severity: 'high' })];
+  const unverified = [
+    makeFinding('S2', { dimension: 'security', severity: 'low' }),
+    makeFinding('S3', { dimension: 'security', severity: 'low' }),
+  ];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: [], findings, unverified });
+  const row = tableRows(md)[rowIndex('code-gauntlet:security-reviewer')];
+  assert.equal(row.findings, '1 (+2 unverified)');
+  // Severity breakdown is over the HIGH-CONFIDENCE findings only, not the unverified ones.
+  assert.equal(row.notes, '1 high');
+});
+
+test('rule 5: a severity outside SEVERITY_ORDER trails the known ones in first-seen order, never dropped', () => {
+  const findings = [
+    makeFinding('S1', { dimension: 'security', severity: 'exotic' }),
+    makeFinding('S2', { dimension: 'security', severity: 'low' }),
+    makeFinding('S3', { dimension: 'security', severity: 'weird' }),
+  ];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: [], findings, unverified: [] });
+  const row = tableRows(md)[rowIndex('code-gauntlet:security-reviewer')];
+  assert.equal(row.findings, '3');
+  assert.equal(row.notes, '1 low, 1 exotic, 1 weird');
+});
+
+test('rule 5: no finding in the row carries a severity value -> empty Notes', () => {
+  const findings = [makeFinding('S1', { dimension: 'security', severity: undefined })];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: [], findings, unverified: [] });
+  const row = tableRows(md)[rowIndex('code-gauntlet:security-reviewer')];
+  assert.equal(row.findings, '1');
+  assert.equal(row.notes, '');
+});
+
+test('rule 6: zero high-confidence but unverified findings exist -> Findings "0 (+M unverified)", "Unverified findings only" note', () => {
+  const unverified = [makeFinding('S1', { dimension: 'security', severity: 'low' })];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: [], findings: [], unverified });
+  const row = tableRows(md)[rowIndex('code-gauntlet:security-reviewer')];
+  assert.equal(row.findings, '0 (+1 unverified)');
+  assert.equal(row.notes, 'Unverified findings only — see secondary section');
+});
+
+// --- Multi-dimension aggregation (conventions-and-intent) -----------------------
+
+test('multi-dimension aggregation: convention + comment_accuracy findings roll into ONE row', () => {
+  const findings = [
+    makeFinding('C1', { dimension: 'convention', severity: 'medium' }),
+    makeFinding('C2', { dimension: 'comment_accuracy', severity: 'medium' }),
+  ];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: [], findings, unverified: [] });
+  const rows = tableRows(md).filter((r) => r.agent === 'conventions-and-intent');
+  assert.equal(rows.length, 1, 'exactly one row for the multi-dimension agent');
+  assert.equal(rows[0].findings, '2');
+  assert.equal(rows[0].notes, '2 medium');
+});
+
+test('multi-dimension aggregation: degraded if only ONE of the agent\'s dimensions is degraded', () => {
+  const findings = [makeFinding('I1', { dimension: 'intent', severity: 'medium' })];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: ['convention'], findings, unverified: [] });
+  const row = tableRows(md)[rowIndex('code-gauntlet:conventions-and-intent')];
+  assert.equal(row.notes, 'Partial — agent may not have completed');
+});
+
+// --- Robustness -------------------------------------------------------------------
+
+test('a finding with an unknown or missing dimension is ignored for every count', () => {
+  const findings = [
+    makeFinding('X1', { dimension: 'not-a-real-dimension' }),
+    makeFinding('X2', { dimension: undefined }),
+  ];
+  const md = dimensionsSummaryTable({ dispatched: AGENTS, degraded: [], findings, unverified: [] });
+  for (const r of tableRows(md)) assert.equal(r.findings, '0');
+});
+
+test('all fields absent renders a full table of Skipped rows without throwing', () => {
+  assert.doesNotThrow(() => {
+    const md = dimensionsSummaryTable();
+    const rows = tableRows(md);
+    assert.equal(rows.length, AGENTS.length);
+    assert.ok(rows.every((r) => r.notes === 'Skipped — not dispatched in this run'));
+  });
+});
+
+test('dimensionsSummaryTable() called with no argument at all does not throw', () => {
+  assert.doesNotThrow(() => dimensionsSummaryTable());
+});
+
+// --- reportStage plumbing (ctx-mock pattern, see pipeline_run.test.js) ------------
+
+// The Results JSON body reportPrompt embeds between "Results JSON:\n" and "\nReturn
+// { report }". Parsed rather than substring-matched so the assertions read the same
+// structured value the report-writer itself would.
+function resultsBody(prompt) {
+  const m = /Results JSON:\n([\s\S]*)\nReturn \{ report \}/.exec(prompt);
+  assert.ok(m, `prompt did not carry a Results JSON body: ${prompt.slice(0, 200)}`);
+  return JSON.parse(m[1]);
+}
+
+test('reportStage: the unsegmented (segment-0) prompt carries the rendered table verbatim + the paste-verbatim instruction', async () => {
+  let capturedPrompt = null;
+  const ctx = {
+    agent: async (prompt) => { capturedPrompt = prompt; return { report: '# r' }; },
+    parallel: async () => [],
+  };
+  const findings = [makeFinding('B1', { dimension: 'bug', severity: 'high' })];
+  const dims = { dispatched: AGENTS, degraded: [] };
+  await reportStage(ctx, { findings, unverified: [], stats: {}, dimensions: dims });
+
+  assert.equal(typeof capturedPrompt, 'string', 'the dispatch contract requires a STRING prompt');
+  const expectedTable = dimensionsSummaryTable({ ...dims, findings, unverified: [] });
+  const body = resultsBody(capturedPrompt);
+  assert.equal(body.dimensionsTable, expectedTable);
+  assert.match(capturedPrompt, /paste it verbatim, unmodified/);
+  assert.match(capturedPrompt, /Review Dimensions Summary/);
+});
+
+test('reportStage: on a segmented report, only segment 0 carries the table and the instruction', async () => {
+  const prompts = [];
+  const ctx = {
+    agent: async (prompt, opts) => { prompts.push({ label: opts.label, prompt }); return { report: `body ${opts.label}` }; },
+    parallel: async (thunks) => Promise.all(thunks.map((t) => t())),
+  };
+  const big = Array.from({ length: 80 }, (_, i) => makeFinding(`F${i}`, { description: 'x'.repeat(2000), dimension: 'bug', severity: 'high' }));
+  await reportStage(ctx, { findings: big, unverified: [], stats: {}, dimensions: { dispatched: AGENTS, degraded: [] } });
+
+  assert.ok(prompts.length > 1, 'fixture must segment for this test to be meaningful');
+  const seg0 = prompts.find((p) => p.label === 'report-writer-0');
+  const seg1 = prompts.find((p) => p.label === 'report-writer-1');
+  assert.ok(seg0 && seg1, 'both segment 0 and segment 1 must have dispatched');
+
+  const body0 = resultsBody(seg0.prompt);
+  const body1 = resultsBody(seg1.prompt);
+  assert.ok('dimensionsTable' in body0, 'segment 0 carries the table field');
+  assert.ok(!('dimensionsTable' in body1), 'segment 1 must NOT carry the table field');
+  assert.match(seg0.prompt, /paste it verbatim, unmodified/);
+  assert.ok(!/paste it verbatim, unmodified/.test(seg1.prompt), 'segment 1 must not carry the paste instruction');
+});
+
+test('reportStage: a writer throw degrades to the minimal report, which still carries the table', async () => {
+  const ctx = {
+    agent: async () => { throw new Error('boom'); },
+    parallel: async () => [],
+  };
+  const findings = [makeFinding('B1', { dimension: 'bug', severity: 'high' })];
+  const dims = { dispatched: AGENTS, degraded: [] };
+  const out = await reportStage(ctx, { findings, unverified: [], stats: {}, dimensions: dims });
+
+  const expectedTable = dimensionsSummaryTable({ ...dims, findings, unverified: [] });
+  assert.match(out.report, /## Review Dimensions Summary/);
+  assert.ok(out.report.includes(expectedTable), 'the minimal-report fallback carries the exact rendered table');
+});
+
+test('reportStage: when parallel() null-isolates segment 0, the outer minimal-report fallback still carries the table exactly once', async () => {
+  const ctx = {
+    agent: async (prompt, opts) => ({ report: `body ${opts.label}` }),
+    parallel: async (thunks) => Promise.all(thunks.map((t, i) => (i === 0 ? Promise.resolve(null) : t()))),
+  };
+  const big = Array.from({ length: 80 }, (_, i) => makeFinding(`F${i}`, { description: 'x'.repeat(2000), dimension: 'bug', severity: 'high' }));
+  const dims = { dispatched: AGENTS, degraded: [] };
+  const out = await reportStage(ctx, { findings: big, unverified: [], stats: {}, dimensions: dims });
+
+  const parts = out.report.split('## Report segment ');
+  assert.ok(parts.length > 2, 'fixture must segment into more than one chunk for this test to be meaningful');
+  assert.match(parts[1], /## Review Dimensions Summary/, 'segment 1 (index 0, null-isolated) falls back to the minimal report and carries the table');
+  assert.ok(!/## Review Dimensions Summary/.test(parts[2]), 'segment 2 (index 1) must not carry the table');
+});


### PR DESCRIPTION
Closes #89 — last item in Wave 3 (#101); Smoke A is the next roadmap checkpoint after this merges.

## What

The Review Dimensions Summary table is now computed in code as a pure function of pipeline stats, handed to Phase 8 pre-rendered, and pasted verbatim — removing the capability to misclassify a dimension instead of instructing against it.

**Rescope note (per the 2026-07-30 triage comment):** the issue was written against PR #87's discarded `stats.health.dimensionsLost` / `healthBanner()` groundwork. Against the fresh #69-era code the gap is deeper than prose classification: the table was never rendered at all — `reportPrompt` never asked for it, and `discoverOut.dispatched` / `discoverOut.degraded` were computed in `discover()` and then dropped before `reportInput` assembly. This PR plumbs that data through and renders the table structurally.

## Mechanism

- `dimensionsSummaryTable({ dispatched, degraded, findings, unverified })` in `workflows/src/stages.js` — one row per discovery agent in registry order, classified in fixed priority: Skipped (not dispatched, e.g. light scope) / No results (degraded, nothing survived) / Partial (degraded, findings survived) / Clean (dispatched, zero findings) / N findings with a severity-breakdown note and `(+M unverified)` suffix.
- `AGENT_LABELS` in `workflows/src/registry.js` — per-agent display strings, keyed by agentType (a `DIMENSIONS`-row field would force conventions-and-intent's 3 rows to repeat one value). Sync guard in `registry.test.js` pins the key set to `AGENTS`, so an 8th agent costs one registry edit and the label — the test catches omission.
- Threaded into the report-writer dispatch prompt (segment 0 only, mirroring the existing `unverified` scoping; the caller pre-scopes, downstream reads are plain truthiness) with a paste-verbatim instruction, and into the `minimalReport()` code fallback — the table survives a report-writer outage, including the parallel-null segment-0 isolation path.
- `report-format.md`'s template section becomes a paste-verbatim contract (code owns the content, Phase 8 places it — the footer/marker treatment); `agents/report-writer.md` documents the `dimensionsTable` input field and the verbatim protocol step.

Scope boundary: issue #36 req 3 (report-writer never receives the full formatting contract) stays open and untouched — this PR moves one table from that contract into code; branding/emoji/methodology are #36's.

## Validation

- Bundle: `node workflows/build.js` → byte-identical `pipeline.js` (rebuilt twice, idempotent).
- JS: 702/702; coverage 98.79 lines / 84.77 branches / 98.27 functions (floors 98 / 83.3 / 97.2), presence check green.
- Python: 1290 passed + 510 subtests, 92.89% (floor 91.8). Bench: 537 passed (untouched).
- pre-commit: all hooks pass.
- **Mutation-verified** (AGENTS.md rule): three mutants each killed by named tests — `isDegraded` forced false (4 red), the rule-3/5 unverified-suffix ternary made unconditional (5 red — this mutant survived the suite before two hardening tests were added on review), severity trailing-order term dropped (1 red). Implementation restored byte-identical (hash-checked) after each cycle.
- **Adversarial review**: 4-lens sonnet finder pass over the diff (logic vs upstream semantics, repo/sandbox rules, test adequacy, doc coherence) → 8 findings, each independently opus-refuted or confirmed. 1 confirmed defect (a new comment cross-referencing label strings this same diff removed from report-format.md) — fixed. Notable refuted-by-evidence edge, recorded for posterity: a finding with a non-canonical `dimension` value (merge warns-and-keeps) would be excluded from row counts; unreachable without an agent violating its pinned output contract and surviving verify/validate/filter/challenge, and the pre-change state rendered no table at all.

Per the roadmap's per-PR rule this ships on green suites; no smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GcE6YUDMs6tLtwAzAMtaUF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes report assembly and plumbs discover dispatched/degraded data into Phase 8, but is a pure deterministic table with strong unit and integration coverage and no auth/security impact.
> 
> **Overview**
> **Computes the Review Dimensions Summary table in code** and hands it to the report-writer pre-rendered, so Phase 8 pastes it verbatim instead of classifying dimensions itself. Before this, the table was never rendered — `reportPrompt` never asked for it, and `discoverOut.dispatched` / `discoverOut.degraded` were dropped before `reportInput`.
> 
> Adds `dimensionsSummaryTable()` with fixed-priority row classification (Skipped / No results / Partial / Clean / severity breakdown / unverified-only), plus `AGENT_LABELS` keyed by agent type. The table is scoped to segment 0 (and the `minimalReport` fallback) so it survives writer outages without duplicating across segments.
> 
> Updates `report-writer.md` and `report-format.md` to the paste-verbatim contract, and adds focused unit/plumbing tests covering all classification rules and segment scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1ba838e1703c862a92ce716f6934d6b1387aa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->