### PR TITLE
feat(args): in-pipeline REVIEW.md parse via reviewMd/exclusionsText waist fields (#24 sub-PR 2)

### DIFF
--- a/skills/code-gauntlet/SKILL.md
+++ b/skills/code-gauntlet/SKILL.md
@@ -253,21 +253,31 @@ python3 -c "import secrets; print(secrets.token_hex(8))"
 
 **Composites A/B never subsume 2d (CLAUDE.md/REVIEW.md discovery), 2g (test discovery), or 2k (AI-marker scan)** — those three stay on Glob/Grep exactly as `references/phase2-triage.md` already mandates for each ("Never use `find` from Bash..." / "Never use `find` or `grep` from Bash..."). Routing them through Bash here is the mistake the recorded run made; keep them as separate Glob/Grep tool calls.
 
-### Parse REVIEW.md into the review config
+### Discover REVIEW.md and stamp its raw text
 
-Discover REVIEW.md hierarchically (`references/review-md-spec.md`). Schema-validate it and split it into the two objects the filter stage consumes by value:
+Discover REVIEW.md files across the repo root + changed-file directories + their ancestors —
+the same directory set `scripts/collect_project_rules.py` walks for AGENTS.md/CLAUDE.md/QODO.md
+(`references/review-md-spec.md`, issue #80). For each REVIEW.md found, in that discovery order
+(root first, then increasing directory depth), Read its raw text. Stamp them as:
 
-- `args.reviewConfig` — thresholds + `ignore` list (the parsed object).
-- `args.exclusionPatterns` — the exclusion-pattern list.
-- `args.reviewConfigPath` — the REVIEW.md path (or `null` if none), carried for provenance.
+- `args.reviewMd` — `[{ path, text }, ...]` in discovery order (`path` repo-relative, `text` the
+  file's raw content). An empty array means "discovery ran, no REVIEW.md found" — a legal,
+  authoritative signal in its own right, distinct from omitting the field entirely.
+- `args.exclusionsText` — the raw text of whatever exclusions source was found (e.g.
+  `.reviewignore`), unchanged from today.
 
-The assembled `reviewConfig` is exactly the `parseReviewMd` output shape — **`ignore` entries are flat strings, never objects** (the Filter stage regex-escapes each entry as a literal substring; a `{pattern, reason}` object crashes it after five paid stages, and the args waist rejects it). Concrete example:
+Do not hand-parse or schema-validate REVIEW.md here — pass the raw text through. The workflow's
+`resolveReviewConfig` (`workflows/src/args.js`) calls `parseReviewMd` per entry and merges them
+in array order per the precedence in `references/review-md-spec.md` (settings override deeper-
+wins, `ignore` accumulates); this is a structural guarantee of the args waist, not a prompt-level
+contract. In particular, `resolveReviewConfig` never pins a numeric default for
+`confidence_threshold` / `security_min_confidence` when REVIEW.md does not set one — the Filter
+stage's own built-in defaults (non-security **55**, security **70**) apply exactly when absent,
+so there is nothing to "get right" by hand here anymore.
 
-```json
-{ "confidence_threshold": 65, "severity_threshold": "medium", "ignore": ["*.generated.cs", "TODO comments in migration files"] }
-```
-
-> **Threshold defaults.** Only put `confidence_threshold` / `security_min_confidence` in `reviewConfig` when REVIEW.md actually sets them — do **not** pin a numeric default. When they are absent the Filter stage applies its built-in defaults (non-security **55**, security **70**); pinning an explicit `70` would silently raise the non-security bar back to 70 and undo the default.
+**Do not stamp both `args.reviewMd` and `args.reviewConfig`** (or both `args.exclusionsText` and
+`args.exclusionPatterns`) — the args waist refuses a waist that stamps both the raw and
+pre-parsed form for the same axis (single authority).
 
 ### Write the shared agent context file
 
@@ -338,7 +348,7 @@ Assemble the args waist (see `references/phase2-triage.md` for the full field li
                                              // Phase 8 posts it without hand-assembly
 
   // by-value inputs the in-memory stages need (the workflow has no disk):
-  changedFiles, changedLines, baseBranch, reviewConfig, exclusionPatterns,
+  changedFiles, changedLines, baseBranch, reviewMd, exclusionsText,
 
   // the shared context file's own measured size, from the write step above. Feeds
   // contextReadPlan, which turns it into the exact Read calls the discovery/validate/

--- a/skills/code-gauntlet/SKILL.md
+++ b/skills/code-gauntlet/SKILL.md
@@ -267,10 +267,12 @@ the same directory set `scripts/collect_project_rules.py` walks for AGENTS.md/CL
   `.reviewignore`), unchanged from today.
 
 Do not hand-parse or schema-validate REVIEW.md here — pass the raw text through. The workflow's
-`resolveReviewConfig` (`workflows/src/args.js`) calls `parseReviewMd` per entry and merges them
-in array order per the precedence in `references/review-md-spec.md` (settings override deeper-
-wins, `ignore` accumulates); this is a structural guarantee of the args waist, not a prompt-level
-contract. In particular, `resolveReviewConfig` never pins a numeric default for
+`resolveReviewConfig` (`workflows/src/args.js`) calls `parseReviewMd` per entry, sorts entries
+root-first by path depth (structural, not caller order), and merges: a deeper entry's threshold
+**setting** overrides a shallower one's when both set it, `ignore` lists accumulate across every
+entry. The result is **one flat config applied to every finding in the run** — resolveReviewConfig
+does not implement the per-subtree scoping `references/review-md-spec.md` describes; see that
+file's own note on the gap. In particular, `resolveReviewConfig` never pins a numeric default for
 `confidence_threshold` / `security_min_confidence` when REVIEW.md does not set one — the Filter
 stage's own built-in defaults (non-security **55**, security **70**) apply exactly when absent,
 so there is nothing to "get right" by hand here anymore.
@@ -320,7 +322,7 @@ agentFlags = (trivial_gate_fired AND scope answer == light) ? { "deep": false } 
 
 All three inputs are on hand at this step: the 2e risk table, the `changedLines` value being stamped two lines up, and the fresh echo above. (This scope gate is distinct from Phase 1's eligibility check #4 — "only lockfile/generated changes → stop" — which aborts; this one narrows dimensions.) The map is **opt-out**: `{}` = full scope (every dimension on — byte-identical to no flags); `{ "deep": false }` = light scope (only the two core dimensions `bug`, `security` run — two discovery agents). Stamping `{}` after a light decision silently runs a full 7-agent review the user/operator declined — that exact miss occurred in live verification, which is why this is a derivation rule, not prose. Never stamp a non-boolean value: `agentActive` gates only on the literal `false`, and the args waist rejects anything else.
 
-**Omit optional fields you have no value for — never stamp an explicit `null`.** The waist tolerates an explicit `null` as equivalent to absent for `reviewConfig`, `exclusionPatterns`, `delivery`, and `checkpoints`, but omitting is the norm: a live run once stamped `reviewConfig: null` and paid a 21.3s round trip re-deriving it before dispatch. Two fields are the opposite case — `null` there is a meaningful value, not a stand-in for absent, so do not "fix" it away: `reviewConfigPath: null` (no REVIEW.md found — pure provenance) and `limits.deliveryCap: null` (uncapped delivery — an explicit choice, not an oversight).
+**Omit optional fields you have no value for — never stamp an explicit `null`.** The waist tolerates an explicit `null` as equivalent to absent for `reviewConfig`, `exclusionPatterns`, `reviewMd`, `exclusionsText`, `delivery`, and `checkpoints`, but omitting is the norm: a live run once stamped `reviewConfig: null` and paid a 21.3s round trip re-deriving it before dispatch. Two fields are the opposite case — `null` there is a meaningful value, not a stand-in for absent, so do not "fix" it away: `reviewConfigPath: null` (no REVIEW.md found — pure provenance) and `limits.deliveryCap: null` (uncapped delivery — an explicit choice, not an oversight).
 
 Assemble the args waist (see `references/phase2-triage.md` for the full field list and shapes):
 

--- a/skills/code-gauntlet/references/phase2-triage.md
+++ b/skills/code-gauntlet/references/phase2-triage.md
@@ -124,7 +124,8 @@ Check for `docs/`, `specs/`, `research/` directories and `REVIEW.md`, `CLAUDE.md
 
 ## 2d. Gather Project Context
 
-1. **CLAUDE.md** — Read from repo root and directories with changed files.
+1. **CLAUDE.md / AGENTS.md / QODO.md** — resolved by `scripts/collect_project_rules.py` (step 3
+   below); never `Read` or `Glob` these directly here.
 2. **REVIEW.md** — Discover across the repo root + changed-file directories + their ancestors (the same directory set step 3 below walks for AGENTS.md/CLAUDE.md/QODO.md, issue #80) — not a CLAUDE.md-location anchor. See `references/review-md-spec.md` for format, scaffolding templates, and hierarchy rules. REVIEW.md lets maintainers set confidence/severity thresholds and finding-suppression patterns via its config block, plus custom rules and other free-text guidance folded into agent context by value. It does not gate which dimensions run — that is automatic (the trivial-scope gate below). Stamp each discovered file's raw text into `args.reviewMd` (root-first, increasing depth) — do not hand-parse it here; `resolveReviewConfig` (`workflows/src/args.js`) owns the parse/merge.
 3. **AGENTS.md / QODO.md — resolved by `scripts/collect_project_rules.py`, never `Read` directly.** A plain `Read` of a repo's CLAUDE.md does not expand Claude Code's `@path` import directive — verified empirically — and Anthropic's own docs tell AGENTS.md-using repos to write exactly that: a CLAUDE.md whose entire body is an import pointer. Measured against the benchmark mirror repos at current HEAD: sentry's and grafana's root CLAUDE.md is the identical 11-byte string `@AGENTS.md\n`; discourse's is the 40-byte inline pointer `See @AI-AGENTS.md for all instructions.\n`. A plain `Read` returns that literal pointer text as the entirety of "project rules" for three of five repos, silently — and a fourth hardcoded filename would still miss discourse's arbitrary `AI-AGENTS.md` target. Resolving the pointer, not naming more files, is the fix.
 
@@ -140,14 +141,15 @@ Check for `docs/`, `specs/`, `research/` directories and `REVIEW.md`, `CLAUDE.md
 
    **Precedence.** Sources accumulate — CLAUDE.md, AGENTS.md, and QODO.md text are additive rule content, not competing settings, so every discovered file's content is included, not just the first found. A directory-level file's rules apply to that subtree. On a direct conflict between two rules, the more specific directory wins; at equal specificity, CLAUDE.md wins over AGENTS.md over QODO.md, matching `PROJECT_RULE_FILENAMES`'s declared order. This is separate from REVIEW.md's own precedence (`references/review-md-spec.md` → Hierarchy), which this script does not touch.
 
-**Tool instructions for file discovery:**
+**Tool instructions for REVIEW.md discovery:**
 
-Use **Glob** to find all CLAUDE.md and REVIEW.md files:
-
-```
-Glob(pattern: "**/CLAUDE.md")
-Glob(pattern: "**/REVIEW.md")
-```
+Do not `Glob(pattern: "**/REVIEW.md")` — a repo-wide glob returns REVIEW.md files with no
+relationship to any changed file, which then fold into the single merged config and govern
+findings they were never meant to scope (issue #80). Walk the same directory set step 3 walks
+for AGENTS.md/CLAUDE.md/QODO.md instead: the repo root, every changed file's directory, and
+their ancestors up to root. Check each directory in that walk for a `REVIEW.md`. CLAUDE.md
+project-rules discovery is not a `Glob` either — it is resolved by
+`scripts/collect_project_rules.py` in step 3 above, never `Read` or `Glob`'d directly here.
 
 Never use `find` from Bash for locating these files.
 
@@ -166,12 +168,12 @@ set), and check each for a matching REVIEW.md:
   No REVIEW.md found. For a guided setup, run build-review-md first, then restart the review. Or continue without one.
   ```
 
-- **Root exists but subdirectory CLAUDE.md has no matching REVIEW.md:**
+- **Root exists but a walked directory has no matching REVIEW.md:**
 
   ```
   AskUserQuestion(
     questions: [{
-      question: "Found REVIEW.md at repo root, but {directory} has a CLAUDE.md without a matching REVIEW.md. A subdirectory REVIEW.md lets you set different review standards for this area. Create one?",
+      question: "Found REVIEW.md at repo root, but {directory} (in the walked set) has no matching REVIEW.md. A subdirectory REVIEW.md lets you set different review standards for this area. Create one?",
       header: "Subdirectory REVIEW.md",
       multiSelect: false,
       options: [

--- a/skills/code-gauntlet/references/phase2-triage.md
+++ b/skills/code-gauntlet/references/phase2-triage.md
@@ -125,7 +125,7 @@ Check for `docs/`, `specs/`, `research/` directories and `REVIEW.md`, `CLAUDE.md
 ## 2d. Gather Project Context
 
 1. **CLAUDE.md** — Read from repo root and directories with changed files.
-2. **REVIEW.md** — Discover hierarchically. See `references/review-md-spec.md` for format, scaffolding templates, and hierarchy rules. REVIEW.md lets maintainers set confidence/severity thresholds and finding-suppression patterns via its config block, plus custom rules and other free-text guidance folded into agent context by value. It does not gate which dimensions run — that is automatic (the trivial-scope gate below).
+2. **REVIEW.md** — Discover across the repo root + changed-file directories + their ancestors (the same directory set step 3 below walks for AGENTS.md/CLAUDE.md/QODO.md, issue #80) — not a CLAUDE.md-location anchor. See `references/review-md-spec.md` for format, scaffolding templates, and hierarchy rules. REVIEW.md lets maintainers set confidence/severity thresholds and finding-suppression patterns via its config block, plus custom rules and other free-text guidance folded into agent context by value. It does not gate which dimensions run — that is automatic (the trivial-scope gate below). Stamp each discovered file's raw text into `args.reviewMd` (root-first, increasing depth) — do not hand-parse it here; `resolveReviewConfig` (`workflows/src/args.js`) owns the parse/merge.
 3. **AGENTS.md / QODO.md — resolved by `scripts/collect_project_rules.py`, never `Read` directly.** A plain `Read` of a repo's CLAUDE.md does not expand Claude Code's `@path` import directive — verified empirically — and Anthropic's own docs tell AGENTS.md-using repos to write exactly that: a CLAUDE.md whose entire body is an import pointer. Measured against the benchmark mirror repos at current HEAD: sentry's and grafana's root CLAUDE.md is the identical 11-byte string `@AGENTS.md\n`; discourse's is the 40-byte inline pointer `See @AI-AGENTS.md for all instructions.\n`. A plain `Read` returns that literal pointer text as the entirety of "project rules" for three of five repos, silently — and a fourth hardcoded filename would still miss discourse's arbitrary `AI-AGENTS.md` target. Resolving the pointer, not naming more files, is the fix.
 
    Invoke the script directly (a standalone script call, not `python3 -c` JSON assembly), after 2c has saved the changed-files list:
@@ -157,7 +157,8 @@ Complete this check before proceeding to 2e. REVIEW.md settings cascade to all t
 
 > Headless exception (`CODE_GAUNTLET_HEADLESS=1`): skip both REVIEW.md-setup prompts below (the "No REVIEW.md found" build-review-md suggestion and the subdirectory-REVIEW.md `AskUserQuestion`). Root config applies to all directories; never invoke `build-review-md`. REVIEW.md is read-only in headless mode — the hierarchical parse still runs, but no REVIEW.md is created. See `references/headless-mode.md`.
 
-Find all CLAUDE.md locations, check each for a matching REVIEW.md:
+Walk the repo root + changed-file directories + their ancestors (the project-rules directory
+set), and check each for a matching REVIEW.md:
 
 - **No REVIEW.md anywhere:**
 
@@ -390,9 +391,10 @@ Assemble the args waist the workflow consumes. It is a single JSON object passed
 - `contextLines` / `contextChars` — the shared context file's measured size, from the write step above. **Not provenance — consumed.** `contextReadPlan` turns them into the exact `Read` calls the Summarize/Discover/Validate prompts enumerate, so the agent is told which calls to make instead of having to notice an unannounced truncation. Both optional (absent ⇒ count-free read-to-end wording); `contextChars` requires `contextLines`; both must be positive integers.
 - `changedFilesPath` — `{output_dir}/code-gauntlet-files-{head_sha_short}.json`, the on-disk companion to `changedFiles`. Optional provenance only — the workflow has no disk access and never opens it.
 - `baseBranch` — the base branch name (verify/blame).
-- `reviewConfig` — the parsed REVIEW.md object (thresholds + `ignore`), consumed by the Filter stage.
-- `exclusionPatterns` — the parsed exclusion-pattern list, consumed by the Filter stage.
-- `reviewConfigPath` — the REVIEW.md path (or `null`), carried for provenance.
+- `reviewMd` — `[{ path, text }, ...]` in discovery order (root-first, increasing depth), the raw text of every REVIEW.md found (2d step 2). Never hand-parsed by the skill: the workflow's `resolveReviewConfig` (`workflows/src/args.js`) calls `parseReviewMd` per entry and merges them (settings override deeper-wins, `ignore` accumulates) before the Filter stage runs. An empty array is a legal, authoritative "discovered nothing."
+- `exclusionsText` — the raw text of whatever exclusions source was found (e.g. `.reviewignore`), parsed by `resolveReviewConfig` via `loadExclusions`.
+- `reviewConfig` / `exclusionPatterns` — the LEGACY pre-parsed form. Still accepted for backward compatibility (bench children, older callers), but do not stamp these alongside `reviewMd`/`exclusionsText` for the same axis — the waist rejects a waist that stamps both the raw and pre-parsed form (single authority).
+- `reviewConfigPath` — the REVIEW.md path (or `null`), carried for provenance. Unrelated to the reviewMd/reviewConfig choice above.
 - `persist` — optional, `{ assembleScriptPath: "{plugin_root}/scripts/assemble_artifacts.py", returnPrimaries: true }`. **Stamp both.** It selects one of three channels. `returnPrimaries: true` takes the RETURN channel: no agent is dispatched at persist time — the workflow returns the three primaries (findings JSON, report markdown, persist plan) in its own return, and Phase 8 writes them with `materialize_artifacts.py`. `{ assembleScriptPath }` alone takes the derived-writer path: the artifact-writer transcribes those primaries and a pinned executor runs `assemble_artifacts.py` to *derive* the post-review and checkpoint artifacts from `findings.json` plus the plan, returning a content-proof receipt instead of re-emitting them by value. That path is still live and is the automatic fallback when the primaries exceed the return channel's budget, which is the only reason to stamp the script path alongside `returnPrimaries`. Absent → the legacy full by-value writer, unchanged. `artifactPaths` and Phase 8 are the same on all three; see `SKILL.md` § "`persist` (optional, but stamp it)".
 
 **`verify` handoff (sha-scoped paths for the executor's pinned command):**

--- a/skills/code-gauntlet/references/review-md-spec.md
+++ b/skills/code-gauntlet/references/review-md-spec.md
@@ -202,6 +202,15 @@ When a subdirectory has its own REVIEW.md, its settings combine with the root as
 
 In short: **settings override, rules and patterns accumulate.**
 
+**Current implementation note.** This section describes the intended per-file scoping. The
+shipped merge (`resolveReviewConfig`, `workflows/src/args.js`) does not scope by subtree yet: it
+sorts every discovered REVIEW.md root-first by path depth and folds them into **one flat config
+applied to every finding in the run**, not per-file. A deeper entry's setting still overrides a
+shallower one's in that single merged config, and `ignore` still accumulates across all of
+them — so the override/accumulate rules above hold — but a subdirectory REVIEW.md's threshold
+currently governs the whole review, not just files under that subdirectory. The worked example
+below states the intended per-file result; treat it as the target, not the current behavior.
+
 ### Example
 
 ```

--- a/skills/code-gauntlet/references/review-md-spec.md
+++ b/skills/code-gauntlet/references/review-md-spec.md
@@ -175,10 +175,13 @@ is no in-file place to put a per-entry note that both parses correctly and doesn
 
 ## Hierarchy
 
-REVIEW.md files mirror CLAUDE.md locations. A repository can have:
+REVIEW.md discovery walks the repo root, every changed file's directory, and their
+ancestors up to root — the same directory set the project-rules pass walks
+(`scripts/collect_project_rules.py`), not a CLAUDE.md-location anchor (issue #80). A
+repository can have:
 
 - A **root** `REVIEW.md` at the repo root (applies to all files by default)
-- **Subdirectory** `REVIEW.md` files in any directory that also has a `CLAUDE.md` (applies to files in that directory tree)
+- **Subdirectory** `REVIEW.md` files in any directory on that walked set (applies to files in that directory tree)
 
 Subdirectory REVIEW.md files are optional — they're only needed when different parts of the codebase need different review standards (e.g., stricter security rules for an API directory, different thresholds for a legacy module).
 
@@ -224,11 +227,19 @@ For a file in `legacy/`:
 
 ### Discovery
 
-REVIEW.md files are discovered lazily, following the same pattern as CLAUDE.md — loaded on demand for directories containing changed files. Code-gauntlet checks each CLAUDE.md location for a matching REVIEW.md during Phase 2d context gathering. AGENTS.md/QODO.md resolution (`references/phase2-triage.md` 2d step 3, `scripts/collect_project_rules.py`) is a separate discovery pass with its own source list and its own directory set — it does not piggyback on this CLAUDE.md-location anchor, and finding no AGENTS.md/QODO.md never affects REVIEW.md discovery or precedence.
+REVIEW.md discovery is repo root + changed-file directories + their ancestors — the same
+directory set as the project-rules pass (`scripts/collect_project_rules.py`). Code-gauntlet
+walks that set during Phase 2d context gathering and checks each directory for a matching
+REVIEW.md. AGENTS.md/QODO.md resolution (`references/phase2-triage.md` 2d step 3,
+`scripts/collect_project_rules.py`) shares that directory walk but remains a separate pass
+with its own source list: REVIEW.md config and AGENTS.md/CLAUDE.md project rules are still
+read and applied independently — only the directory walk is shared, not the content, and
+finding no AGENTS.md/QODO.md never affects REVIEW.md discovery or precedence.
 
 #### Detection flow (Phase 2d)
 
-Find all CLAUDE.md locations, check each for a matching REVIEW.md:
+Walk the repo root + changed-file directories + their ancestors (the project-rules directory
+set), and check each for a matching REVIEW.md:
 
 > Headless exception (`CODE_GAUNTLET_HEADLESS=1`): skip both REVIEW.md-setup `AskUserQuestion` prompts below — root config applies, `build-review-md` is never invoked, and REVIEW.md is read-only. The hierarchical parse still runs; no REVIEW.md is created. See `references/headless-mode.md`.
 

--- a/tests/test_workflows_dead_exports.py
+++ b/tests/test_workflows_dead_exports.py
@@ -23,8 +23,6 @@ _EXPORT_FN = re.compile(r"^export\s+(?:async\s+)?function\s+(\w+)\s*\(", re.M)
 
 # key: "filterFindings.js:parseReviewMd" -> inventory ID + citation
 EXPORT_ALLOWLIST = {
-    "filterFindings.js:parseReviewMd": "R-003 owned-elsewhere:#24",
-    "filterFindings.js:loadExclusions": "R-003 owned-elsewhere:#24",
     "stages.js:parseWriterPayload": "R-044 intentional-and-documented (test-only)",
     "args.js:normalizeArgs": "R-045 intentional-and-documented (test-only)",
 }

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -2010,7 +2010,7 @@ const REVIEW_MD_PATH_CONTROL_RE = /[\u0000-\u001F\u007F]/;
 // nullToleranceGap): degraded-but-disclosed, the contract this pipeline uses everywhere else.
 // A drop that validateArgs would have accepted anyway (`checkpoints`) tolerated nothing and
 // is deliberately NOT disclosed — see nullToleranceRejectedKeys.
-const NULLABLE_TOP_LEVEL = ['reviewConfig', 'exclusionPatterns', 'delivery', 'checkpoints', 'persist'];
+const NULLABLE_TOP_LEVEL = ['reviewConfig', 'exclusionPatterns', 'reviewMd', 'exclusionsText', 'delivery', 'checkpoints', 'persist'];
 
 // Issue #24 req 7: the ONE place the four benchmarked-default limits live. Every stage that
 // used to hand-roll `Math.max(1, limits.X || <literal>)` (stages.js summarize/verify/
@@ -2035,6 +2035,8 @@ const LIMIT_DEFAULTS = {
 const NULL_TOLERANCE_CONSEQUENCE = {
   reviewConfig: 'the review runs on the Filter stage built-in thresholds (non-security 55, security 70) with no ignore list, NOT your REVIEW.md configuration, so the delivered findings can differ',
   exclusionPatterns: 'no exclusion patterns are applied, so the delivered findings can differ',
+  reviewMd: 'the review runs on the Filter stage built-in thresholds (non-security 55, security 70) with no ignore list, NOT your REVIEW.md configuration, so the delivered findings can differ',
+  exclusionsText: 'no exclusion patterns are applied, so the delivered findings can differ',
   delivery: 'delivery falls back to tier "all" with no PR identity',
   'delivery.tier': 'delivery falls back to tier "all", so a narrowing intent is lost',
   'delivery.prIdentity': 'the post-review artifact is persisted as a bare findings array instead of the post_review-ready wrapper',
@@ -2705,7 +2707,7 @@ function validateArgs(args) {
 }
 
 // resolveReviewConfig(A) -> { reviewConfig, exclusionPatterns, reviewConfigSource,
-// reviewMdEntryCount } (issue #24 PR2 / #80).
+// exclusionsSource, reviewMdEntryCount } (issue #24 PR2 / #80).
 //
 // A strict SUPERSET of today's behavior: when A.reviewMd/A.exclusionsText are absent this
 // resolves to exactly A.reviewConfig/A.exclusionPatterns as before (req 8 backward compat —
@@ -2713,52 +2715,60 @@ function validateArgs(args) {
 // refuses a waist that stamps BOTH the raw and pre-parsed form for the same axis, so at most
 // one of each pair is ever present here.
 //
-// reviewMd merge order is the array's OWN order (root-first, increasing depth — the caller's
-// discovery order, never re-sorted here). Per skills/code-gauntlet/references/review-md-spec.md:
-// a later (deeper) entry's threshold SETTING overrides an earlier one's when both set it;
-// `ignore` lists ACCUMULATE across every entry, in encounter order. Absent settings are never
-// defaulted here — parseReviewMd only stamps a key when the text actually set it (see its own
-// doc comment), and this merge preserves that: a setting neither entry set stays `undefined`
-// so applyThresholdFilter's own config-absent 55/70 split (filterFindings.js) still applies.
+// reviewMd entries are stably sorted by path depth ascending (root first, ties keep their
+// original relative order) BEFORE merging — "deeper wins" is a code guarantee here, not a
+// promise the caller's discovery order happens to keep. Per
+// skills/code-gauntlet/references/review-md-spec.md: a later (deeper) entry's threshold
+// SETTING overrides an earlier one's when both set it; `ignore` lists ACCUMULATE across every
+// entry, in post-sort order. Absent settings are never defaulted here — parseReviewMd only
+// stamps a key when the text actually set it (see its own doc comment), and this merge
+// preserves that: a setting neither entry set stays `undefined` so applyThresholdFilter's own
+// config-absent 55/70 split (filterFindings.js) still applies.
 //
-// reviewConfigSource covers the REVIEW.md/exclusions pair as ONE story rather than two
-// separate provenance signals (a single field, not a per-axis pair, per this repo's
-// "extending should cost one edit" design note) — 'reviewMd' when A.reviewMd was present (even
-// an empty array: discovery ran and found nothing is still authoritative), 'preParsed' when
-// A.reviewConfig or A.exclusionPatterns was present instead, 'none' when neither pair member
-// was supplied at all.
+// reviewConfigSource and exclusionsSource are two INDEPENDENT provenance signals, one per
+// axis — 'reviewMd' when A.reviewMd was present (even an empty array: discovery ran and found
+// nothing is still authoritative) / 'exclusionsText' when A.exclusionsText was present;
+// 'preParsed' when the axis's pre-parsed field (A.reviewConfig / A.exclusionPatterns) was
+// present instead; 'none' when neither form of that axis was supplied. A mixed waist (one axis
+// raw, the other pre-parsed) is legal transition back-compat and reports one label per axis
+// accordingly — the two never need to agree.
+function pathDepth(entry) {
+  const p = (entry && entry.path) || '';
+  return p.split('/').length;
+}
+
 function resolveReviewConfig(A) {
   const a = A || {};
+  const reviewConfigSource = a.reviewMd !== undefined ? 'reviewMd'
+    : (a.reviewConfig !== undefined ? 'preParsed' : 'none');
+  const exclusionsSource = a.exclusionsText !== undefined ? 'exclusionsText'
+    : (a.exclusionPatterns !== undefined ? 'preParsed' : 'none');
+
+  let reviewConfig;
+  let reviewMdEntryCount = 0;
   if (a.reviewMd !== undefined) {
+    const sorted = a.reviewMd
+      .map((entry, index) => ({ entry, index }))
+      .sort((x, y) => (pathDepth(x.entry) - pathDepth(y.entry)) || (x.index - y.index))
+      .map((wrapped) => wrapped.entry);
     const merged = { ignore: [] };
-    for (const entry of a.reviewMd) {
+    for (const entry of sorted) {
       const parsed = parseReviewMd(entry && entry.text);
       if (parsed.confidence_threshold !== undefined) merged.confidence_threshold = parsed.confidence_threshold;
       if (parsed.security_min_confidence !== undefined) merged.security_min_confidence = parsed.security_min_confidence;
       if (parsed.severity_threshold !== undefined) merged.severity_threshold = parsed.severity_threshold;
       merged.ignore.push(...parsed.ignore);
     }
-    return {
-      reviewConfig: merged,
-      exclusionPatterns: a.exclusionsText !== undefined ? loadExclusions(a.exclusionsText) : (a.exclusionPatterns || []),
-      reviewConfigSource: 'reviewMd',
-      reviewMdEntryCount: a.reviewMd.length,
-    };
+    reviewConfig = merged;
+    reviewMdEntryCount = a.reviewMd.length;
+  } else {
+    reviewConfig = a.reviewConfig || {};
   }
-  if (a.exclusionsText !== undefined) {
-    return {
-      reviewConfig: a.reviewConfig || {},
-      exclusionPatterns: loadExclusions(a.exclusionsText),
-      reviewConfigSource: 'reviewMd',
-      reviewMdEntryCount: 0,
-    };
-  }
-  return {
-    reviewConfig: a.reviewConfig || {},
-    exclusionPatterns: a.exclusionPatterns || [],
-    reviewConfigSource: (a.reviewConfig !== undefined || a.exclusionPatterns !== undefined) ? 'preParsed' : 'none',
-    reviewMdEntryCount: 0,
-  };
+
+  const exclusionPatterns = a.exclusionsText !== undefined ? loadExclusions(a.exclusionsText)
+    : (a.exclusionPatterns || []);
+
+  return { reviewConfig, exclusionPatterns, reviewConfigSource, exclusionsSource, reviewMdEntryCount };
 }
 
 // --- stages.js ---
@@ -6520,9 +6530,11 @@ async function runWith(ctx, rawArgs) {
         validate: validateOut.stats,
         filter: filterOut.stats,
         // Compact provenance echo (issue #24 PR2): names/counts only, never bulk content —
-        // no raw REVIEW.md text, no full config object. 'reviewMd' | 'preParsed' | 'none';
-        // see resolveReviewConfig's doc comment (args.js) for the full contract.
+        // no raw REVIEW.md text, no full config object. Two independent per-axis signals,
+        // each 'reviewMd'/'exclusionsText' | 'preParsed' | 'none'; see resolveReviewConfig's
+        // doc comment (args.js) for the full contract.
         reviewConfigSource: resolvedReview.reviewConfigSource,
+        exclusionsSource: resolvedReview.exclusionsSource,
         reviewMdEntryCount: resolvedReview.reviewMdEntryCount,
         challenge: challengeOut.stats,
       },

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -1936,6 +1936,7 @@ function resolvePolicy(agentType, opts = {}) {
 }
 
 // --- args.js ---
+
 // args.js — the pipeline args waist: ARGS_VERSION, normalizeArgs, validateArgs.
 // Single producer of the waist shape that bench and the pipeline entry both consume.
 //
@@ -1980,6 +1981,12 @@ const DELIVERY_TIERS = ['all', 'main_only'];
 // names, so gateway sessions are firstParty; non-standard gateway names go through the
 // subagentModel escape hatch.
 const POLICY_PROVIDERS = ['firstParty', 'bedrock', 'vertex', 'foundry'];
+
+// Shared with PATH_CONTROL_RE further down (declared locally there because it sits inside
+// validateArgs); duplicated at module scope here so the reviewMd[].path guard above — which
+// runs earlier in validateArgs, before that local const is declared in source order — can
+// reuse the identical charset without a forward reference.
+const REVIEW_MD_PATH_CONTROL_RE = /[\u0000-\u001F\u007F]/;
 
 // Issue #38 A1 (measured): a dispatch was rejected solely because reviewConfig arrived as a
 // stamped `null` rather than absent — a wasted model round trip. These five top-level
@@ -2538,6 +2545,64 @@ function validateArgs(args) {
       }
     }
   }
+  // Optional reviewMd (issue #24 PR2): the raw, ORDERED discovery of REVIEW.md files —
+  // root-first, increasing directory depth — as [{path, text}]. This is the RAW-text
+  // counterpart to the pre-parsed `reviewConfig` above: resolveReviewConfig (below) turns it
+  // into the same shape reviewConfig has always had by calling parseReviewMd per entry and
+  // merging in array order. An empty array is a legal, authoritative "discovery ran and found
+  // nothing" signal — distinct from the field being absent entirely (see resolveReviewConfig's
+  // reviewConfigSource). `path` is repo-relative (must NOT start with '/', the opposite
+  // convention from repoRoot/outputDir above, which must) and reuses PATH_CONTROL_RE below via
+  // a local copy since this guard runs before that regex is declared in file order... — see
+  // REVIEW_MD_PATH_CONTROL_RE just below, same pattern.
+  if (args.reviewMd !== undefined) {
+    if (!Array.isArray(args.reviewMd)) {
+      errors.push('reviewMd must be an array of {path, text} objects when present');
+    } else {
+      for (let i = 0; i < args.reviewMd.length; i++) {
+        const entry = args.reviewMd[i];
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+          errors.push(`reviewMd[${i}] must be an object of the form {path, text}`);
+          continue;
+        }
+        const keys = Object.keys(entry).sort();
+        const extra = keys.filter((k) => k !== 'path' && k !== 'text');
+        if (extra.length > 0) {
+          errors.push(`reviewMd[${i}] has unexpected key(s): ${extra.join(', ')} (only path and text are allowed)`);
+        }
+        if (typeof entry.path !== 'string' || entry.path === '') {
+          errors.push(`reviewMd[${i}].path must be a non-empty string`);
+        } else {
+          if (REVIEW_MD_PATH_CONTROL_RE.test(entry.path)) {
+            errors.push(`reviewMd[${i}].path must not contain a control character`);
+          }
+          if (entry.path.startsWith('/')) {
+            errors.push(`reviewMd[${i}].path must be repo-relative (must not start with /)`);
+          }
+        }
+        if (typeof entry.text !== 'string') {
+          errors.push(`reviewMd[${i}].text must be a string`);
+        }
+      }
+    }
+  }
+  // Optional exclusionsText (issue #24 PR2): the raw text of whatever exclusions source the
+  // skill discovered (e.g. .reviewignore), consumed by loadExclusions (filterFindings.js) in
+  // resolveReviewConfig below. Empty string is legal (an exclusions file that exists but is
+  // empty).
+  if (args.exclusionsText !== undefined && typeof args.exclusionsText !== 'string') {
+    errors.push('exclusionsText must be a string when present');
+  }
+  // Single-authority guards (issue #24 req 4 analog): a caller must pass EITHER the raw
+  // discovery (reviewMd/exclusionsText) OR the pre-parsed shape (reviewConfig/
+  // exclusionPatterns), never both for the same axis — two authorities for one piece of
+  // config is exactly the silent-substitution hazard this waist exists to refuse loudly.
+  if (args.reviewMd !== undefined && args.reviewConfig !== undefined) {
+    errors.push('reviewMd and reviewConfig are both present — pass raw reviewMd or pre-parsed reviewConfig, not both (single authority)');
+  }
+  if (args.exclusionsText !== undefined && args.exclusionPatterns !== undefined) {
+    errors.push('exclusionsText and exclusionPatterns are both present — pass raw exclusionsText or pre-parsed exclusionPatterns, not both (single authority)');
+  }
   // Optional delivery selector. Absence is fine; when present it must be an object, and a
   // present tier must be a known value — an unknown tier would otherwise fall through to the
   // 'all' default in selectDelivery, silently ignoring an operator's narrowing intent.
@@ -2637,6 +2702,63 @@ function validateArgs(args) {
     }
   }
   return { ok: errors.length === 0, errors };
+}
+
+// resolveReviewConfig(A) -> { reviewConfig, exclusionPatterns, reviewConfigSource,
+// reviewMdEntryCount } (issue #24 PR2 / #80).
+//
+// A strict SUPERSET of today's behavior: when A.reviewMd/A.exclusionsText are absent this
+// resolves to exactly A.reviewConfig/A.exclusionPatterns as before (req 8 backward compat —
+// bench children and older invocation shapes are unaffected). validateArgs above already
+// refuses a waist that stamps BOTH the raw and pre-parsed form for the same axis, so at most
+// one of each pair is ever present here.
+//
+// reviewMd merge order is the array's OWN order (root-first, increasing depth — the caller's
+// discovery order, never re-sorted here). Per skills/code-gauntlet/references/review-md-spec.md:
+// a later (deeper) entry's threshold SETTING overrides an earlier one's when both set it;
+// `ignore` lists ACCUMULATE across every entry, in encounter order. Absent settings are never
+// defaulted here — parseReviewMd only stamps a key when the text actually set it (see its own
+// doc comment), and this merge preserves that: a setting neither entry set stays `undefined`
+// so applyThresholdFilter's own config-absent 55/70 split (filterFindings.js) still applies.
+//
+// reviewConfigSource covers the REVIEW.md/exclusions pair as ONE story rather than two
+// separate provenance signals (a single field, not a per-axis pair, per this repo's
+// "extending should cost one edit" design note) — 'reviewMd' when A.reviewMd was present (even
+// an empty array: discovery ran and found nothing is still authoritative), 'preParsed' when
+// A.reviewConfig or A.exclusionPatterns was present instead, 'none' when neither pair member
+// was supplied at all.
+function resolveReviewConfig(A) {
+  const a = A || {};
+  if (a.reviewMd !== undefined) {
+    const merged = { ignore: [] };
+    for (const entry of a.reviewMd) {
+      const parsed = parseReviewMd(entry && entry.text);
+      if (parsed.confidence_threshold !== undefined) merged.confidence_threshold = parsed.confidence_threshold;
+      if (parsed.security_min_confidence !== undefined) merged.security_min_confidence = parsed.security_min_confidence;
+      if (parsed.severity_threshold !== undefined) merged.severity_threshold = parsed.severity_threshold;
+      merged.ignore.push(...parsed.ignore);
+    }
+    return {
+      reviewConfig: merged,
+      exclusionPatterns: a.exclusionsText !== undefined ? loadExclusions(a.exclusionsText) : (a.exclusionPatterns || []),
+      reviewConfigSource: 'reviewMd',
+      reviewMdEntryCount: a.reviewMd.length,
+    };
+  }
+  if (a.exclusionsText !== undefined) {
+    return {
+      reviewConfig: a.reviewConfig || {},
+      exclusionPatterns: loadExclusions(a.exclusionsText),
+      reviewConfigSource: 'reviewMd',
+      reviewMdEntryCount: 0,
+    };
+  }
+  return {
+    reviewConfig: a.reviewConfig || {},
+    exclusionPatterns: a.exclusionPatterns || [],
+    reviewConfigSource: (a.reviewConfig !== undefined || a.exclusionPatterns !== undefined) ? 'preParsed' : 'none',
+    reviewMdEntryCount: 0,
+  };
 }
 
 // --- stages.js ---
@@ -6246,9 +6368,15 @@ async function runWith(ctx, rawArgs) {
     }));
     gaps.push(...(validateOut.gaps || []));
 
+    // resolveReviewConfig (issue #24 PR2): a strict superset of the old A.reviewConfig ||
+    // {} / A.exclusionPatterns || [] passthrough — when A.reviewMd/A.exclusionsText are
+    // absent this resolves to exactly that, unchanged. filterStage's own input shape
+    // ({findings, reviewConfig, exclusionPatterns, generatedAt}) stays untouched (parity
+    // seam, issue #24 req 9).
+    const resolvedReview = resolveReviewConfig(A);
     const filterOut = await runPhase('filter', () => filterStage({
-      findings: validateOut.findings || [], reviewConfig: A.reviewConfig || {},
-      exclusionPatterns: A.exclusionPatterns || [], generatedAt: A.generatedAt,
+      findings: validateOut.findings || [], reviewConfig: resolvedReview.reviewConfig,
+      exclusionPatterns: resolvedReview.exclusionPatterns, generatedAt: A.generatedAt,
     }));
 
     const challengeOut = await runPhase('challenge', () => challengeStage(c, {
@@ -6391,6 +6519,11 @@ async function runWith(ctx, rawArgs) {
         degraded: discoverOut.degraded || [],
         validate: validateOut.stats,
         filter: filterOut.stats,
+        // Compact provenance echo (issue #24 PR2): names/counts only, never bulk content —
+        // no raw REVIEW.md text, no full config object. 'reviewMd' | 'preParsed' | 'none';
+        // see resolveReviewConfig's doc comment (args.js) for the full contract.
+        reviewConfigSource: resolvedReview.reviewConfigSource,
+        reviewMdEntryCount: resolvedReview.reviewMdEntryCount,
         challenge: challengeOut.stats,
       },
       artifactPaths: writeOut.artifactPaths,

--- a/workflows/src/args.js
+++ b/workflows/src/args.js
@@ -73,7 +73,7 @@ const REVIEW_MD_PATH_CONTROL_RE = /[\u0000-\u001F\u007F]/;
 // nullToleranceGap): degraded-but-disclosed, the contract this pipeline uses everywhere else.
 // A drop that validateArgs would have accepted anyway (`checkpoints`) tolerated nothing and
 // is deliberately NOT disclosed — see nullToleranceRejectedKeys.
-const NULLABLE_TOP_LEVEL = ['reviewConfig', 'exclusionPatterns', 'delivery', 'checkpoints', 'persist'];
+const NULLABLE_TOP_LEVEL = ['reviewConfig', 'exclusionPatterns', 'reviewMd', 'exclusionsText', 'delivery', 'checkpoints', 'persist'];
 
 // Issue #24 req 7: the ONE place the four benchmarked-default limits live. Every stage that
 // used to hand-roll `Math.max(1, limits.X || <literal>)` (stages.js summarize/verify/
@@ -98,6 +98,8 @@ export const LIMIT_DEFAULTS = {
 const NULL_TOLERANCE_CONSEQUENCE = {
   reviewConfig: 'the review runs on the Filter stage built-in thresholds (non-security 55, security 70) with no ignore list, NOT your REVIEW.md configuration, so the delivered findings can differ',
   exclusionPatterns: 'no exclusion patterns are applied, so the delivered findings can differ',
+  reviewMd: 'the review runs on the Filter stage built-in thresholds (non-security 55, security 70) with no ignore list, NOT your REVIEW.md configuration, so the delivered findings can differ',
+  exclusionsText: 'no exclusion patterns are applied, so the delivered findings can differ',
   delivery: 'delivery falls back to tier "all" with no PR identity',
   'delivery.tier': 'delivery falls back to tier "all", so a narrowing intent is lost',
   'delivery.prIdentity': 'the post-review artifact is persisted as a bare findings array instead of the post_review-ready wrapper',
@@ -768,7 +770,7 @@ export function validateArgs(args) {
 }
 
 // resolveReviewConfig(A) -> { reviewConfig, exclusionPatterns, reviewConfigSource,
-// reviewMdEntryCount } (issue #24 PR2 / #80).
+// exclusionsSource, reviewMdEntryCount } (issue #24 PR2 / #80).
 //
 // A strict SUPERSET of today's behavior: when A.reviewMd/A.exclusionsText are absent this
 // resolves to exactly A.reviewConfig/A.exclusionPatterns as before (req 8 backward compat —
@@ -776,50 +778,58 @@ export function validateArgs(args) {
 // refuses a waist that stamps BOTH the raw and pre-parsed form for the same axis, so at most
 // one of each pair is ever present here.
 //
-// reviewMd merge order is the array's OWN order (root-first, increasing depth — the caller's
-// discovery order, never re-sorted here). Per skills/code-gauntlet/references/review-md-spec.md:
-// a later (deeper) entry's threshold SETTING overrides an earlier one's when both set it;
-// `ignore` lists ACCUMULATE across every entry, in encounter order. Absent settings are never
-// defaulted here — parseReviewMd only stamps a key when the text actually set it (see its own
-// doc comment), and this merge preserves that: a setting neither entry set stays `undefined`
-// so applyThresholdFilter's own config-absent 55/70 split (filterFindings.js) still applies.
+// reviewMd entries are stably sorted by path depth ascending (root first, ties keep their
+// original relative order) BEFORE merging — "deeper wins" is a code guarantee here, not a
+// promise the caller's discovery order happens to keep. Per
+// skills/code-gauntlet/references/review-md-spec.md: a later (deeper) entry's threshold
+// SETTING overrides an earlier one's when both set it; `ignore` lists ACCUMULATE across every
+// entry, in post-sort order. Absent settings are never defaulted here — parseReviewMd only
+// stamps a key when the text actually set it (see its own doc comment), and this merge
+// preserves that: a setting neither entry set stays `undefined` so applyThresholdFilter's own
+// config-absent 55/70 split (filterFindings.js) still applies.
 //
-// reviewConfigSource covers the REVIEW.md/exclusions pair as ONE story rather than two
-// separate provenance signals (a single field, not a per-axis pair, per this repo's
-// "extending should cost one edit" design note) — 'reviewMd' when A.reviewMd was present (even
-// an empty array: discovery ran and found nothing is still authoritative), 'preParsed' when
-// A.reviewConfig or A.exclusionPatterns was present instead, 'none' when neither pair member
-// was supplied at all.
+// reviewConfigSource and exclusionsSource are two INDEPENDENT provenance signals, one per
+// axis — 'reviewMd' when A.reviewMd was present (even an empty array: discovery ran and found
+// nothing is still authoritative) / 'exclusionsText' when A.exclusionsText was present;
+// 'preParsed' when the axis's pre-parsed field (A.reviewConfig / A.exclusionPatterns) was
+// present instead; 'none' when neither form of that axis was supplied. A mixed waist (one axis
+// raw, the other pre-parsed) is legal transition back-compat and reports one label per axis
+// accordingly — the two never need to agree.
+function pathDepth(entry) {
+  const p = (entry && entry.path) || '';
+  return p.split('/').length;
+}
+
 export function resolveReviewConfig(A) {
   const a = A || {};
+  const reviewConfigSource = a.reviewMd !== undefined ? 'reviewMd'
+    : (a.reviewConfig !== undefined ? 'preParsed' : 'none');
+  const exclusionsSource = a.exclusionsText !== undefined ? 'exclusionsText'
+    : (a.exclusionPatterns !== undefined ? 'preParsed' : 'none');
+
+  let reviewConfig;
+  let reviewMdEntryCount = 0;
   if (a.reviewMd !== undefined) {
+    const sorted = a.reviewMd
+      .map((entry, index) => ({ entry, index }))
+      .sort((x, y) => (pathDepth(x.entry) - pathDepth(y.entry)) || (x.index - y.index))
+      .map((wrapped) => wrapped.entry);
     const merged = { ignore: [] };
-    for (const entry of a.reviewMd) {
+    for (const entry of sorted) {
       const parsed = parseReviewMd(entry && entry.text);
       if (parsed.confidence_threshold !== undefined) merged.confidence_threshold = parsed.confidence_threshold;
       if (parsed.security_min_confidence !== undefined) merged.security_min_confidence = parsed.security_min_confidence;
       if (parsed.severity_threshold !== undefined) merged.severity_threshold = parsed.severity_threshold;
       merged.ignore.push(...parsed.ignore);
     }
-    return {
-      reviewConfig: merged,
-      exclusionPatterns: a.exclusionsText !== undefined ? loadExclusions(a.exclusionsText) : (a.exclusionPatterns || []),
-      reviewConfigSource: 'reviewMd',
-      reviewMdEntryCount: a.reviewMd.length,
-    };
+    reviewConfig = merged;
+    reviewMdEntryCount = a.reviewMd.length;
+  } else {
+    reviewConfig = a.reviewConfig || {};
   }
-  if (a.exclusionsText !== undefined) {
-    return {
-      reviewConfig: a.reviewConfig || {},
-      exclusionPatterns: loadExclusions(a.exclusionsText),
-      reviewConfigSource: 'reviewMd',
-      reviewMdEntryCount: 0,
-    };
-  }
-  return {
-    reviewConfig: a.reviewConfig || {},
-    exclusionPatterns: a.exclusionPatterns || [],
-    reviewConfigSource: (a.reviewConfig !== undefined || a.exclusionPatterns !== undefined) ? 'preParsed' : 'none',
-    reviewMdEntryCount: 0,
-  };
+
+  const exclusionPatterns = a.exclusionsText !== undefined ? loadExclusions(a.exclusionsText)
+    : (a.exclusionPatterns || []);
+
+  return { reviewConfig, exclusionPatterns, reviewConfigSource, exclusionsSource, reviewMdEntryCount };
 }

--- a/workflows/src/args.js
+++ b/workflows/src/args.js
@@ -1,3 +1,5 @@
+import { parseReviewMd, loadExclusions } from './filterFindings.js';
+
 // args.js — the pipeline args waist: ARGS_VERSION, normalizeArgs, validateArgs.
 // Single producer of the waist shape that bench and the pipeline entry both consume.
 //
@@ -42,6 +44,12 @@ const DELIVERY_TIERS = ['all', 'main_only'];
 // names, so gateway sessions are firstParty; non-standard gateway names go through the
 // subagentModel escape hatch.
 const POLICY_PROVIDERS = ['firstParty', 'bedrock', 'vertex', 'foundry'];
+
+// Shared with PATH_CONTROL_RE further down (declared locally there because it sits inside
+// validateArgs); duplicated at module scope here so the reviewMd[].path guard above — which
+// runs earlier in validateArgs, before that local const is declared in source order — can
+// reuse the identical charset without a forward reference.
+const REVIEW_MD_PATH_CONTROL_RE = /[\u0000-\u001F\u007F]/;
 
 // Issue #38 A1 (measured): a dispatch was rejected solely because reviewConfig arrived as a
 // stamped `null` rather than absent — a wasted model round trip. These five top-level
@@ -600,6 +608,64 @@ export function validateArgs(args) {
       }
     }
   }
+  // Optional reviewMd (issue #24 PR2): the raw, ORDERED discovery of REVIEW.md files —
+  // root-first, increasing directory depth — as [{path, text}]. This is the RAW-text
+  // counterpart to the pre-parsed `reviewConfig` above: resolveReviewConfig (below) turns it
+  // into the same shape reviewConfig has always had by calling parseReviewMd per entry and
+  // merging in array order. An empty array is a legal, authoritative "discovery ran and found
+  // nothing" signal — distinct from the field being absent entirely (see resolveReviewConfig's
+  // reviewConfigSource). `path` is repo-relative (must NOT start with '/', the opposite
+  // convention from repoRoot/outputDir above, which must) and reuses PATH_CONTROL_RE below via
+  // a local copy since this guard runs before that regex is declared in file order... — see
+  // REVIEW_MD_PATH_CONTROL_RE just below, same pattern.
+  if (args.reviewMd !== undefined) {
+    if (!Array.isArray(args.reviewMd)) {
+      errors.push('reviewMd must be an array of {path, text} objects when present');
+    } else {
+      for (let i = 0; i < args.reviewMd.length; i++) {
+        const entry = args.reviewMd[i];
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+          errors.push(`reviewMd[${i}] must be an object of the form {path, text}`);
+          continue;
+        }
+        const keys = Object.keys(entry).sort();
+        const extra = keys.filter((k) => k !== 'path' && k !== 'text');
+        if (extra.length > 0) {
+          errors.push(`reviewMd[${i}] has unexpected key(s): ${extra.join(', ')} (only path and text are allowed)`);
+        }
+        if (typeof entry.path !== 'string' || entry.path === '') {
+          errors.push(`reviewMd[${i}].path must be a non-empty string`);
+        } else {
+          if (REVIEW_MD_PATH_CONTROL_RE.test(entry.path)) {
+            errors.push(`reviewMd[${i}].path must not contain a control character`);
+          }
+          if (entry.path.startsWith('/')) {
+            errors.push(`reviewMd[${i}].path must be repo-relative (must not start with /)`);
+          }
+        }
+        if (typeof entry.text !== 'string') {
+          errors.push(`reviewMd[${i}].text must be a string`);
+        }
+      }
+    }
+  }
+  // Optional exclusionsText (issue #24 PR2): the raw text of whatever exclusions source the
+  // skill discovered (e.g. .reviewignore), consumed by loadExclusions (filterFindings.js) in
+  // resolveReviewConfig below. Empty string is legal (an exclusions file that exists but is
+  // empty).
+  if (args.exclusionsText !== undefined && typeof args.exclusionsText !== 'string') {
+    errors.push('exclusionsText must be a string when present');
+  }
+  // Single-authority guards (issue #24 req 4 analog): a caller must pass EITHER the raw
+  // discovery (reviewMd/exclusionsText) OR the pre-parsed shape (reviewConfig/
+  // exclusionPatterns), never both for the same axis — two authorities for one piece of
+  // config is exactly the silent-substitution hazard this waist exists to refuse loudly.
+  if (args.reviewMd !== undefined && args.reviewConfig !== undefined) {
+    errors.push('reviewMd and reviewConfig are both present — pass raw reviewMd or pre-parsed reviewConfig, not both (single authority)');
+  }
+  if (args.exclusionsText !== undefined && args.exclusionPatterns !== undefined) {
+    errors.push('exclusionsText and exclusionPatterns are both present — pass raw exclusionsText or pre-parsed exclusionPatterns, not both (single authority)');
+  }
   // Optional delivery selector. Absence is fine; when present it must be an object, and a
   // present tier must be a known value — an unknown tier would otherwise fall through to the
   // 'all' default in selectDelivery, silently ignoring an operator's narrowing intent.
@@ -699,4 +765,61 @@ export function validateArgs(args) {
     }
   }
   return { ok: errors.length === 0, errors };
+}
+
+// resolveReviewConfig(A) -> { reviewConfig, exclusionPatterns, reviewConfigSource,
+// reviewMdEntryCount } (issue #24 PR2 / #80).
+//
+// A strict SUPERSET of today's behavior: when A.reviewMd/A.exclusionsText are absent this
+// resolves to exactly A.reviewConfig/A.exclusionPatterns as before (req 8 backward compat —
+// bench children and older invocation shapes are unaffected). validateArgs above already
+// refuses a waist that stamps BOTH the raw and pre-parsed form for the same axis, so at most
+// one of each pair is ever present here.
+//
+// reviewMd merge order is the array's OWN order (root-first, increasing depth — the caller's
+// discovery order, never re-sorted here). Per skills/code-gauntlet/references/review-md-spec.md:
+// a later (deeper) entry's threshold SETTING overrides an earlier one's when both set it;
+// `ignore` lists ACCUMULATE across every entry, in encounter order. Absent settings are never
+// defaulted here — parseReviewMd only stamps a key when the text actually set it (see its own
+// doc comment), and this merge preserves that: a setting neither entry set stays `undefined`
+// so applyThresholdFilter's own config-absent 55/70 split (filterFindings.js) still applies.
+//
+// reviewConfigSource covers the REVIEW.md/exclusions pair as ONE story rather than two
+// separate provenance signals (a single field, not a per-axis pair, per this repo's
+// "extending should cost one edit" design note) — 'reviewMd' when A.reviewMd was present (even
+// an empty array: discovery ran and found nothing is still authoritative), 'preParsed' when
+// A.reviewConfig or A.exclusionPatterns was present instead, 'none' when neither pair member
+// was supplied at all.
+export function resolveReviewConfig(A) {
+  const a = A || {};
+  if (a.reviewMd !== undefined) {
+    const merged = { ignore: [] };
+    for (const entry of a.reviewMd) {
+      const parsed = parseReviewMd(entry && entry.text);
+      if (parsed.confidence_threshold !== undefined) merged.confidence_threshold = parsed.confidence_threshold;
+      if (parsed.security_min_confidence !== undefined) merged.security_min_confidence = parsed.security_min_confidence;
+      if (parsed.severity_threshold !== undefined) merged.severity_threshold = parsed.severity_threshold;
+      merged.ignore.push(...parsed.ignore);
+    }
+    return {
+      reviewConfig: merged,
+      exclusionPatterns: a.exclusionsText !== undefined ? loadExclusions(a.exclusionsText) : (a.exclusionPatterns || []),
+      reviewConfigSource: 'reviewMd',
+      reviewMdEntryCount: a.reviewMd.length,
+    };
+  }
+  if (a.exclusionsText !== undefined) {
+    return {
+      reviewConfig: a.reviewConfig || {},
+      exclusionPatterns: loadExclusions(a.exclusionsText),
+      reviewConfigSource: 'reviewMd',
+      reviewMdEntryCount: 0,
+    };
+  }
+  return {
+    reviewConfig: a.reviewConfig || {},
+    exclusionPatterns: a.exclusionPatterns || [],
+    reviewConfigSource: (a.reviewConfig !== undefined || a.exclusionPatterns !== undefined) ? 'preParsed' : 'none',
+    reviewMdEntryCount: 0,
+  };
 }

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -21,7 +21,7 @@ import { merge } from './mergeFindings.js';
 import { applyValidations, pyIntStrict } from './applyValidations.js';
 import { applyFilterPipeline, SEVERITY_ORDER } from './filterFindings.js';
 import { applyChallenges, rankFindings, deepClone } from './applyChallenges.js';
-import { normalizeArgsReport, nullToleranceGap, nullToleranceRejectedKeys, validateArgs, entryArgs, makeArgsRejectEnvelope, SKILL_RECOVERY_LINE, LIMIT_DEFAULTS } from './args.js';
+import { normalizeArgsReport, nullToleranceGap, nullToleranceRejectedKeys, validateArgs, entryArgs, makeArgsRejectEnvelope, SKILL_RECOVERY_LINE, LIMIT_DEFAULTS, resolveReviewConfig } from './args.js';
 
 // Runtime globals are injected by the workflow host; under node:test they are absent,
 // so ctx must be supplied. defaultCtx lets the shipped pipeline call stages without wiring.
@@ -3610,9 +3610,15 @@ export async function runWith(ctx, rawArgs) {
     }));
     gaps.push(...(validateOut.gaps || []));
 
+    // resolveReviewConfig (issue #24 PR2): a strict superset of the old A.reviewConfig ||
+    // {} / A.exclusionPatterns || [] passthrough — when A.reviewMd/A.exclusionsText are
+    // absent this resolves to exactly that, unchanged. filterStage's own input shape
+    // ({findings, reviewConfig, exclusionPatterns, generatedAt}) stays untouched (parity
+    // seam, issue #24 req 9).
+    const resolvedReview = resolveReviewConfig(A);
     const filterOut = await runPhase('filter', () => filterStage({
-      findings: validateOut.findings || [], reviewConfig: A.reviewConfig || {},
-      exclusionPatterns: A.exclusionPatterns || [], generatedAt: A.generatedAt,
+      findings: validateOut.findings || [], reviewConfig: resolvedReview.reviewConfig,
+      exclusionPatterns: resolvedReview.exclusionPatterns, generatedAt: A.generatedAt,
     }));
 
     const challengeOut = await runPhase('challenge', () => challengeStage(c, {
@@ -3755,6 +3761,11 @@ export async function runWith(ctx, rawArgs) {
         degraded: discoverOut.degraded || [],
         validate: validateOut.stats,
         filter: filterOut.stats,
+        // Compact provenance echo (issue #24 PR2): names/counts only, never bulk content —
+        // no raw REVIEW.md text, no full config object. 'reviewMd' | 'preParsed' | 'none';
+        // see resolveReviewConfig's doc comment (args.js) for the full contract.
+        reviewConfigSource: resolvedReview.reviewConfigSource,
+        reviewMdEntryCount: resolvedReview.reviewMdEntryCount,
         challenge: challengeOut.stats,
       },
       artifactPaths: writeOut.artifactPaths,

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -3762,9 +3762,11 @@ export async function runWith(ctx, rawArgs) {
         validate: validateOut.stats,
         filter: filterOut.stats,
         // Compact provenance echo (issue #24 PR2): names/counts only, never bulk content —
-        // no raw REVIEW.md text, no full config object. 'reviewMd' | 'preParsed' | 'none';
-        // see resolveReviewConfig's doc comment (args.js) for the full contract.
+        // no raw REVIEW.md text, no full config object. Two independent per-axis signals,
+        // each 'reviewMd'/'exclusionsText' | 'preParsed' | 'none'; see resolveReviewConfig's
+        // doc comment (args.js) for the full contract.
         reviewConfigSource: resolvedReview.reviewConfigSource,
+        exclusionsSource: resolvedReview.exclusionsSource,
         reviewMdEntryCount: resolvedReview.reviewMdEntryCount,
         challenge: challengeOut.stats,
       },

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import {
   ARGS_VERSION, normalizeArgs, validateArgs, parseEntryArgs,
   stripNullOptionalsReport, normalizeArgsReport, nullToleranceGap, LIMIT_DEFAULTS,
+  resolveReviewConfig,
 } from '../src/args.js';
 
 const good = {
@@ -671,4 +672,121 @@ test('validateArgs rejects a zero/negative/non-integer discoveryCap when present
     assert.equal(r.ok, false, `limits.discoveryCap=${bad} should be rejected`);
   }
   assert.deepEqual(validateArgs(good), { ok: true, errors: [] });
+});
+
+// --- reviewMd / exclusionsText (issue #24 PR2) -------------------------------
+
+test('validateArgs accepts a well-formed reviewMd array', () => {
+  const r = validateArgs({ ...good, reviewMd: [{ path: 'REVIEW.md', text: '' }, { path: 'src/REVIEW.md', text: 'ignore:\n  - foo' }] });
+  assert.deepEqual(r, { ok: true, errors: [] });
+});
+test('validateArgs accepts an empty reviewMd array (authoritative "found nothing")', () => {
+  assert.deepEqual(validateArgs({ ...good, reviewMd: [] }), { ok: true, errors: [] });
+});
+test('validateArgs rejects a non-array reviewMd', () => {
+  const r = validateArgs({ ...good, reviewMd: { path: 'x', text: '' } });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /reviewMd must be an array/);
+});
+test('validateArgs rejects a reviewMd entry with an extra key', () => {
+  const r = validateArgs({ ...good, reviewMd: [{ path: 'x', text: '', extra: 1 }] });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /unexpected key/);
+});
+test('validateArgs rejects a reviewMd entry missing path or text', () => {
+  assert.equal(validateArgs({ ...good, reviewMd: [{ text: 'x' }] }).ok, false);
+  assert.equal(validateArgs({ ...good, reviewMd: [{ path: 'x' }] }).ok, false);
+});
+test('validateArgs rejects an absolute reviewMd path', () => {
+  const r = validateArgs({ ...good, reviewMd: [{ path: '/foo/REVIEW.md', text: '' }] });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /repo-relative/);
+});
+test('validateArgs rejects non-string reviewMd text', () => {
+  const r = validateArgs({ ...good, reviewMd: [{ path: 'x', text: 123 }] });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /text must be a string/);
+});
+test('validateArgs rejects non-string reviewMd path', () => {
+  const r = validateArgs({ ...good, reviewMd: [{ path: 123, text: '' }] });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /path must be a non-empty string/);
+});
+test('validateArgs rejects a reviewMd path with a control character', () => {
+  const r = validateArgs({ ...good, reviewMd: [{ path: 'foo bar', text: '' }] });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /control character/);
+});
+test('validateArgs rejects reviewMd + reviewConfig both present (single authority)', () => {
+  const r = validateArgs({ ...good, reviewMd: [], reviewConfig: { ignore: [] } });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /reviewMd and reviewConfig are both present/);
+});
+test('validateArgs rejects exclusionsText + exclusionPatterns both present (single authority)', () => {
+  const r = validateArgs({ ...good, exclusionsText: '', exclusionPatterns: [] });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /exclusionsText and exclusionPatterns are both present/);
+});
+test('validateArgs accepts exclusionsText alone', () => {
+  assert.deepEqual(validateArgs({ ...good, exclusionsText: 'foo.js\n' }), { ok: true, errors: [] });
+});
+test('validateArgs rejects non-string exclusionsText', () => {
+  const r = validateArgs({ ...good, exclusionsText: 42 });
+  assert.equal(r.ok, false);
+  assert.match(r.errors.join(' '), /exclusionsText must be a string/);
+});
+test('validateArgs: reviewConfig alone (no reviewMd) still validates cleanly (req 8 backward compat)', () => {
+  assert.deepEqual(validateArgs({ ...good, reviewConfig: { ignore: ['x'] } }), { ok: true, errors: [] });
+});
+
+// --- resolveReviewConfig (issue #24 PR2) -------------------------------------
+
+test('resolveReviewConfig: absent reviewMd/exclusionsText falls back to reviewConfig/exclusionPatterns unchanged (req 8)', () => {
+  const A = { reviewConfig: { ignore: ['a'] }, exclusionPatterns: ['b'] };
+  assert.deepEqual(resolveReviewConfig(A), {
+    reviewConfig: { ignore: ['a'] }, exclusionPatterns: ['b'],
+    reviewConfigSource: 'preParsed', reviewMdEntryCount: 0,
+  });
+});
+test('resolveReviewConfig: neither present -> source "none"', () => {
+  assert.deepEqual(resolveReviewConfig({}), {
+    reviewConfig: {}, exclusionPatterns: [], reviewConfigSource: 'none', reviewMdEntryCount: 0,
+  });
+});
+test('resolveReviewConfig: single reviewMd entry parses correctly', () => {
+  const text = '```yaml code-gauntlet\nconfidence_threshold: 80\nignore:\n  - foo.js\n```';
+  const out = resolveReviewConfig({ reviewMd: [{ path: 'REVIEW.md', text }] });
+  assert.equal(out.reviewConfig.confidence_threshold, 80);
+  assert.deepEqual(out.reviewConfig.ignore, ['foo.js']);
+  assert.equal(out.reviewConfigSource, 'reviewMd');
+  assert.equal(out.reviewMdEntryCount, 1);
+});
+test('resolveReviewConfig: deeper entry overrides an earlier entry\'s threshold setting', () => {
+  const root = '```yaml code-gauntlet\nconfidence_threshold: 70\n```';
+  const deep = '```yaml code-gauntlet\nconfidence_threshold: 90\n```';
+  const out = resolveReviewConfig({ reviewMd: [{ path: 'REVIEW.md', text: root }, { path: 'src/REVIEW.md', text: deep }] });
+  assert.equal(out.reviewConfig.confidence_threshold, 90);
+});
+test('resolveReviewConfig: ignore lists accumulate across entries, in order', () => {
+  const root = '```yaml code-gauntlet\nignore:\n  - a.js\n  - b.js\n```';
+  const deep = '```yaml code-gauntlet\nignore:\n  - c.js\n```';
+  const out = resolveReviewConfig({ reviewMd: [{ path: 'REVIEW.md', text: root }, { path: 'src/REVIEW.md', text: deep }] });
+  assert.deepEqual(out.reviewConfig.ignore, ['a.js', 'b.js', 'c.js']);
+});
+test('resolveReviewConfig: absent settings stay strictly undefined after merge (no default fill)', () => {
+  const out = resolveReviewConfig({ reviewMd: [{ path: 'REVIEW.md', text: 'no config block here' }] });
+  assert.equal(out.reviewConfig.confidence_threshold, undefined);
+  assert.equal(out.reviewConfig.security_min_confidence, undefined);
+  assert.equal(out.reviewConfig.severity_threshold, undefined);
+  assert.deepEqual(out.reviewConfig.ignore, []);
+});
+test('resolveReviewConfig: empty reviewMd array is equivalent to today\'s no-REVIEW.md path', () => {
+  const out = resolveReviewConfig({ reviewMd: [] });
+  assert.deepEqual(out.reviewConfig, { ignore: [] });
+  assert.equal(out.reviewConfigSource, 'reviewMd');
+  assert.equal(out.reviewMdEntryCount, 0);
+});
+test('resolveReviewConfig: exclusionsText is parsed via loadExclusions', () => {
+  const out = resolveReviewConfig({ exclusionsText: '- foo.js\n- bar/*.js\n' });
+  assert.deepEqual(out.exclusionPatterns, ['foo.js', 'bar/*.js']);
 });

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -236,6 +236,14 @@ test('stripNullOptionalsReport drops delivery.prIdentity: null and delivery.tier
   const stripped = stripNullOptionalsReport(a).args;
   assert.deepEqual(stripped.delivery, {});
 });
