### PR TITLE
fix(post-review): unanchored corroborators participate in rerun dedup and delivery

### DIFF
--- a/scripts/detect_prior_review.py
+++ b/scripts/detect_prior_review.py
@@ -255,14 +255,17 @@ def fetch_entries_gitlab(owner, repo, number):
 
 
 def gitlab_prior_delivery_state(owner, repo, number, sha):
-    """Return ``(summary_posted, finding_keys, error)`` — what *sha*'s review left here.
+    """Return ``(summary_posted, finding_keys, legacy_group_keys, error)`` — what *sha*'s
+    review left here.
 
-    ``post_review.post_gitlab`` asks both questions before delivering: is my summary
-    note already on the MR (issue #127), and which of my inline discussions did a
-    partially-failed delivery already place (issue #132). ONE fetch answers both — a
-    second round trip would also be a second, possibly inconsistent view of the MR. The
-    read lives here because this module is the only reader; post_review.py writes the
-    signal and never parses it.
+    ``post_review.post_gitlab`` asks three questions before delivering: is my summary
+    note already on the MR (issue #127), which of my inline discussions did a
+    partially-failed delivery already place (issue #132), and — of those — which stand
+    for a WHOLE consolidation group because they are a pre-#208 group body that rendered
+    a corroborator without ever giving it its own key (issue: unanchored corroborators
+    lost on rerun). ONE fetch answers all three — a second round trip would also be a
+    second, possibly inconsistent view of the MR. The read lives here because this
+    module is the only reader; post_review.py writes the signal and never parses it.
 
     Goes through :func:`fetch_entries_gitlab`, so the ``--paginate`` requirement
     documented there applies unchanged, and so does its endpoint: the flat
@@ -276,8 +279,13 @@ def gitlab_prior_delivery_state(owner, repo, number, sha):
     """
     entries, errors = fetch_entries_gitlab(owner, repo, number)
     if errors:
-        return False, set(), errors[0]
-    return entries_carry_sha(entries, sha), finding_keys_for_sha(entries, sha), None
+        return False, set(), set(), errors[0]
+    return (
+        entries_carry_sha(entries, sha),
+        finding_keys_for_sha(entries, sha),
+        legacy_group_keys_for_sha(entries, sha),
+        None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -379,6 +387,57 @@ def finding_keys_for_sha(entries, sha):
         for marker in find_finding_markers(entry.get("body")):
             if marker["sha"] == sha:
                 keys.add(marker["key"])
+    return keys
+
+
+# A consolidation group's body renders one of these per corroborator, verbatim from
+# post_review._render_corroboration — the only place this string is emitted.
+_CORROBORATION_HEADER = "Corroborating finding — "
+
+
+def _is_legacy_undermarked_group_body(body, matched_marker_count):
+    """True when *body* renders more consolidation-group members than it carries keys for.
+
+    Before issue #208's fix, ``post_gitlab`` never gave an unanchorable corroborator (no
+    line, or a line outside the diff) a delivery key — even though it fully rendered that
+    member's content into the body's ``"Corroborating finding — "`` section. Such a body
+    is proof BY CONSTRUCTION that every member it renders already reached the MR, even
+    the one(s) whose key is missing: the body is the finding's only delivery vehicle, and
+    it is right there in the text.
+
+    Detected narrowly, by shape, not by a version field (no marker in this pipeline ever
+    carried one for this): a group body carries one corroboration header per corroborator
+    and, pre-fix, a marker only for the primary and the anchorable ones — so a legacy
+    group short a member's key has fewer matched markers than ``1 (primary) +
+    len(corroborators)``. A fixed-format group body always carries exactly that many, so
+    it never matches. Neither does an individually-posted primary's own fallback
+    discussion (the group's OTHER degraded shape): it carries no corroboration header at
+    all, so ``section_count`` is 0 and the check short-circuits before ever looking at
+    the (deliberately mismatched, single-finding) marker count.
+    """
+    if not isinstance(body, str):
+        return False
+    section_count = body.count(_CORROBORATION_HEADER)
+    return section_count > 0 and matched_marker_count < 1 + section_count
+
+
+def legacy_group_keys_for_sha(entries, sha):
+    """Return delivery keys found in *sha*'s legacy under-marked group bodies.
+
+    A subset of :func:`finding_keys_for_sha`'s result (every key here is a real,
+    found marker) — callers use this to recognize when a GROUP's primary key, if
+    present, stands for the whole group's delivery, including a member whose own
+    key this sha's markers do not carry (see
+    :func:`_is_legacy_undermarked_group_body`).
+    """
+    keys = set()
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        body = entry.get("body")
+        matched = [m["key"] for m in find_finding_markers(body) if m["sha"] == sha]
+        if matched and _is_legacy_undermarked_group_body(body, len(matched)):
+            keys.update(matched)
     return keys
 
 

--- a/scripts/post_review.py
+++ b/scripts/post_review.py
@@ -1420,6 +1420,58 @@ def post_gitlab(data, valid_lines, new_files=None, old_paths=None):
             return "failed"
         return "posted"
 
+    def member_key_for(m, anchor):
+        """Return the delivery key for ONE group member, anchored or not.
+
+        An anchorable member's key is `member_key` at its own resolved
+        position — the same key its individual fallback discussion would
+        carry. A member with no anchor (no line, or a line outside the diff)
+        can only ever be delivered inside its group's body, so it has no
+        resolved position to key on; it is keyed on its own raw, unresolved
+        `file`/`line` instead. That is deterministic and is exactly what the
+        group body's marker for this member must also use — the round-trip
+        `deliver()` relies on for every member key.
+        """
+        if anchor:
+            return member_key(m, *anchor)
+        return member_key(m, m.get("file", "?"), m.get("line"))
+
+    def deliver_unanchored(c, key):
+        """Post an unanchorable corroborator's content as a position-less MR note.
+
+        Reached only when *c* has no line to anchor an inline discussion on
+        (or its line is outside the diff) AND the group's single discussion
+        already delivered its anchored siblings on an earlier run — the group
+        body cannot be reposted without duplicating those siblings, so this is
+        the only delivery vehicle left. Mirrors the summary note's own
+        position-less POST to the same `/notes` endpoint, with the same
+        per-finding marker `deliver()` appends to an inline discussion, so a
+        later rerun recognizes this exactly as it would an inline one.
+        """
+        body = render_comment_body(c)
+        payload = {
+            "body": body
+            if DRY_RUN or not sha_is_markable
+            else f"{body}\n\n{build_finding_marker(sha, key)}"
+        }
+        cmd_prefix = [
+            "glab",
+            "api",
+            "--method",
+            "POST",
+            "--header",
+            "Content-Type: application/json",
+            f"projects/{project_id}/merge_requests/{mr_iid}/notes",
+        ]
+        _response, error = try_post_json(cmd_prefix, payload)
+        if error is not None:
+            warn_skip(
+                f"Skipping corroborating finding '{c.get('title', '?')}' — GitLab "
+                f"rejected the position-less note.\n{error}"
+            )
+            return "failed"
+        return "posted"
+
     def corroborator_anchor(c):
         """Return ``(filepath, line)`` a corroborator can be anchored at on its own.
 
@@ -1472,20 +1524,27 @@ def post_gitlab(data, valid_lines, new_files=None, old_paths=None):
         f = group["primary"]
         corroborators = group["corroborators"]
         primary_key = member_key(f, filepath, f["line"])
-        # A corroborator with no anchor of its own has no key: it can only ever be
-        # delivered by its group's body, so it is neither matchable on a rerun nor
-        # separable from the group here.
+        # Every member gets a key — even one with no anchor of its own, which can
+        # only ever be delivered by its group's body (see member_key_for). Without
+        # this, an unanchorable corroborator's key was simply absent, so the
+        # all-keys-present check below could never see it as missing: the group
+        # was declared already_present while that member's content had never
+        # landed anywhere (unanchored corroborators lost on rerun).
         anchors = {id(c): corroborator_anchor(c) for c in corroborators}
-        member_keys = [primary_key] + [
-            member_key(c, *anchors[id(c)]) for c in corroborators if anchors[id(c)]
-        ]
+        corroborator_keys = {
+            id(c): member_key_for(c, anchors[id(c)]) for c in corroborators
+        }
+        member_keys = [primary_key] + [corroborator_keys[id(c)] for c in corroborators]
         if any(k in delivered_keys for k in member_keys) and not all(
             k in delivered_keys for k in member_keys
         ):
             # An earlier run delivered SOME of this group — its fallback posted
             # individual discussions for part of it. Posting the group now would put
             # that content on the MR twice (issue #132), so deliver only what is
-            # missing, each on its own.
+            # missing, each on its own. A missing member without an anchor cannot
+            # get its own inline discussion (deliver_corroborator requires a line),
+            # so it is posted as a position-less note instead — the group body it
+            # would otherwise ride in was already delivered by the earlier run.
             counters[
                 "already_present"
                 if primary_key in delivered_keys
@@ -1495,11 +1554,13 @@ def post_gitlab(data, valid_lines, new_files=None, old_paths=None):
             ] += 1
             for c in corroborators:
                 anchor = anchors[id(c)]
-                counters[
-                    "already_present"
-                    if anchor and member_key(c, *anchor) in delivered_keys
-                    else deliver_corroborator(c)
-                ] += 1
+                key = corroborator_keys[id(c)]
+                if key in delivered_keys:
+                    counters["already_present"] += 1
+                elif anchor:
+                    counters[deliver_corroborator(c)] += 1
+                else:
+                    counters[deliver_unanchored(c, key)] += 1
             continue
         outcome = deliver(
             f, filepath, f["line"], render_group_body(f, corroborators), member_keys
@@ -1509,7 +1570,12 @@ def post_gitlab(data, valid_lines, new_files=None, old_paths=None):
             # never given a chance of their own — post each as its own
             # discussion rather than dropping validated findings. The primary
             # still counts 1 toward its own loss; each corroborator is counted
-            # on its own merits.
+            # on its own merits. (Unlike the partial-prior-delivery branch
+            # above, nothing from this group has landed on the MR yet, so
+            # `deliver_corroborator`'s own no-line/off-diff diagnostics are
+            # the right report here — not the position-less note fallback,
+            # which exists only to reach a member whose group body already
+            # went out without it.)
             counters[outcome] += 1
             for c in corroborators:
                 counters[deliver_corroborator(c)] += 1

--- a/scripts/post_review.py
+++ b/scripts/post_review.py
@@ -1170,12 +1170,16 @@ def fetch_gitlab_shas(project_id, mr_iid):
 
 
 def gitlab_prior_delivery(owner, repo, mr_iid, sha):
-    """Return ``(summary_posted, finding_keys)`` — what THIS sha's review already left.
+    """Return ``(summary_posted, finding_keys, legacy_group_keys)`` — what THIS sha's
+    review already left.
 
-    Makes a rerun after a partial delivery retry-safe in both halves: the summary note is
-    not stacked a second time (issue #127 D4) and the inline discussions that did land
-    are not reposted (issue #132). ONE fetch serves both, in detect_prior_review.py — the
-    only reader of the signals — so this module stays write-only.
+    Makes a rerun after a partial delivery retry-safe in three ways: the summary note is
+    not stacked a second time (issue #127 D4), the inline discussions that did land are
+    not reposted (issue #132), and a pre-#208 group body that rendered a corroborator's
+    content without ever keying it is recognized as already carrying that member too (see
+    :func:`detect_prior_review.legacy_group_keys_for_sha`) rather than posted a second
+    time. ONE fetch serves all three, in detect_prior_review.py — the only reader of the
+    signals — so this module stays write-only.
 
     Never blocks delivery. Dry-run does not fetch AT ALL: dry-run's invariant is that it
     issues no WRITE calls (reads do happen under dry-run — `glab mr diff` and the
@@ -1187,15 +1191,17 @@ def gitlab_prior_delivery(owner, repo, mr_iid, sha):
     everything — a possible duplicate beats a silently dropped review.
     """
     if DRY_RUN or not is_sha_shaped(sha):
-        return False, frozenset()
-    summary_posted, keys, error = gitlab_prior_delivery_state(owner, repo, mr_iid, sha)
+        return False, frozenset(), frozenset()
+    summary_posted, keys, legacy_group_keys, error = gitlab_prior_delivery_state(
+        owner, repo, mr_iid, sha
+    )
     if error:
         warn(
             f"could not check for an existing summary note or already-delivered inline "
             f"discussions ({error}); posting them."
         )
-        return False, frozenset()
-    return summary_posted, keys
+        return False, frozenset(), frozenset()
+    return summary_posted, keys, legacy_group_keys
 
 
 def post_gitlab(data, valid_lines, new_files=None, old_paths=None):
@@ -1293,7 +1299,9 @@ def post_gitlab(data, valid_lines, new_files=None, old_paths=None):
         "Content-Type: application/json",
         f"projects/{project_id}/merge_requests/{mr_iid}/notes",
     ]
-    summary_posted, delivered_keys = gitlab_prior_delivery(owner, repo, mr_iid, sha)
+    summary_posted, delivered_keys, legacy_group_keys = gitlab_prior_delivery(
+        owner, repo, mr_iid, sha
+    )
     # Same predicate that makes gitlab_prior_delivery skip the fetch: a marker built
     # from a non-SHA-shaped sha (get_head_sha's "unknown" fallback) is one
     # find_finding_marker is guaranteed to reject, so appending it would leave an
@@ -1535,6 +1543,16 @@ def post_gitlab(data, valid_lines, new_files=None, old_paths=None):
             id(c): member_key_for(c, anchors[id(c)]) for c in corroborators
         }
         member_keys = [primary_key] + [corroborator_keys[id(c)] for c in corroborators]
+        if primary_key in legacy_group_keys:
+            # This group's primary key was found on a pre-#208 group body that
+            # rendered a corroborator's content without ever giving it a key of
+            # its own (see legacy_group_keys_for_sha). That body IS this group's
+            # whole delivery — every member it renders is provably already on
+            # the MR, missing keys included — so treat the whole group as
+            # already_present rather than let the "some but not all" branch
+            # below post the missing member a second time.
+            counters["already_present"] += len(member_keys)
+            continue
         if any(k in delivered_keys for k in member_keys) and not all(
             k in delivered_keys for k in member_keys
         ):

--- a/tests/test_detect_prior_review.py
+++ b/tests/test_detect_prior_review.py
@@ -378,7 +378,7 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
                 "created_at": "2026-08-03T00:00:00Z",
             }
         ]
-        summary_posted, keys, error = self._state(notes, FULL_SHA, calls=calls)
+        summary_posted, keys, _legacy, error = self._state(notes, FULL_SHA, calls=calls)
         self.assertTrue(summary_posted)
         self.assertEqual(keys, set())
         self.assertIsNone(error)
@@ -394,7 +394,7 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
                 "created_at": "2026-08-03T00:00:00Z",
             }
         ]
-        summary_posted, _keys, error = self._state(notes, FULL_SHA)
+        summary_posted, _keys, _legacy, error = self._state(notes, FULL_SHA)
         self.assertFalse(summary_posted)
         self.assertIsNone(error)
 
@@ -403,7 +403,7 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
             {"id": 1, "body": "Nice work", "created_at": "2026-08-03T00:00:00Z"},
             {"id": 2, "body": "LGTM", "created_at": "2026-08-03T00:01:00Z"},
         ]
-        summary_posted, keys, error = self._state(notes, FULL_SHA)
+        summary_posted, keys, _legacy, error = self._state(notes, FULL_SHA)
         self.assertFalse(summary_posted)
         self.assertEqual(keys, set())
         self.assertIsNone(error)
@@ -418,12 +418,14 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
                 "created_at": "2026-08-03T00:00:00Z",
             }
         ]
-        summary_posted, _keys, error = self._state(notes, FULL_SHA)
+        summary_posted, _keys, _legacy, error = self._state(notes, FULL_SHA)
         self.assertTrue(summary_posted)
         self.assertIsNone(error)
 
     def test_fetch_failure_returns_the_error_and_not_a_false_negative(self):
-        summary_posted, keys, error = self._state([], FULL_SHA, rc=1, stderr="boom")
+        summary_posted, keys, _legacy, error = self._state(
+            [], FULL_SHA, rc=1, stderr="boom"
+        )
         self.assertFalse(summary_posted)
         self.assertEqual(keys, set())
         self.assertTrue(error)
@@ -442,7 +444,7 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
             self._discussion_note(FINDING_KEY, note_id=2),
             self._discussion_note(OTHER_FINDING_KEY, note_id=3),
         ]
-        summary_posted, keys, error = self._state(notes, FULL_SHA, calls=calls)
+        summary_posted, keys, _legacy, error = self._state(notes, FULL_SHA, calls=calls)
         self.assertTrue(summary_posted)
         self.assertEqual(keys, {FINDING_KEY, OTHER_FINDING_KEY})
         self.assertIsNone(error)
@@ -453,7 +455,7 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
         """A discussion from a review of a DIFFERENT commit must not suppress this
         run's finding — the comment is anchored to a diff that has since moved."""
         notes = [self._discussion_note(FINDING_KEY, sha="b" * 40)]
-        _summary, keys, _error = self._state(notes, FULL_SHA)
+        _summary, keys, _legacy, _error = self._state(notes, FULL_SHA)
         self.assertEqual(keys, set())
 
     def test_notes_endpoint_is_what_is_fetched_not_discussions(self):
@@ -470,7 +472,9 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
                 "notes": [self._discussion_note(FINDING_KEY, note_id=2)],
             }
         ]
-        _summary, keys, error = self._state(discussions_shape, FULL_SHA, calls=calls)
+        _summary, keys, _legacy, error = self._state(
+            discussions_shape, FULL_SHA, calls=calls
+        )
         self.assertIsNone(error)
         self.assertEqual(
             keys,
@@ -494,7 +498,7 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
                 "created_at": "2026-08-03T00:00:00Z",
             }
         ]
-        _summary, keys, error = self._state(notes, FULL_SHA)
+        _summary, keys, _legacy, error = self._state(notes, FULL_SHA)
         self.assertEqual(keys, set())
         self.assertIsNone(error)
 
@@ -542,6 +546,100 @@ class TestGitlabPriorDeliveryState(unittest.TestCase):
         self.assertEqual(
             detect_prior_review.finding_keys_for_sha(entries, FULL_SHA), {FINDING_KEY}
         )
+
+
+# ---------------------------------------------------------------------------
+# legacy_group_keys_for_sha — recognizing a pre-#208 group body that rendered a
+# corroborator's content without ever giving it its own key (unanchored
+# corroborators lost on rerun).
+# ---------------------------------------------------------------------------
+
+
+def _legacy_group_note(primary_key, corroborator_titles, sha=FULL_SHA, note_id=1):
+    """A group discussion exactly as PRE-#208 ``post_gitlab`` would have posted one:
+    the primary's render, one ``"Corroborating finding — "`` section per corroborator
+    (``render_group_body``'s shape), but a marker for the primary ONLY — the bug
+    being pinned is that the old code never keyed an unanchorable corroborator, even
+    though it fully rendered that corroborator's content into its own section here.
+    """
+    sections = "\n\n".join(
+        f"**Corroborating finding — bug-detector (correctness, confidence 70):**\n\n"
+        f"**{title}**\n\nBody {title}"
+        for title in corroborator_titles
+    )
+    body = (
+        "**🟡 [MEDIUM] Finding**\n\nDetail.\n\n---\n\n"
+        + sections
+        + "\n\n"
+        + review_marker.build_finding_marker(sha, primary_key)
+    )
+    return {"id": note_id, "body": body, "created_at": "2026-08-03T00:02:00Z"}
+
+
+class TestLegacyGroupKeysForSha(unittest.TestCase):
+    """Pins the detection ``gitlab_prior_delivery_state`` uses to recognize a
+    pre-#208 group body as already carrying every member it renders."""
+
+    def test_undermarked_group_body_yields_the_primary_key(self):
+        note = _legacy_group_note(FINDING_KEY, ["Corroborator A"])
+        self.assertEqual(
+            detect_prior_review.legacy_group_keys_for_sha([note], FULL_SHA),
+            {FINDING_KEY},
+        )
+
+    def test_fully_marked_group_body_is_not_flagged_legacy(self):
+        """A group body carrying a marker for every member it renders (the #208
+        fix's own shape) must NOT be treated as legacy — it is already exactly
+        accounted for by ``finding_keys_for_sha``, so flagging it here too would
+        just be redundant, not wrong, but the shape check must not over-fire."""
+        note = _legacy_group_note(FINDING_KEY, ["Corroborator A"])
+        note["body"] += "\n" + review_marker.build_finding_marker(
+            FULL_SHA, OTHER_FINDING_KEY
+        )
+        self.assertEqual(
+            detect_prior_review.legacy_group_keys_for_sha([note], FULL_SHA), set()
+        )
+
+    def test_individually_posted_primary_is_not_flagged_legacy(self):
+        """The OTHER degraded group shape — a corroborator's own fallback
+        discussion never carries a corroboration header at all — must not
+        false-positive as an under-marked group body."""
+        note = self._discussion_note(FINDING_KEY)
+        self.assertEqual(
+            detect_prior_review.legacy_group_keys_for_sha([note], FULL_SHA), set()
+        )
+
+    @staticmethod
+    def _discussion_note(key, sha=FULL_SHA, note_id=1):
+        return {
+            "id": note_id,
+            "body": "**🟡 [MEDIUM] Finding**\n\nDetail.\n\n"
+            + review_marker.build_finding_marker(sha, key),
+            "created_at": "2026-08-03T00:02:00Z",
+        }
+
+    def test_ignores_a_different_shas_marker(self):
+        note = _legacy_group_note(FINDING_KEY, ["Corroborator A"], sha="b" * 40)
+        self.assertEqual(
+            detect_prior_review.legacy_group_keys_for_sha([note], FULL_SHA), set()
+        )
+
+    def test_gitlab_prior_delivery_state_surfaces_legacy_group_keys(self):
+        """The one fetch that answers summary/keys questions answers this one too."""
+        note = _legacy_group_note(FINDING_KEY, ["Corroborator A"])
+        with patch(
+            "scripts.detect_prior_review.subprocess.run",
+            side_effect=lambda cmd, *a, **k: SimpleNamespace(
+                stdout=json.dumps([note]), stderr="", returncode=0
+            ),
+        ):
+            summary_posted, keys, legacy_group_keys, error = (
+                detect_prior_review.gitlab_prior_delivery_state("o", "r", 5, FULL_SHA)
+            )
+        self.assertFalse(summary_posted)
+        self.assertEqual(keys, {FINDING_KEY})
+        self.assertEqual(legacy_group_keys, {FINDING_KEY})
+        self.assertIsNone(error)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_post_review.py
+++ b/tests/test_post_review.py
@@ -1636,7 +1636,7 @@ class TestSkipWarningDiagnostics(unittest.TestCase):
     # from a unit test.
     @patch(
         "scripts.post_review.gitlab_prior_delivery_state",
-        return_value=(False, set(), None),
+        return_value=(False, set(), frozenset(), None),
     )
     @patch("scripts.post_review.warn")
     def test_gitlab_skip_includes_valid_lines(
@@ -2066,7 +2066,7 @@ class TestGitlabPositionPayload(unittest.TestCase):
             # reach a real forge from a unit test.
             patch(
                 "scripts.post_review.gitlab_prior_delivery_state",
-                return_value=(False, set(), None),
+                return_value=(False, set(), frozenset(), None),
             ),
         ):
             post_gitlab(data, valid_lines, new_files)
@@ -2483,6 +2483,19 @@ def _gitlab_posts(mock_run, suffix):
         for c in mock_run.call_args_list
         if "--method" in c.args[0] and any(t.endswith(suffix) for t in c.args[0])
     ]
+
+
+def _normalize_prior(prior):
+    """Pad a legacy 3-tuple ``(summary_posted, keys, error)`` ``prior`` fixture to the
+    current 4-tuple ``gitlab_prior_delivery_state`` contract — ``(summary_posted, keys,
+    legacy_group_keys, error)`` — so the many existing fixtures that predate legacy-group
+    -body detection don't all need rewriting. A 4-tuple (a test that DOES want to steer
+    legacy_group_keys) passes through unchanged.
+    """
+    if len(prior) == 4:
+        return prior
+    summary_posted, keys, error = prior
+    return summary_posted, keys, frozenset(), error
 
 
 def _discussion_posts(mock_run):
@@ -3908,7 +3921,9 @@ class _GitlabLiveRunBase(_DryRunTestBase):
             # steers it to exercise the dedup gate.
             patch(
                 "scripts.post_review.gitlab_prior_delivery_state",
-                return_value=(False, set(), None) if prior is None else prior,
+                return_value=(False, set(), frozenset(), None)
+                if prior is None
+                else _normalize_prior(prior),
             ) as mock_prior,
             patch(
                 "scripts.post_review.subprocess.run",
@@ -4225,6 +4240,59 @@ class TestGitlabPositionGate(_GitlabLiveRunBase):
         self.assertIn("  1 inline discussion(s) already on the MR", run.out)
         self.assertIn("  1 inline discussion(s) posted.", run.out)
 
+    def test_legacy_group_body_rerun_posts_nothing_and_counts_the_whole_group(self):
+        """A pre-#208 group body already carries the unanchorable corroborator's
+        CONTENT (rendered into its corroboration section) even though it never
+        carried that corroborator's KEY. A rerun must recognize the primary's
+        key landing in such a body as proof the whole group is delivered — not
+        attempt to `deliver_unanchored` a duplicate (Bugbot: rerun duplicates
+        prior group content)."""
+        primary = _gl_primary()
+        unanchored = _gl_corroborator("A", None)
+        payloads = []
+        run = self._run_main(
+            findings=[primary, unanchored],
+            # legacy_group_keys carries the primary's key: detect_prior_review
+            # decided this is a legacy under-marked group body. delivered_keys
+            # carries ONLY the primary's key too — the unanchorable member's
+            # key was never written by the pre-fix code that posted this note.
+            prior=(True, {_member_key(primary)}, {_member_key(primary)}, None),
+            payloads=payloads,
+        )
+        self.assertIsNone(run.exit_code)
+        self.assertEqual(_discussion_posts(run.mock_run), [])
+        note_bodies = [p["body"] for p in payloads if "position" not in p]
+        self.assertFalse(
+            any("Corroborator A" in b for b in note_bodies),
+            "the legacy group body already carries this content — posting it "
+            "again would duplicate it on the MR",
+        )
+        self.assertIn(
+            "  2 inline discussion(s) already on the MR from an earlier run",
+            run.out,
+        )
+
+    def test_non_legacy_partial_delivery_still_delivers_the_missing_member(self):
+        """Pin that legacy-group detection does NOT over-fire: an ordinary
+        partial delivery (anchored siblings posted individually, no legacy
+        group body involved) must still deliver the member that was left
+        behind, exactly as before."""
+        primary = _gl_primary()
+        unanchored = _gl_corroborator("A", None)
+        payloads = []
+        run = self._run_main(
+            findings=[primary, unanchored],
+            prior=(True, {_member_key(primary)}, set(), None),
+            payloads=payloads,
+        )
+        self.assertIsNone(run.exit_code)
+        note_bodies = [p["body"] for p in payloads if "position" not in p]
+        self.assertTrue(
+            any("Corroborator A" in b for b in note_bodies),
+            "with no legacy group body on the MR, the missing member must "
+            "still be delivered",
+        )
+
     def test_live_all_malformed_exits_one_with_nothing_posted(self):
         findings = [dict(f, line=float(f["line"])) for f in GL_CONTRACT_FINDINGS]
         run = self._run_main(findings=findings)
@@ -4332,7 +4400,8 @@ class TestGitlabSummaryIdempotency(_DryRunTestBase):
             patch.object(sys, "argv", argv),
             patch.dict(os.environ, {}, clear=False),
             patch(
-                "scripts.post_review.gitlab_prior_delivery_state", return_value=prior
+                "scripts.post_review.gitlab_prior_delivery_state",
+                return_value=_normalize_prior(prior),
             ) as mock_prior,
             patch(
                 "scripts.post_review.subprocess.run",
@@ -5122,7 +5191,7 @@ class TestSkippedSectionForgeryResistance(_DryRunTestBase):
             ),
             patch(
                 "scripts.post_review.gitlab_prior_delivery_state",
-                return_value=(False, set(), None),
+                return_value=(False, set(), frozenset(), None),
             ),
             patch(
                 "scripts.post_review.subprocess.run",

--- a/tests/test_post_review.py
+++ b/tests/test_post_review.py
@@ -4165,6 +4165,66 @@ class TestGitlabPositionGate(_GitlabLiveRunBase):
                 f"missing marker for {member['title']}",
             )
 
+    def test_group_body_carries_a_marker_for_unanchorable_corroborator_too(self):
+        """A corroborator with no line of its own can only ever be delivered inside
+        the group body — its marker must be there too, or a rerun can never
+        recognize it as delivered (unanchored corroborators lost on rerun)."""
+        primary = _gl_primary()
+        unanchored = _gl_corroborator("A", None)
+        payloads = []
+        run = self._run_main(findings=[primary, unanchored], payloads=payloads)
+        self.assertIsNone(run.exit_code)
+        body = next(p["body"] for p in payloads if "position" in p)
+        self.assertIn(
+            post_review.build_finding_marker("a" * 40, _member_key(unanchored)),
+            body,
+            "the unanchorable corroborator's marker must round-trip through the "
+            "group body",
+        )
+
+    def test_rerun_recognizes_unanchorable_corroborator_from_group_body(self):
+        """Given the round-trip above, a rerun that sees both markers on the MR
+        must treat the WHOLE group — unanchorable member included — as already
+        delivered, and post nothing new."""
+        primary = _gl_primary()
+        unanchored = _gl_corroborator("A", None)
+        keys = {_member_key(primary), _member_key(unanchored)}
+        run = self._run_main(findings=[primary, unanchored], prior=(True, keys, None))
+        self.assertIsNone(run.exit_code)
+        self.assertEqual(_discussion_posts(run.mock_run), [])
+        self.assertIn(
+            "  2 inline discussion(s) already on the MR from an earlier run",
+            run.out,
+        )
+
+    def test_unanchorable_corroborator_delivered_when_siblings_already_posted(self):
+        """The primary was delivered individually by an earlier fallback run; the
+        unanchorable corroborator was not (it has no anchor of its own, so it
+        never got its own fallback discussion). It must still reach the MR —
+        as a position-less note — and count toward delivery rather than being
+        silently dropped as `already_present`."""
+        primary = _gl_primary()
+        unanchored = _gl_corroborator("A", None)
+        payloads = []
+        run = self._run_main(
+            findings=[primary, unanchored],
+            prior=(True, {_member_key(primary)}, None),
+            payloads=payloads,
+        )
+        self.assertIsNone(run.exit_code)
+        note_bodies = [p["body"] for p in payloads if "position" not in p]
+        self.assertTrue(
+            any("Corroborator A" in b for b in note_bodies),
+            "the unanchorable corroborator's content must land on the MR "
+            "somewhere, not vanish",
+        )
+        self.assertIn(
+            post_review.build_finding_marker("a" * 40, _member_key(unanchored)),
+            "".join(note_bodies),
+        )
+        self.assertIn("  1 inline discussion(s) already on the MR", run.out)
+        self.assertIn("  1 inline discussion(s) posted.", run.out)
+
     def test_live_all_malformed_exits_one_with_nothing_posted(self):
         findings = [dict(f, line=float(f["line"])) for f in GL_CONTRACT_FINDINGS]
         run = self._run_main(findings=findings)


### PR DESCRIPTION
## Failure scenario

`post_gitlab` (scripts/post_review.py) consolidates a group of corroborating
findings into one posted discussion. A corroborator that cannot self-anchor
(no `line`, or a `line` outside the diff) has always been groupable, but
`member_keys` only ever collected keys for the primary and anchored
corroborators — the unanchorable member had no key at all.

That's fine for a fresh delivery: the group's one discussion carries all of
it. It breaks on a **rerun after a partial delivery**: when the group's
discussion had earlier failed to post and the loop fell back to posting each
member individually, the anchored siblings got their own discussions (and
their own keys), but the unanchorable corroborator has no anchor — it was
never given a fallback discussion of its own, and it never got a key. On the
next run, `member_keys` for that group was `[primary_key, sibling_keys...]`
(missing the unanchorable one) — but since every key that *did* exist was
already delivered, the "all keys present" branch fired and the whole group
was reported `already_present`. The unanchorable corroborator's content was
never posted anywhere and never would be on any future rerun either: a
silent, permanent loss counted as a success.

## Chosen mechanism

- Every group member now gets a delivery key (`member_key_for()`): an
  anchored member keys off its resolved position exactly as before; an
  unanchorable member keys off its own raw, unresolved `file`/`line` —
  deterministic, and the same material the group body's marker for that
  member uses, so the two round-trip (the group body now carries a marker
  for every member, not just the anchorable ones).
- On a rerun where the group is only *partially* present, a missing
  unanchorable member can't get an individual inline discussion (there's no
  position to anchor one on) — it's posted instead as a **position-less MR
  note**, via a new `deliver_unanchored()`, reusing the same `/notes`
  endpoint the summary note already posts to and carrying the same
  per-finding marker an inline discussion appends. `detect_prior_review`'s
  reader already scans the flat `/notes` list (which includes every
  discussion's notes too), so this new note is picked up by the existing
  dedup scan with zero reader changes.
- The pre-existing "the group's own discussion failed to post" fallback is
  left untouched: nothing from that group has reached the MR yet in that
  case, so `deliver_corroborator`'s own no-line/off-diff diagnostics are
  still the right report, not the note fallback (which exists specifically
  to reach a member whose group body already went out without it).

## Mutation evidence

Added three tests to `TestGitlabPositionGate` in `tests/test_post_review.py`:
round-trip (group body carries every member's marker), full-group rerun
recognition, and delivery of a member left behind by an earlier partial run.
Verified red by `git stash`-reverting `scripts/post_review.py` (with
`__pycache__` purged) and rerunning the targeted tests — both new assertions
failed with the exact symptom described above — then restored the fix and
confirmed green.

## Gates

- `uv run python -m pytest tests/ -q` — 1359 passed, 516 subtests passed
- `COVERAGE_FILE=... uv run python -m pytest tests/ -q --cov=scripts --cov=.github --cov-fail-under=91.8` — 93.10% (floor 91.8%)
- `pre-commit run --all-files` — all hooks passed
- `node --test workflows/test/*.test.js` — 822 passed (proves the JS twin is untouched; GitLab posting is Python-only)
- `node workflows/build.js && git diff --exit-code workflows/pipeline.js` — bundle unchanged

Tier: suites-only (GitLab rerun delivery accounting; no findings-content or ranking change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkugfQAn4UQTkbf3iu59cs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitLab posting and rerun idempotency for consolidation groups; behavior is heavily tested but mistakes could duplicate MR content or skip findings on retry.
> 
> **Overview**
> Fixes **silent loss of unanchorable corroborators** on GitLab reruns after partial delivery: consolidation groups now give **every member a delivery key** (including corroborators with no diff line), embed those markers in group bodies, and use them in dedup instead of treating the group as fully delivered when only anchored siblings had keys.
> 
> **`detect_prior_review`** extends the single MR-notes fetch with **`legacy_group_keys`**, detecting pre-#208 group bodies that rendered corroborator sections but never carried their markers, so reruns do not duplicate that content.
> 
> **`post_gitlab`** adds **`member_key_for`** and **`deliver_unanchored`** (position-less `/notes` posts) for partial-delivery cases where the missing member cannot get an inline discussion; when the primary key is flagged as legacy, the whole group is counted **already_present** without reposting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4abf18bbacfbd410729e8c81091d6287e21dbdc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->