### PR TITLE
fix(skills): pin Workflow availability check to passive self-inspection (#201)

### DIFF
--- a/skills/code-gauntlet/SKILL.md
+++ b/skills/code-gauntlet/SKILL.md
@@ -22,7 +22,7 @@ Inline checks before any workflow run — no subagent dispatch. Read `references
 
 ### Workflow-tool availability check — MANDATORY, FIRST
 
-Before anything else, confirm the **`Workflow` tool is present in this session's available tools**. v3 orchestration is a single `Workflow` invocation; there is no in-session fallback. If `Workflow` is not available, print exactly:
+Before anything else, confirm the **`Workflow` tool is present in this session's available tools**. The check is **passive self-inspection of your tool definitions** — `Workflow` is either defined in your toolset or it is not; no tool call verifies this. **Never probe with `ToolSearch`**: it searches deferred tools only, so a `Workflow` tool already defined top-level returns zero hits — a recorded run (2026-08-17, issue #201) did exactly that and false-aborted a review while `Workflow` was available the whole time. v3 orchestration is a single `Workflow` invocation; there is no in-session fallback. Only if `Workflow` is genuinely absent from your tool definitions, print exactly:
 
 ```
 code-gauntlet v3 requires Claude Code >= 2.1.154 with dynamic workflows. Install the pre-rename deep-review v2.x for older CLIs.

--- a/skills/code-gauntlet/SKILL.md
+++ b/skills/code-gauntlet/SKILL.md
@@ -22,7 +22,7 @@ Inline checks before any workflow run — no subagent dispatch. Read `references
 
 ### Workflow-tool availability check — MANDATORY, FIRST
 
-Before anything else, confirm the **`Workflow` tool is present in this session's available tools**. The check is **passive self-inspection of your tool definitions** — `Workflow` is either defined in your toolset or it is not; no tool call verifies this. **Never probe with `ToolSearch`**: it searches deferred tools only, so a `Workflow` tool already defined top-level returns zero hits — a recorded run (2026-08-17, issue #201) did exactly that and false-aborted a review while `Workflow` was available the whole time. v3 orchestration is a single `Workflow` invocation; there is no in-session fallback. Only if `Workflow` is genuinely absent from your tool definitions, print exactly:
+Before anything else, confirm the **`Workflow` tool is present in this session's tool definitions**. This is passive self-inspection — no tool call verifies it. Never probe with `ToolSearch`: it searches deferred tools only and returns zero hits for a top-level `Workflow`, which reads as a false "absent". v3 orchestration is a single `Workflow` invocation; there is no in-session fallback. If `Workflow` is absent from your tool definitions, print exactly:
 
 ```
 code-gauntlet v3 requires Claude Code >= 2.1.154 with dynamic workflows. Install the pre-rename deep-review v2.x for older CLIs.

--- a/skills/code-gauntlet/references/phase1-preflight.md
+++ b/skills/code-gauntlet/references/phase1-preflight.md
@@ -8,10 +8,10 @@ Workflow-tool availability check, review target resolution, eligibility logic, t
 
 ## Workflow-Tool Availability Check (run first)
 
-v3 orchestration is a single `Workflow` tool call (Phase 3). There is no in-session fallback — the break from v2's inline subagent dispatch is a locked decision. Before any other work, confirm the **`Workflow` tool is present in this session's available tools** — by **passive self-inspection of your own tool definitions only**. No tool call verifies this, and **`ToolSearch` must never be used as the probe**: it searches deferred tools only, so a `Workflow` tool defined top-level returns zero hits and reads as a false "absent" (recorded false abort 2026-08-17, issue #201 — same wrong-instrument class as the plugin-root `find` ban in SKILL.md).
+v3 orchestration is a single `Workflow` tool call (Phase 3). There is no in-session fallback — the break from v2's inline subagent dispatch is a locked decision. Before any other work, confirm the **`Workflow` tool is present in this session's tool definitions** by passive self-inspection only — never via `ToolSearch`, which searches deferred tools only and returns a false "absent" for a top-level `Workflow`.
 
 - **Present in your tool definitions** → continue with target resolution.
-- **Absent from your tool definitions** (not merely absent from a ToolSearch result) → print exactly the message below and STOP. Do not emulate the pipeline by dispatching agents inline.
+- **Absent from your tool definitions** → print exactly the message below and STOP. Do not emulate the pipeline by dispatching agents inline.
 
 ```
 code-gauntlet v3 requires Claude Code >= 2.1.154 with dynamic workflows. Install the pre-rename deep-review v2.x for older CLIs.

--- a/skills/code-gauntlet/references/phase1-preflight.md
+++ b/skills/code-gauntlet/references/phase1-preflight.md
@@ -8,10 +8,10 @@ Workflow-tool availability check, review target resolution, eligibility logic, t
 
 ## Workflow-Tool Availability Check (run first)
 
-v3 orchestration is a single `Workflow` tool call (Phase 3). There is no in-session fallback — the break from v2's inline subagent dispatch is a locked decision. Before any other work, confirm the **`Workflow` tool is present in this session's available tools**.
+v3 orchestration is a single `Workflow` tool call (Phase 3). There is no in-session fallback — the break from v2's inline subagent dispatch is a locked decision. Before any other work, confirm the **`Workflow` tool is present in this session's available tools** — by **passive self-inspection of your own tool definitions only**. No tool call verifies this, and **`ToolSearch` must never be used as the probe**: it searches deferred tools only, so a `Workflow` tool defined top-level returns zero hits and reads as a false "absent" (recorded false abort 2026-08-17, issue #201 — same wrong-instrument class as the plugin-root `find` ban in SKILL.md).
 
-- **Present** → continue with target resolution.
-- **Absent** → print exactly the message below and STOP. Do not emulate the pipeline by dispatching agents inline.
+- **Present in your tool definitions** → continue with target resolution.
+- **Absent from your tool definitions** (not merely absent from a ToolSearch result) → print exactly the message below and STOP. Do not emulate the pipeline by dispatching agents inline.
 
 ```
 code-gauntlet v3 requires Claude Code >= 2.1.154 with dynamic workflows. Install the pre-rename deep-review v2.x for older CLIs.


### PR DESCRIPTION
## What

Closes #201 — a live run (2026-08-17, `/code-gauntlet PR 200`) false-aborted at the mandatory Phase-0 Workflow-availability check: the model probed with `ToolSearch("Workflow tool")`, which searches **deferred tools only**, got zero hits for the top-level `Workflow` tool, and the abort rule fired while Workflow was available the whole time.

Both `skills/code-gauntlet/SKILL.md` and `references/phase1-preflight.md` said *confirm the tool is present* without naming the instrument. They now pin the check to passive self-inspection of the session's own tool definitions and explicitly ban the ToolSearch probe, citing the recorded false abort — the same wrong-instrument-ban pattern as the plugin-root `find` ban.

## Verification

Suites-only (skill prose): `pytest tests/ -q` → 1303 passed, 513 subtests; pre-commit hooks green on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkugfQAn4UQTkbf3iu59cs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to skill guidance; no runtime, auth, or pipeline code paths are modified.
> 
> **Overview**
> Fixes a **false abort** at code-gauntlet’s mandatory Phase-0 check when a run used **`ToolSearch`** to see if `Workflow` exists: that search only covers deferred tools, so a top-level `Workflow` looks missing even when it’s available.
> 
> **`SKILL.md`** and **`references/phase1-preflight.md`** now require checking the session’s **tool definitions** by passive self-inspection (no tool call), and **forbid** probing with `ToolSearch`. Present/absent bullets are reworded to match (“in your tool definitions”). The abort message and stop behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69c0a1c1db55b81fad18c562525bb25fbce169c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->