### PR TITLE
docs(bench): record the first live subscription smoke (Smoke A)

### DIFF
--- a/bench/MEASUREMENT.md
+++ b/bench/MEASUREMENT.md
@@ -43,10 +43,13 @@ marginal cost. Mechanics, prerequisites, and cost-honesty rules:
 | Paired mini-subset | **No** | Of record: clean cost accounting, no throttle-induced timeouts mid-leg |
 | Full-15 / holdout | **No** | Same, at release grade |
 
-Caveat on the "yes" rows: what a subscription usage-limit hit looks like in bench terms
-is **not yet confirmed** — expected to surface as a per-PR watchdog `timeout`, recoverable
-with `--retry-failed`, but no live subscription smoke has run yet. The first one settles
-it and updates [`README.md` → Usage limits](README.md#usage-limits).
+Caveat on the "yes" rows: the first live subscription smoke has now run
+(`smoke-20260812-030333-0f3f550`, 2026-08-12, main @ 0f3f550 / v3.8.0, `--tier
+smoke`, 3 PRs sequential, `--child-auth subscription`). All 3 review children
+ran to completion under the subscription token — no watchdog timeout, no
+mid-run auth failure. N=1: what a usage-limit hit looks like in bench terms
+remains unobserved. See [`README.md` → Usage limits](README.md#usage-limits)
+for the full record.
 
 Every ledger cost figure in this runbook is `auth_mode=api` spend. A
 `auth_mode=subscription` row's `cost_usd` is recorded but is not billable spend

--- a/bench/README.md
+++ b/bench/README.md
@@ -251,14 +251,16 @@ qualifies it with `auth_mode` on the ledger row:
 
 ### Usage limits
 
-**Unconfirmed — to be recorded here by the first subscription-mode smoke.**
-Official docs describe a 5-hour rolling window plus weekly and Opus-specific
-caps, and say that on a limit hit further `-p` requests are blocked until the
-window resets. No machine-readable error shape is documented, so in bench terms
-the expected symptom is the per-PR watchdog firing (status `timeout`, reason
-`watchdog_timeout`) rather than a clean error. Either way, `--retry-failed
-RUN_ID` after the reset recovers the affected PRs. The first live smoke settles
-which of the two it actually is; update this paragraph with what was observed.
+The first live subscription smoke (`smoke-20260812-030333-0f3f550`,
+2026-08-12, main @ 0f3f550 / v3.8.0) observed **no usage-limit hit** across 3
+sequential PRs (~38 min of child time). Official docs describe a 5-hour
+rolling window plus weekly and Opus-specific caps, and say that on a limit hit
+further `-p` requests are blocked until the window resets. No machine-readable
+error shape is documented, so the predicted symptom in bench terms — the
+per-PR watchdog firing (status `timeout`, reason `watchdog_timeout`) rather
+than a clean error — remains unexercised; this run didn't trip the window.
+Either way, `--retry-failed RUN_ID` after a reset is expected to recover the
+affected PRs.
 
 ### Recommended usage, and scope
 


### PR DESCRIPTION
## Summary

Records the measured facts from the first-ever live `--child-auth subscription` benchmark smoke, replacing the "unconfirmed / not yet run" caveats in two docs. This is the Wave 3 Smoke A checkpoint's residue (roadmap issue #101).

Run: `smoke-20260812-030333-0f3f550`, 2026-08-12, main @ 0f3f550 (v3.8.0), tier smoke (3 PRs, sequential), `--child-auth subscription`.

- All 3 review children ran to completion under the subscription OAuth token; no usage-limit symptoms were observed (no watchdog timeout, no mid-run auth failure). N=1 run — what a limit-hit looks like under subscription remains unobserved.
- Per-child wall clock: 741s / 821s / 728s (~12–14 min each, ~38 min total). Non-billable `cost_usd` was recorded normally by the harness: $7.08 / $6.71 / $6.57 (total ≈ $20.36 equivalent absorbed by the subscription).
- 2 PRs `ok`; 1 marked `invalid: config_echo_mismatch` — the documented receipt-formatting floor, unrelated to auth mode (the child completed all 8 phases).
- The run proceeded with no `ANTHROPIC_API_KEY`/`BENCH_JUDGE_API_KEY` present at all — the "subscription run with no judge key" path printed its non-fatal warning and completed, gate-able with `--check`, exactly as designed.

### Edits

- `bench/MEASUREMENT.md` — the "yes" tier caveat (`Which tiers may run on subscription`) now records that the first live subscription smoke ran and completed, citing the run id, instead of "no live subscription smoke has run yet."
- `bench/README.md` — the `Usage limits` section now records that this run observed no usage-limit hit across ~38 min of child time. The predicted symptom (per-PR watchdog `timeout`, recoverable via `--retry-failed`) is kept, explicitly labeled as an untested prediction — it remains unexercised.

No other files touched.

## Test plan

- [x] `pre-commit run --files bench/MEASUREMENT.md bench/README.md` — all hooks passed (markdownlint-fix, trailing whitespace, gitleaks, etc.)
- [x] Docs-only change; no code, `experiments.jsonl`, or `CHANGELOG.md` touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jktbMnKvydmNgfMYFZBiM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to bench runbooks; no code, harness, or measurement logic changes.
> 
> **Overview**
> Replaces the "unconfirmed / not yet run" caveats with measured results from the first live subscription smoke (`smoke-20260812-030333-0f3f550`).
> 
> In `MEASUREMENT.md`, the subscription-tier caveat now notes that all 3 review children completed under the subscription token with no watchdog timeout or mid-run auth failure. In `README.md`, **Usage limits** records that this ~38 min run observed **no usage-limit hit**, while keeping the predicted watchdog-timeout symptom as still unexercised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e38742ba9d2b0afe354e9a4575d61f2b939c79a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->