+test('stripNullOptionalsReport deletes a null reviewMd/exclusionsText and validateArgs accepts the stripped result', () => {
+  const a = { ...good, reviewMd: null, exclusionsText: null };
+  const { args: stripped, dropped } = stripNullOptionalsReport(a);
+  assert.equal('reviewMd' in stripped, false);
+  assert.equal('exclusionsText' in stripped, false);
+  assert.deepEqual([...dropped].sort(), ['exclusionsText', 'reviewMd']);
+  assert.equal(validateArgs(stripped).ok, true);
+});
 test('stripNullOptionalsReport does NOT strip limits.deliveryCap: null (uncapped is load-bearing)', () => {
   const a = { ...good, limits: { ...good.limits, deliveryCap: null } };
   const stripped = stripNullOptionalsReport(a).args;
@@ -713,7 +721,7 @@ test('validateArgs rejects non-string reviewMd path', () => {
   assert.match(r.errors.join(' '), /path must be a non-empty string/);
 });
 test('validateArgs rejects a reviewMd path with a control character', () => {
-  const r = validateArgs({ ...good, reviewMd: [{ path: 'foo bar', text: '' }] });
+  const r = validateArgs({ ...good, reviewMd: [{ path: 'foo\u0000bar', text: '' }] });
   assert.equal(r.ok, false);
   assert.match(r.errors.join(' '), /control character/);
 });
@@ -745,12 +753,12 @@ test('resolveReviewConfig: absent reviewMd/exclusionsText falls back to reviewCo
   const A = { reviewConfig: { ignore: ['a'] }, exclusionPatterns: ['b'] };
   assert.deepEqual(resolveReviewConfig(A), {
     reviewConfig: { ignore: ['a'] }, exclusionPatterns: ['b'],
-    reviewConfigSource: 'preParsed', reviewMdEntryCount: 0,
+    reviewConfigSource: 'preParsed', exclusionsSource: 'preParsed', reviewMdEntryCount: 0,
   });
 });
 test('resolveReviewConfig: neither present -> source "none"', () => {
   assert.deepEqual(resolveReviewConfig({}), {
-    reviewConfig: {}, exclusionPatterns: [], reviewConfigSource: 'none', reviewMdEntryCount: 0,
+    reviewConfig: {}, exclusionPatterns: [], reviewConfigSource: 'none', exclusionsSource: 'none', reviewMdEntryCount: 0,
   });
 });
 test('resolveReviewConfig: single reviewMd entry parses correctly', () => {
@@ -789,4 +797,50 @@ test('resolveReviewConfig: empty reviewMd array is equivalent to today\'s no-REV
 test('resolveReviewConfig: exclusionsText is parsed via loadExclusions', () => {
   const out = resolveReviewConfig({ exclusionsText: '- foo.js\n- bar/*.js\n' });
   assert.deepEqual(out.exclusionPatterns, ['foo.js', 'bar/*.js']);
+});
+test('resolveReviewConfig: deeper entry overrides an earlier entry\'s severity_threshold setting', () => {
+  const root = '```yaml code-gauntlet\nseverity_threshold: low\n```';
+  const deep = '```yaml code-gauntlet\nseverity_threshold: high\n```';
+  const out = resolveReviewConfig({ reviewMd: [{ path: 'REVIEW.md', text: root }, { path: 'src/REVIEW.md', text: deep }] });
+  assert.equal(out.reviewConfig.severity_threshold, 'high');
+});
+test('resolveReviewConfig: deeper entry overrides an earlier entry\'s security_min_confidence setting', () => {
+  const root = '```yaml code-gauntlet\nsecurity_min_confidence: 60\n```';
+  const deep = '```yaml code-gauntlet\nsecurity_min_confidence: 85\n```';
+  const out = resolveReviewConfig({ reviewMd: [{ path: 'REVIEW.md', text: root }, { path: 'src/REVIEW.md', text: deep }] });
+  assert.equal(out.reviewConfig.security_min_confidence, 85);
+});
+test('resolveReviewConfig: reviewMd + exclusionsText together — reviewConfig from reviewMd, exclusions actually parsed from exclusionsText', () => {
+  const text = '```yaml code-gauntlet\nconfidence_threshold: 80\n```';
+  const out = resolveReviewConfig({
+    reviewMd: [{ path: 'REVIEW.md', text }],
+    exclusionsText: '- foo.js\n- bar/*.js\n',
+  });
+  assert.equal(out.reviewConfig.confidence_threshold, 80);
+  assert.equal(out.reviewConfigSource, 'reviewMd');
+  assert.equal(out.exclusionsSource, 'exclusionsText');
+  assert.deepEqual(out.exclusionPatterns, ['foo.js', 'bar/*.js']);
+});
+test('resolveReviewConfig: reviewMd present + exclusionsText absent falls back to legacy exclusionPatterns', () => {
+  const text = '```yaml code-gauntlet\nconfidence_threshold: 80\n```';
+  const out = resolveReviewConfig({
+    reviewMd: [{ path: 'REVIEW.md', text }],
+    exclusionPatterns: ['legacy.js'],
+  });
+  assert.deepEqual(out.exclusionPatterns, ['legacy.js']);
+  assert.equal(out.exclusionsSource, 'preParsed');
+});
+test('resolveReviewConfig: exclusionsText-only (no reviewMd) echoes reviewConfigSource "preParsed" when reviewConfig was also stamped, never "reviewMd"', () => {
+  const out = resolveReviewConfig({ exclusionsText: '- foo.js\n', reviewConfig: { confidence_threshold: 70 } });
+  assert.equal(out.reviewConfigSource, 'preParsed');
+  assert.equal(out.exclusionsSource, 'exclusionsText');
+  assert.equal(out.reviewConfig.confidence_threshold, 70);
+});
+test('resolveReviewConfig: reviewMd entries are merged root-first by path depth, regardless of input order', () => {
+  const root = '```yaml code-gauntlet\nconfidence_threshold: 70\n```';
+  const deep = '```yaml code-gauntlet\nconfidence_threshold: 90\n```';
+  // Deliberately reversed input order (deep before root) — the merge result must still
+  // reflect "deeper wins", proving the sort runs before merge rather than trusting caller order.
+  const out = resolveReviewConfig({ reviewMd: [{ path: 'src/deep/REVIEW.md', text: deep }, { path: 'REVIEW.md', text: root }] });
+  assert.equal(out.reviewConfig.confidence_threshold, 90);
 });

--- a/workflows/test/stages_delivery.test.js
+++ b/workflows/test/stages_delivery.test.js
@@ -250,3 +250,48 @@ test('runWith exposes the persisted post-review artifact path', async () => {
   assert.match(out.artifactPaths.postReview, /post-review/);
   assert.match(out.artifactPaths.postReview, /abc1234/);
 });
+
+// --- runWith: args.reviewMd (issue #24 PR2) ----------------------------------
+
+test('runWith threads a single-entry args.reviewMd through resolveReviewConfig into the filter stage, and echoes provenance', async () => {
+  // A validate checkpoint gives a deterministic pre-filter finding set: one at
+  // confidence 95 (survives a confidence_threshold: 90 REVIEW.md config) and one at
+  // confidence 50 (eliminated by it). The challenge checkpoint then hands runWith a
+  // fixed post-filter delivered set so the test does not depend on challenge dispatch
+  // mocking — the assertion here is about the FILTER stage's observable effect
+  // (stats.filter / reviewConfigSource), not about what challenge does next.
+  const reviewMdText = '```yaml code-gauntlet\nconfidence_threshold: 90\n```';
+  const args = validArgs({
+    reviewMd: [{ path: 'REVIEW.md', text: reviewMdText }],
+    checkpoints: {
+      validate: {
+        findings: [
+          makeFinding('KEEP', { confidence: 95 }),
+          // 65 sits ABOVE the Filter stage's config-absent non-security default (55) but
+          // BELOW the REVIEW.md confidence_threshold: 90 above — this value is chosen
+          // specifically so the assertion below discriminates "the configured threshold was
+          // applied" from "the stage's own built-in default happened to eliminate it too".
+          makeFinding('DROP', { confidence: 65 }),
+        ],
+        stats: { batches_dispatched: 0, batches_completed: 0, validated: 2, skipped: 0, adjusted: 0 },
+      },
+      challenge: challengeCheckpoint(),
+    },
+  });
+  const out = await runWith(makeCtx(args), args);
+  assert.equal(out.ok, true);
+  assert.equal(out.stats.reviewConfigSource, 'reviewMd');
+  assert.equal(out.stats.reviewMdEntryCount, 1);
+  // The filter stage kept KEEP (95 >= 90) and eliminated DROP (50 < 90) — proof the
+  // REVIEW.md confidence_threshold was actually applied, not just threaded silently.
+  assert.equal(out.stats.filter.total, 2);
+  assert.equal(out.stats.filter.passed_threshold, 1);
+});
+
+test('runWith without args.reviewMd reports reviewConfigSource "none" (no config supplied)', async () => {
+  const args = validArgs({ checkpoints: { challenge: challengeCheckpoint() } });
+  const out = await runWith(makeCtx(args), args);
+  assert.equal(out.ok, true);
+  assert.equal(out.stats.reviewConfigSource, 'none');
+  assert.equal(out.stats.reviewMdEntryCount, 0);
+});

--- a/workflows/test/stages_delivery.test.js
+++ b/workflows/test/stages_delivery.test.js
@@ -295,3 +295,29 @@ test('runWith without args.reviewMd reports reviewConfigSource "none" (no config
   assert.equal(out.stats.reviewConfigSource, 'none');
   assert.equal(out.stats.reviewMdEntryCount, 0);
 });
+
+test('runWith with legacy args.reviewConfig (no args.reviewMd) threads it into the filter stage and echoes "preParsed"', async () => {
+  // Req 8 backward compat, at the runWith level: an older caller (or a bench child) that
+  // still stamps the pre-parsed reviewConfig/exclusionPatterns pair directly — never
+  // reviewMd — must see its config applied exactly as before, with provenance reflecting
+  // that no raw REVIEW.md discovery happened.
+  const args = validArgs({
+    reviewConfig: { confidence_threshold: 90, ignore: [] },
+    checkpoints: {
+      validate: {
+        findings: [
+          makeFinding('KEEP', { confidence: 95 }),
+          makeFinding('DROP', { confidence: 65 }),
+        ],
+        stats: { batches_dispatched: 0, batches_completed: 0, validated: 2, skipped: 0, adjusted: 0 },
+      },
+      challenge: challengeCheckpoint(),
+    },
+  });
+  const out = await runWith(makeCtx(args), args);
+  assert.equal(out.ok, true);
+  assert.equal(out.stats.reviewConfigSource, 'preParsed');
+  assert.equal(out.stats.reviewMdEntryCount, 0);
+  assert.equal(out.stats.filter.total, 2);
+  assert.equal(out.stats.filter.passed_threshold, 1);
+});

--- a/workflows/test/stages_delivery.test.js
+++ b/workflows/test/stages_delivery.test.js
@@ -296,6 +296,14 @@ test('runWith without args.reviewMd reports reviewConfigSource "none" (no config
   assert.equal(out.stats.reviewMdEntryCount, 0);
 });
 
+test('runWith echoes exclusionsSource independently of reviewConfigSource: exclusionsText-only reports "exclusionsText" for the exclusions axis, "none" for the config axis', async () => {
+  const args = validArgs({ exclusionsText: '- foo.js\n', checkpoints: { challenge: challengeCheckpoint() } });
+  const out = await runWith(makeCtx(args), args);
+  assert.equal(out.ok, true);
+  assert.equal(out.stats.reviewConfigSource, 'none');
+  assert.equal(out.stats.exclusionsSource, 'exclusionsText');
+});
+
 test('runWith with legacy args.reviewConfig (no args.reviewMd) threads it into the filter stage and echoes "preParsed"', async () => {
   // Req 8 backward compat, at the runWith level: an older caller (or a bench child) that
   // still stamps the pre-parsed reviewConfig/exclusionPatterns pair directly — never


### PR DESCRIPTION
## Summary

Part 2 of a 3-PR stack for issue #24 (the "args waist" refactor). This PR moves REVIEW.md parsing itself into the pipeline waist:

- Adds raw-text waist fields (`reviewMd`, `exclusionsText`) alongside the existing pre-parsed path, guarded by a single-authority check — a caller supplying both is rejected, and the pre-parsed-only path is completely unchanged for back-compat (requirement 8).
- `resolveReviewConfig` now runs the real `parseReviewMd` per entry: a structural root-first depth sort, deeper-directory settings winning over shallower ones, and ignore patterns accumulating up the tree — with no default pre-fill. This makes the #94 REVIEW.md precedence contract structural (the parser enforces it directly) rather than prose — so the SKILL.md warning about threshold-pinning is deleted, since there's nothing left for it to warn about.
- `filterStage`'s parity seam is untouched (requirement 9); golden fixtures are unchanged.
- Per-axis provenance is echoed (`reviewConfigSource` / `exclusionsSource` plus an entry count), so precedence resolution stays auditable post-hoc without re-parsing.

### Issue #80 decision (made in this PR)

REVIEW.md discovery switches from the CLAUDE.md-location anchor to repo root + changed-file directories + ancestors — the same discovery set `collect_project_rules.py` already uses. This is motivated by a mirror measurement: 8 of 9 `AGENTS.md` directories in the grafana mirror set have no `CLAUDE.md` sibling, and 0 `REVIEW.md` files exist across any of 12 mirrors today — so the change is bounded and latent-feature-safe (nothing currently depends on the old anchor because nothing currently uses it).

### Known limitation

Merged REVIEW.md config applies globally; per-subtree scoping is not implemented in this PR. This is a deliberate scope cut, tracked as an adjacent issue to file separately.

### Verification

Two adversarial review rounds; mutation ledgers red-verified. Full suites, coverage floors, and bundle freshness green.

---

Part of a 3-PR stack for issue #24. Merge order: limits waist (A) → this PR (B) → scope waist (C). Each PR retargets to `main` as its predecessor merges. Issue #24's verification tier (release smoke + M4 trivial-PR fixture, ~$3) runs owner-triggered after the full stack merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkugfQAn4UQTkbf3iu59cs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how review thresholds and ignore lists reach the Filter stage and narrows REVIEW.md discovery; behavior is guarded by validation, backward-compatible pre-parsed args, and new integration tests, but wrong discovery or merge would silently shift delivered findings.
> 
> **Overview**
> Moves **REVIEW.md parsing out of Phase 2** and into the workflow args waist. The skill now discovers `REVIEW.md` on the repo root plus changed-file directories and ancestors (aligned with `collect_project_rules.py`, issue **#80**), **reads raw text**, and stamps **`reviewMd`** / **`exclusionsText`** instead of hand-building **`reviewConfig`** / **`exclusionPatterns`**.
> 
> **`resolveReviewConfig`** in `workflows/src/args.js` becomes the single authority: it calls **`parseReviewMd`** per entry, **sorts by path depth** (root first, deeper settings win), **accumulates `ignore`**, parses exclusions via **`loadExclusions`**, and feeds the Filter stage. **`validateArgs`** rejects supplying both raw and pre-parsed forms on the same axis; legacy pre-parsed args still work unchanged.
> 
> Docs (`SKILL.md`, `phase2-triage.md`, `review-md-spec.md`) drop skill-side parse/threshold-pinning guidance, forbid repo-wide `**/REVIEW.md` globs, and note that merged config is still **global per run** (per-subtree scoping not implemented). Run stats echo **`reviewConfigSource`**, **`exclusionsSource`**, and **`reviewMdEntryCount`**. Tests cover validation, merge behavior, and `runWith` filter threading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d319a31cb419af9af410555d7423933bcfad96bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->