### PR TITLE
ci: retry the pinned Biome download on transient release-CDN errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,10 @@ jobs:
           set -euo pipefail
           url="https://github.com/biomejs/biome/releases/download/@biomejs/biome@${BIOME_VERSION}/biome-linux-x64"
           out="${RUNNER_TEMP}/biome"
-          curl -fsSL "$url" -o "$out"
+          # --retry-all-errors: GitHub releases intermittently 503s (redded main
+          # 2026-08-12 on a docs-only merge); the sha256 check below still gates
+          # whatever the retry finally fetches.
+          curl -fsSL --retry 4 --retry-all-errors "$url" -o "$out"
           echo "${BIOME_SHA256}  ${out}" | sha256sum -c -
           chmod +x "$out"
           echo "BIOME=${out}" >> "$GITHUB_ENV"


### PR DESCRIPTION
The js-lint job on main's post-merge run (31622613742) failed at the Biome binary download with `curl: (22) ... 503` from GitHub releases — before any linting ran; the merged PRs were docs-only. The failed job was re-run to green main; this hardens the step so a transient CDN error cannot red main again: `--retry 4 --retry-all-errors` on the download, with the existing `sha256sum -c` still gating whatever the retry fetches (pin integrity unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jktbMnKvydmNgfMYFZBiM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only download resilience with no change to Biome version, checksum verification, or application code.
> 
> **Overview**
> Hardens the **js-lint** job’s pinned Biome binary fetch so transient GitHub release **503**s are less likely to fail CI on unrelated merges.
> 
> The download `curl` now uses **`--retry 4 --retry-all-errors`**; the existing **`sha256sum -c`** check still validates the file after download, so the version pin and integrity gate are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b696ecc09020b3b94c759b918b5f814c6c4e2f0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->