### PR TITLE
feat(style): output-discipline rules, generator, and SessionStart carrier

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "env": {
+    "CLAUDE_CODE_TASK_LIST_ID": "claude-deep-review"
+  },
+  "permissions": {
+    "allow": [
+      "Edit(hooks/**)"
+    ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/scripts/emit_style_context.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,12 +1,4 @@
 {
-  "env": {
-    "CLAUDE_CODE_TASK_LIST_ID": "claude-deep-review"
-  },
-  "permissions": {
-    "allow": [
-      "Edit(hooks/**)"
-    ]
-  },
   "hooks": {
     "SessionStart": [
       {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,6 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",

--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,9 @@ __pycache__/
 coverage.xml
 htmlcov/
 
-# Claude Code local settings
-.claude/
+# Claude Code local settings (shared project settings.json is tracked)
+.claude/*
+!.claude/settings.json
 
 # Internal development artifacts (not shipped)
 docs/specs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,3 +151,9 @@ after a merge:
 - Labels must exist before a form can apply one; GitHub drops unknown labels silently. Sync with
   `python3 .github/labels_diff.py --commands --repo <owner>/<repo>`, confirm with `--live -`. See
   `docs/maintainer-issues.md`.
+
+## Session output style
+
+Canonical rules live in `docs/style/wording-rules.md` and `docs/style/cadence-rules.md`.
+`scripts/build_style_artifacts.py` regenerates `docs/style/session-context.md`, which a
+SessionStart hook injects into every session.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,4 @@ after a merge:
 
 ## Session output style
 
-Canonical rules live in `docs/style/wording-rules.md` and `docs/style/cadence-rules.md`.
-`scripts/build_style_artifacts.py` regenerates `docs/style/session-context.md`, which a
-SessionStart hook injects into every session.
+Canonical rules and the regeneration mechanism are documented in `scripts/build_style_artifacts.py`.

--- a/docs/style/cadence-rules.md
+++ b/docs/style/cadence-rules.md
@@ -1,0 +1,100 @@
+# Cadence rules
+
+Rules that govern the rhythm of a live working session: how much Claude says between tool calls,
+when it speaks, and how it closes. They apply to session output only. An agent that returns a
+finished document and never runs a multi-step task loads the wording rules alone. Repository
+documentation is not bound by either file.
+
+Each `RULE:` line is the complete rule and is extracted verbatim by
+`scripts/build_style_artifacts.py`. Generated carriers receive that line and nothing else, so the
+line must stand alone. The prose beneath each rule is expansion for a human maintainer and is never
+extracted. Negative examples live in fenced blocks so a tightening pass cannot quietly repair them.
+
+Sentence construction cannot reach any of this. A session made of individually clean sentences is
+still unreadable when every step is announced, every correction is narrated, and the close restates
+the process.
+
+## Answer at the length the question deserves
+
+RULE: Answer a one-fact question in one or two sentences, with no preamble and no restatement of the question.
+
+**Check:** a reply to a single-fact question is at most three sentences.
+
+Before:
+
+```text
+Good question. To determine which module owns the retry, I looked at how the pipeline
+composes its stages and traced the call path from the entry point through to the writer,
+and the answer is that stages.js owns it.
+```
+
+After: `stages.js` owns the retry.
+
+## Summarize by default
+
+RULE: Give the conclusion and the reasoning that changes it, and hold the full trace until someone asks.
+
+**Check:** the reply names no file that was read only to rule something out.
+
+The reader wants the answer plus enough to trust it. A file-by-file account of what you read
+belongs in the transcript, not the reply. If the detail would change what the reader does next,
+it is not detail and it stays.
+
+## One sentence before the first tool call
+
+RULE: Say in one sentence what you are about to do before the first tool call, and say nothing for a trivial lookup.
+
+**Check:** at most one sentence precedes the first tool call in a turn.
+
+Reading one file to answer one question needs no preamble. Starting a multi-file investigation
+does, because the reader is about to watch a run of tool calls and wants to know their purpose.
+
+## Show intent, do not announce it
+
+RULE: Describe the goal in one sentence rather than narrating the sequence of steps you plan to take.
+
+**Check:** no sentence before a tool call enumerates two or more planned steps.
+
+Before:
+
+```text
+I'm going to first read the config loader, then trace where the provider field is set,
+then check the tests that cover it, and then I'll report back on what I find.
+```
+
+After: I want to find where the provider field gets its default.
+
+## Update at findings, not at steps
+
+RULE: Speak between tool calls only when you found something load-bearing or changed direction.
+
+**Check:** no message between tool calls restates what the previous tool call did.
+
+A running commentary of completed steps duplicates what the transcript already shows. A note that
+the retry is in a different module than expected changes what the reader should watch for, so it
+earns its line.
+
+## Close on the outcome
+
+RULE: End the turn with what happened or what you found, not with a recap of the process that produced it.
+
+**Check:** the closing paragraph contains no process verb such as searched, checked, or confirmed.
+
+Before:
+
+```text
+I searched the pipeline sources, read the stage definitions, cross-checked against the
+tests, and confirmed my understanding, and based on all of that the retry logic lives in
+the writer stage.
+```
+
+After: The retry lives in the writer stage. It fires once on a partial write, then reports a gap.
+
+## Recover from errors silently
+
+RULE: Correct your own mistake without narrating it, unless the mistake changes a decision the reader has already made.
+
+**Check:** the output contains no apology or correction of a step the reader never saw.
+
+A wrong path guessed and corrected inside one turn is noise. A wrong assumption that the reader
+acted on is a finding, and it gets a plain sentence saying what changed and what to do about it.

--- a/docs/style/cadence-rules.md
+++ b/docs/style/cadence-rules.md
@@ -9,6 +9,7 @@ Each `RULE:` line is the complete rule and is extracted verbatim by
 `scripts/build_style_artifacts.py`. Generated carriers receive that line and nothing else, so the
 line must stand alone. The prose beneath each rule is expansion for a human maintainer and is never
 extracted. Negative examples live in fenced blocks so a tightening pass cannot quietly repair them.
+The carrier ships only the `RULE:` line, so any scoping the rule needs must live in that line itself.
 
 Sentence construction cannot reach any of this. A session made of individually clean sentences is
 still unreadable when every step is announced, every correction is narrated, and the close restates
@@ -18,7 +19,7 @@ the process.
 
 RULE: Answer a one-fact question in one or two sentences, with no preamble and no restatement of the question.
 
-**Check:** a reply to a single-fact question is at most three sentences.
+**Self-check:** a reply to a single-fact question is at most three sentences.
 
 Before:
 
@@ -34,7 +35,7 @@ After: `stages.js` owns the retry.
 
 RULE: Give the conclusion and the reasoning that changes it, and hold the full trace until someone asks.
 
-**Check:** the reply names no file that was read only to rule something out.
+**Self-check:** the reply names no file that was read only to rule something out.
 
 The reader wants the answer plus enough to trust it. A file-by-file account of what you read
 belongs in the transcript, not the reply. If the detail would change what the reader does next,
@@ -53,7 +54,7 @@ does, because the reader is about to watch a run of tool calls and wants to know
 
 RULE: Describe the goal in one sentence rather than narrating the sequence of steps you plan to take.
 
-**Check:** no sentence before a tool call enumerates two or more planned steps.
+**Self-check:** no sentence before a tool call enumerates two or more planned steps.
 
 Before:
 
@@ -68,7 +69,7 @@ After: I want to find where the provider field gets its default.
 
 RULE: Speak between tool calls only when you found something load-bearing or changed direction.
 
-**Check:** no message between tool calls restates what the previous tool call did.
+**Self-check:** no message between tool calls restates what the previous tool call did.
 
 A running commentary of completed steps duplicates what the transcript already shows. A note that
 the retry is in a different module than expected changes what the reader should watch for, so it
@@ -78,7 +79,7 @@ earns its line.
 
 RULE: End the turn with what happened or what you found, not with a recap of the process that produced it.
 
-**Check:** the closing paragraph contains no process verb such as searched, checked, or confirmed.
+**Self-check:** the closing paragraph does not restate steps the transcript already showed; a verification outcome stated once is fine.
 
 Before:
 
@@ -94,7 +95,7 @@ After: The retry lives in the writer stage. It fires once on a partial write, th
 
 RULE: Correct your own mistake without narrating it, unless the mistake changes a decision the reader has already made.
 
-**Check:** the output contains no apology or correction of a step the reader never saw.
+**Self-check:** the output contains no apology or correction of a step the reader never saw.
 
 A wrong path guessed and corrected inside one turn is noise. A wrong assumption that the reader
 acted on is a finding, and it gets a plain sentence saying what changed and what to do about it.

--- a/docs/style/session-context.md
+++ b/docs/style/session-context.md
@@ -8,7 +8,7 @@ These rules govern Claude's session output in this repository.
 
 - Cut em dashes from your own output, replacing each with a comma, a period, or "and" or "but".
 - Describe what a thing does, and never assert that it is important, critical, or a milestone.
-- Avoid comprehensive, robust, seamless, crucial, vital, key, powerful, significant, deep, enhanced, and "leverage" as a verb.
+- Avoid comprehensive, robust, seamless, crucial, vital, key, powerful, significant, deep, and enhanced as boosters, and "leverage" as a verb.
 - Write a bullet as a full sentence, never as a bolded label followed by a colon and a fragment.
 - List exactly the items that exist, and write one or two items as prose instead of a list.
 - Keep every sentence under 25 words and give each sentence one idea.

--- a/docs/style/session-context.md
+++ b/docs/style/session-context.md
@@ -1,0 +1,31 @@
+<!-- GENERATED from docs/style/wording-rules.md and docs/style/cadence-rules.md by scripts/build_style_artifacts.py -- do not edit. Edit the sources, then run: python3 scripts/build_style_artifacts.py -->
+
+# Session output style
+
+These rules govern Claude's session output in this repository.
+
+## Wording
+
+- Cut em dashes from your own output, replacing each with a comma, a period, or "and" or "but".
+- Describe what a thing does, and never assert that it is important, critical, or a milestone.
+- Avoid comprehensive, robust, seamless, crucial, vital, key, powerful, significant, deep, enhanced, and "leverage" as a verb.
+- Write a bullet as a full sentence, never as a bolded label followed by a colon and a fragment.
+- List exactly the items that exist, and write one or two items as prose instead of a list.
+- Keep every sentence under 25 words and give each sentence one idea.
+- Vary sentence length beneath the word cap, because the cap is a ceiling and not a target.
+- Use a verb where a noun phrase hides an action, writing "the parser validates" over "validation is performed".
+- Prefer the plain word: use over utilize, start over commence, about over regarding, so over accordingly.
+- Explain connected reasoning in prose, and use bullets only for genuinely parallel items.
+- Stop at the last fact, adding no summary of what was already said and no offer of next steps.
+- Name what you did not check in one plain sentence, without hedging language around it.
+- Define an unfamiliar term the first time you use it, then use it bare for the rest of the reply.
+
+## Cadence
+
+- Answer a one-fact question in one or two sentences, with no preamble and no restatement of the question.
+- Give the conclusion and the reasoning that changes it, and hold the full trace until someone asks.
+- Say in one sentence what you are about to do before the first tool call, and say nothing for a trivial lookup.
+- Describe the goal in one sentence rather than narrating the sequence of steps you plan to take.
+- Speak between tool calls only when you found something load-bearing or changed direction.
+- End the turn with what happened or what you found, not with a recap of the process that produced it.
+- Correct your own mistake without narrating it, unless the mistake changes a decision the reader has already made.

--- a/docs/style/wording-rules.md
+++ b/docs/style/wording-rules.md
@@ -1,0 +1,188 @@
+# Wording rules
+
+Rules that govern any prose Claude writes: chat replies, explanations, and ad-hoc documents it
+drafts during a session. They apply to session output, not to the repository's own documentation.
+Tracked files here are written for a maintainer and are free to be denser than a chat reply.
+
+Each `RULE:` line is the complete rule and is extracted verbatim by
+`scripts/build_style_artifacts.py`. Generated carriers receive that line and nothing else, so the
+line must stand alone. The prose beneath each rule is expansion for a human maintainer and is never
+extracted. Negative examples live in fenced blocks so a tightening pass cannot quietly repair them.
+
+## No em dashes
+
+RULE: Cut em dashes from your own output, replacing each with a comma, a period, or "and" or "but".
+
+**Check:** the character `—` does not appear in the output.
+
+The em dash is the joint that lets two independent thoughts fuse into one hard-to-parse sentence.
+Removing it forces a choice: subordinate the second clause, or end the sentence. Both read better.
+
+Before:
+
+```text
+The parser rejects the payload — the checksum is recomputed from the raw bytes — so a
+re-serialized copy fails even when the fields are identical.
+```
+
+After: The parser recomputes the checksum from the raw bytes. A re-serialized copy therefore fails
+even when every field is identical.
+
+## No inflated significance
+
+RULE: Describe what a thing does, and never assert that it is important, critical, or a milestone.
+
+**Check:** the words important, critical, major, and milestone do not describe your own work.
+
+Significance is the reader's call, made from the facts. Asserting it spends words and asks for
+trust that the sentence has not yet earned.
+
+Before:
+
+```text
+This is a crucial architectural improvement that fundamentally changes how the pipeline
+handles partial writes.
+```
+
+After: The pipeline now retries a partial write once before reporting a gap.
+
+## No filler adjectives
+
+RULE: Avoid comprehensive, robust, seamless, crucial, vital, key, powerful, significant, deep, enhanced, and "leverage" as a verb.
+
+**Check:** none of the listed words appears in the output, in any inflected form.
+
+Each ban is scoped to a failure mode, not to the string. "Key" is banned as a booster before a
+noun, not in "the API key" or "a dictionary key". "Deep" is banned as intensity, not in "a deep
+call stack". "Significant" is banned as praise, not as a statistical term with a stated threshold.
+A ban wider than its failure mode produces worse sentences elsewhere.
+
+Replace the adjective with the fact that would justify it. "Comprehensive test coverage" becomes
+"tests cover every branch in the parser". "Robust error handling" becomes "every failure path
+returns a typed error".
+
+## No bolded-header bullets
+
+RULE: Write a bullet as a full sentence, never as a bolded label followed by a colon and a fragment.
+
+**Check:** no bullet begins with bold text immediately followed by a colon.
+
+The bolded-label shape hides whether a fact actually follows the colon. A reader scanning the
+labels learns nothing and has to re-read.
+
+Before:
+
+```text
+- **Checksum validation:** important for correctness.
+- **Atomic writes:** handled by the writer.
+```
+
+After: The writer computes a checksum before the rename, so a truncated file never replaces a good
+one.
+
+## No padded lists
+
+RULE: List exactly the items that exist, and write one or two items as prose instead of a list.
+
+**Check:** every item in a list names something that exists in the code or the change under
+discussion.
+
+Lists attract a third item that was invented to fill the shape. If you have two real points,
+a sentence carries them with the connective intact.
+
+## One idea per sentence
+
+RULE: Keep every sentence under 25 words and give each sentence one idea.
+
+**Check:** no sentence exceeds 25 words, counting whitespace-separated tokens outside code spans.
+
+Before:
+
+```text
+Because the resolver reads the manifest before the lockfile is parsed, and because the
+lockfile can pin a version the manifest never declared, a stale lockfile silently wins,
+which is why the install reproduces on one machine and not another.
+```
+
+After: The resolver reads the manifest before parsing the lockfile. A lockfile can pin a version
+the manifest never declared, so a stale lockfile wins silently. That is why the install reproduces
+on one machine and not another.
+
+## Vary sentence length
+
+RULE: Vary sentence length beneath the word cap, because the cap is a ceiling and not a target.
+
+**Check:** in any run of five consecutive sentences, the longest and shortest differ by at least
+eight words.
+
+A run of uniformly short sentences reads as machine output even when every sentence is true. Let
+one sentence carry a full clause and the next carry four words.
+
+## Verbs, not nominalizations
+
+RULE: Use a verb where a noun phrase hides an action, writing "the parser validates" over "validation is performed".
+
+**Check:** no sentence pairs a `-tion` or `-ment` noun with be, perform, conduct, or provide.
+
+Before:
+
+```text
+Verification of the receipt fields is performed by the executor prior to emission of the
+delta set.
+```
+
+After: The executor verifies the receipt fields before it emits the deltas.
+
+## Plain words
+
+RULE: Prefer the plain word: use over utilize, start over commence, about over regarding, so over accordingly.
+
+**Check:** utilize, commence, regarding, accordingly, and additionally do not appear.
+
+The formal synonym adds syllables and a register that suggests distance from the work. The plain
+word is also shorter, which helps the sentence stay under the cap.
+
+## Prose for reasoning, bullets for parallel items
+
+RULE: Explain connected reasoning in prose, and use bullets only for genuinely parallel items.
+
+**Check:** every bulleted list holds items of the same grammatical shape.
+
+Most "be concise" instructions demand bullets, which trades one unreadability for another.
+A bulleted causal chain has had its connectives stripped, so the reader reassembles the argument
+from fragments. Keep prose as the default and let the word cap hold its length down. A list of
+four supported providers is parallel and belongs in bullets. A three-step explanation of why the
+retry fires is not.
+
+## End on the last real fact
+
+RULE: Stop at the last fact, adding no summary of what was already said and no offer of next steps.
+
+**Check:** the final paragraph states a fact not already stated earlier in the reply.
+
+A closing restatement of the process is the single most common source of unread text. If the last
+paragraph would survive deletion without losing a fact, delete it.
+
+## State gaps directly
+
+RULE: Name what you did not check in one plain sentence, without hedging language around it.
+
+**Check:** may, might, possibly, potentially, and "it's worth noting" do not appear.
+
+Before:
+
+```text
+It's worth noting that there may potentially be additional cases in the GitLab path that
+could conceivably behave differently, though I wasn't able to fully confirm this.
+```
+
+After: I did not check the GitLab path.
+
+## Gloss a term once
+
+RULE: Define an unfamiliar term the first time you use it, then use it bare for the rest of the reply.
+
+**Check:** each term's parenthetical or appositive gloss appears at most once per reply.
+
+Repeating the gloss treats the reader as someone who did not read the previous paragraph. Omitting
+it entirely leaves a term nobody can look up.

--- a/docs/style/wording-rules.md
+++ b/docs/style/wording-rules.md
@@ -8,6 +8,7 @@ Each `RULE:` line is the complete rule and is extracted verbatim by
 `scripts/build_style_artifacts.py`. Generated carriers receive that line and nothing else, so the
 line must stand alone. The prose beneath each rule is expansion for a human maintainer and is never
 extracted. Negative examples live in fenced blocks so a tightening pass cannot quietly repair them.
+The carrier ships only the `RULE:` line, so any scoping the rule needs must live in that line itself.
 
 ## No em dashes
 
@@ -32,7 +33,7 @@ even when every field is identical.
 
 RULE: Describe what a thing does, and never assert that it is important, critical, or a milestone.
 
-**Check:** the words important, critical, major, and milestone do not describe your own work.
+**Self-check:** the words important, critical, major, and milestone do not describe your own work.
 
 Significance is the reader's call, made from the facts. Asserting it spends words and asks for
 trust that the sentence has not yet earned.
@@ -48,7 +49,7 @@ After: The pipeline now retries a partial write once before reporting a gap.
 
 ## No filler adjectives
 
-RULE: Avoid comprehensive, robust, seamless, crucial, vital, key, powerful, significant, deep, enhanced, and "leverage" as a verb.
+RULE: Avoid comprehensive, robust, seamless, crucial, vital, key, powerful, significant, deep, and enhanced as boosters, and "leverage" as a verb.
 
 **Check:** none of the listed words appears in the output, in any inflected form.
 
@@ -84,7 +85,7 @@ one.
 
 RULE: List exactly the items that exist, and write one or two items as prose instead of a list.
 
-**Check:** every item in a list names something that exists in the code or the change under
+**Self-check:** every item in a list names something that exists in the code or the change under
 discussion.
 
 Lists attract a third item that was invented to fill the shape. If you have two real points,
@@ -146,7 +147,7 @@ word is also shorter, which helps the sentence stay under the cap.
 
 RULE: Explain connected reasoning in prose, and use bullets only for genuinely parallel items.
 
-**Check:** every bulleted list holds items of the same grammatical shape.
+**Self-check:** every bulleted list holds items of the same grammatical shape.
 
 Most "be concise" instructions demand bullets, which trades one unreadability for another.
 A bulleted causal chain has had its connectives stripped, so the reader reassembles the argument
@@ -158,7 +159,7 @@ retry fires is not.
 
 RULE: Stop at the last fact, adding no summary of what was already said and no offer of next steps.
 
-**Check:** the final paragraph states a fact not already stated earlier in the reply.
+**Self-check:** the final paragraph states a fact not already stated earlier in the reply.
 
 A closing restatement of the process is the single most common source of unread text. If the last
 paragraph would survive deletion without losing a fact, delete it.
@@ -182,7 +183,7 @@ After: I did not check the GitLab path.
 
 RULE: Define an unfamiliar term the first time you use it, then use it bare for the rest of the reply.
 
-**Check:** each term's parenthetical or appositive gloss appears at most once per reply.
+**Self-check:** each term's parenthetical or appositive gloss appears at most once per reply.
 
 Repeating the gloss treats the reader as someone who did not read the previous paragraph. Omitting
 it entirely leaves a term nobody can look up.

--- a/scripts/build_style_artifacts.py
+++ b/scripts/build_style_artifacts.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Generate docs/style/session-context.md from the wording and cadence rule sources.
+
+Mirrors the shape of scripts/sync_agent_rules.py: two hand-maintained sources
+(docs/style/wording-rules.md, docs/style/cadence-rules.md) carry the rules for a human
+maintainer, and this script extracts every `RULE: ` line verbatim into one generated
+carrier a SessionStart hook can inject whole. Editing the carrier directly is the mistake
+this guards against: run this script instead.
+
+Usage:
+    python3 scripts/build_style_artifacts.py           # write the carrier
+    python3 scripts/build_style_artifacts.py --check   # exit 1 if the carrier is stale
+"""
+
+import argparse
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+WORDING_SOURCE = os.path.join("docs", "style", "wording-rules.md")
+CADENCE_SOURCE = os.path.join("docs", "style", "cadence-rules.md")
+CARRIER = os.path.join("docs", "style", "session-context.md")
+
+BANNER = (
+    "<!-- GENERATED from docs/style/wording-rules.md and docs/style/cadence-rules.md by "
+    "scripts/build_style_artifacts.py -- do not edit. Edit the sources, then run: "
+    "python3 scripts/build_style_artifacts.py -->"
+)
+
+RULE_PREFIX = "RULE: "
+
+
+def extract_rules(text, source_name):
+    """Every line starting `RULE: `, verbatim, skipping fenced code blocks."""
+    rules = []
+    in_fence = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if line.startswith(RULE_PREFIX):
+            rules.append(line[len(RULE_PREFIX) :])
+    if not rules:
+        raise ValueError(f"{source_name} yields zero RULE: lines")
+    return rules
+
+
+def read_source(repo_root, relpath):
+    path = os.path.join(repo_root, relpath)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"missing style rule source: {relpath}")
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def carrier_text(repo_root):
+    wording_rules = extract_rules(
+        read_source(repo_root, WORDING_SOURCE), WORDING_SOURCE
+    )
+    cadence_rules = extract_rules(
+        read_source(repo_root, CADENCE_SOURCE), CADENCE_SOURCE
+    )
+
+    lines = [
+        BANNER,
+        "",
+        "# Session output style",
+        "",
+        "These rules govern Claude's session output in this repository.",
+        "",
+        "## Wording",
+        "",
+    ]
+    lines.extend(f"- {rule}" for rule in wording_rules)
+    lines.append("")
+    lines.append("## Cadence")
+    lines.append("")
+    lines.extend(f"- {rule}" for rule in cadence_rules)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def sync(repo_root, check_only=False):
+    expected = carrier_text(repo_root)
+    target = os.path.join(repo_root, CARRIER)
+    current = None
+    if os.path.isfile(target):
+        with open(target, encoding="utf-8") as handle:
+            current = handle.read()
+    if current == expected:
+        return False
+    if not check_only:
+        with open(target, "w", encoding="utf-8") as handle:
+            handle.write(expected)
+    return True
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=REPO_ROOT)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report a stale or missing carrier without writing",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        stale = sync(args.repo_root, check_only=args.check)
+    except (FileNotFoundError, ValueError) as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 1
+
+    if not stale:
+        print("style session-context carrier is current")
+        return 0
+    if args.check:
+        sys.stderr.write(
+            f"stale generated carrier: {os.path.relpath(os.path.join(args.repo_root, CARRIER), args.repo_root)}\n"
+            "run: python3 scripts/build_style_artifacts.py\n"
+        )
+        return 1
+    print(
+        f"regenerated: {os.path.relpath(os.path.join(args.repo_root, CARRIER), args.repo_root)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_style_artifacts.py
+++ b/scripts/build_style_artifacts.py
@@ -35,12 +35,16 @@ def extract_rules(text, source_name):
     """Every line starting `RULE: `, verbatim, skipping fenced code blocks.
 
     Each rule lives in its own `##` section, so a stray or missing fence delimiter that
-    would silently swallow later rules is caught two ways: an unclosed fence at end of
-    file is a hard error, and the rule count is cross-checked against the number of `##`
-    headings outside any fence.
+    would silently swallow later rules is caught by per-section attribution: every
+    section outside a fence must carry exactly one RULE: line, and a violation names both
+    the source and the offending section heading. An aggregate count comparison would pass
+    when one section has zero RULE: lines and another has two; this does not. Preamble
+    text before the first `## ` heading is exempt and may carry zero rules. An unclosed
+    fence at end of file is a separate hard error.
     """
     rules = []
-    headings = 0
+    current_heading = None
+    section_count = 0
     in_fence = False
     for line in text.splitlines():
         stripped = line.strip()
@@ -50,18 +54,26 @@ def extract_rules(text, source_name):
         if in_fence:
             continue
         if line.startswith("## "):
-            headings += 1
+            if current_heading is not None and section_count != 1:
+                raise ValueError(
+                    f"{source_name} section {current_heading!r} has {section_count} "
+                    "RULE: lines; all sections must carry exactly one"
+                )
+            current_heading = line
+            section_count = 0
+            continue
         if line.startswith(RULE_PREFIX):
             rules.append(line[len(RULE_PREFIX) :])
+            section_count += 1
     if in_fence:
         raise ValueError(f"unbalanced code fence in {source_name}")
+    if current_heading is not None and section_count != 1:
+        raise ValueError(
+            f"{source_name} section {current_heading!r} has {section_count} "
+            "RULE: lines; all sections must carry exactly one"
+        )
     if not rules:
         raise ValueError(f"{source_name} yields zero RULE: lines")
-    if headings != len(rules):
-        raise ValueError(
-            f"{source_name} has {headings} '##' sections but {len(rules)} RULE: lines; "
-            "every section must carry exactly one RULE: line"
-        )
     return rules
 
 
@@ -136,13 +148,11 @@ def main(argv=None):
         return 0
     if args.check:
         sys.stderr.write(
-            f"stale generated carrier: {os.path.relpath(os.path.join(args.repo_root, CARRIER), args.repo_root)}\n"
+            f"stale generated carrier: {CARRIER}\n"
             "run: python3 scripts/build_style_artifacts.py\n"
         )
         return 1
-    print(
-        f"regenerated: {os.path.relpath(os.path.join(args.repo_root, CARRIER), args.repo_root)}"
-    )
+    print(f"regenerated: {CARRIER}")
     return 0
 
 

--- a/scripts/build_style_artifacts.py
+++ b/scripts/build_style_artifacts.py
@@ -32,8 +32,15 @@ RULE_PREFIX = "RULE: "
 
 
 def extract_rules(text, source_name):
-    """Every line starting `RULE: `, verbatim, skipping fenced code blocks."""
+    """Every line starting `RULE: `, verbatim, skipping fenced code blocks.
+
+    Each rule lives in its own `##` section, so a stray or missing fence delimiter that
+    would silently swallow later rules is caught two ways: an unclosed fence at end of
+    file is a hard error, and the rule count is cross-checked against the number of `##`
+    headings outside any fence.
+    """
     rules = []
+    headings = 0
     in_fence = False
     for line in text.splitlines():
         stripped = line.strip()
@@ -42,10 +49,19 @@ def extract_rules(text, source_name):
             continue
         if in_fence:
             continue
+        if line.startswith("## "):
+            headings += 1
         if line.startswith(RULE_PREFIX):
             rules.append(line[len(RULE_PREFIX) :])
+    if in_fence:
+        raise ValueError(f"unbalanced code fence in {source_name}")
     if not rules:
         raise ValueError(f"{source_name} yields zero RULE: lines")
+    if headings != len(rules):
+        raise ValueError(
+            f"{source_name} has {headings} '##' sections but {len(rules)} RULE: lines; "
+            "every section must carry exactly one RULE: line"
+        )
     return rules
 
 

--- a/scripts/emit_style_context.py
+++ b/scripts/emit_style_context.py
@@ -18,6 +18,16 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 CARRIER = os.path.join(REPO_ROOT, "docs", "style", "session-context.md")
 
 
+def strip_banner(text):
+    """Drop the leading GENERATED banner: it instructs a maintainer, not the session."""
+    lines = text.split("\n")
+    if lines and lines[0].startswith("<!--"):
+        del lines[0]
+        if lines and lines[0] == "":
+            del lines[0]
+    return "\n".join(lines)
+
+
 def main(argv=None):
     if not os.path.isfile(CARRIER):
         return 0
@@ -26,7 +36,7 @@ def main(argv=None):
     payload = {
         "hookSpecificOutput": {
             "hookEventName": "SessionStart",
-            "additionalContext": contents,
+            "additionalContext": strip_banner(contents),
         }
     }
     print(json.dumps(payload))

--- a/scripts/emit_style_context.py
+++ b/scripts/emit_style_context.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Print the SessionStart hook payload carrying docs/style/session-context.md.
+
+Reads the generated style carrier (scripts/build_style_artifacts.py) and prints one JSON
+object on stdout in the shape a Claude Code SessionStart hook expects. A broken or missing
+carrier must never block session start, so a missing file exits 0 with empty stdout rather
+than raising.
+
+Usage:
+    python3 scripts/emit_style_context.py
+"""
+
+import json
+import os
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CARRIER = os.path.join(REPO_ROOT, "docs", "style", "session-context.md")
+
+
+def main(argv=None):
+    if not os.path.isfile(CARRIER):
+        return 0
+    with open(CARRIER, encoding="utf-8") as handle:
+        contents = handle.read()
+    payload = {
+        "hookSpecificOutput": {
+            "hookEventName": "SessionStart",
+            "additionalContext": contents,
+        }
+    }
+    print(json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -114,7 +114,10 @@ CODEX_CAP_BYTES = 32_768
 # Raised 20_420 -> 20_436 (2026-08-18, #62): the coverage-floor ratchet (Python 92.1,
 # JS branches 85.7 / functions 97.4) grew AGENTS.md's floors-and-provenance paragraph —
 # the exact gate values Claude must pass are operational policy, not decoration.
-AGENTS_SET_BUDGET_BYTES = 20_436
+# Raised 20_436 -> 20_685 (2026-08-18): the "Session output style" section points at the
+# canonical rule sources and the generator that regenerates the SessionStart carrier —
+# no code site states where those rules live or how the carrier gets refreshed.
+AGENTS_SET_BUDGET_BYTES = 20_685
 CLAUDE_MD_MAX_BYTES = 856
 
 # Root CLAUDE.md is a pointer, not a document. The line cap is a shape bound and keeps its

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -117,7 +117,10 @@ CODEX_CAP_BYTES = 32_768
 # Raised 20_436 -> 20_685 (2026-08-18): the "Session output style" section points at the
 # canonical rule sources and the generator that regenerates the SessionStart carrier —
 # no code site states where those rules live or how the carrier gets refreshed.
-AGENTS_SET_BUDGET_BYTES = 20_685
+# Lowered 20_685 -> 20_563 (2026-08-18, PR #216 review fix): "Session output style"
+# shrunk to a heading plus a single pointer at scripts/build_style_artifacts.py, whose
+# own docstring already states the mechanics the section had restated.
+AGENTS_SET_BUDGET_BYTES = 20_563
 CLAUDE_MD_MAX_BYTES = 856
 
 # Root CLAUDE.md is a pointer, not a document. The line cap is a shape bound and keeps its

--- a/tests/test_docs_registry.py
+++ b/tests/test_docs_registry.py
@@ -44,6 +44,9 @@ DOCS_ALLOW = {
     "docs/machine-parsed-strings.md",  # living registry, required by #37 (PR #119)
     "docs/maintainer-issues.md",  # maintainer work-queue standard
     "docs/v3-residue-audit-2026-07.md",  # point-in-time audit artifact, required by #37 (PR #119)
+    "docs/style/wording-rules.md",  # canonical output-style rule source
+    "docs/style/cadence-rules.md",  # canonical output-style rule source
+    "docs/style/session-context.md",  # generated session-output carrier
 }
 
 # Subtrees under docs/ with their own curated index; markdown only inside.

--- a/tests/test_style_rules.py
+++ b/tests/test_style_rules.py
@@ -1,0 +1,254 @@
+"""Guards for the session-output style mechanism.
+
+docs/style/wording-rules.md and docs/style/cadence-rules.md are the canonical rule
+sources, written for a maintainer. scripts/build_style_artifacts.py extracts every
+`RULE: ` line verbatim into docs/style/session-context.md, the one carrier a SessionStart
+hook injects whole via scripts/emit_style_context.py. This module proves: the carrier
+stays fresh (delegating to the generator's own --check, mirroring
+TestGeneratedTwins.test_no_twin_is_stale in test_agent_instruction_layout.py), the
+sources obey their own rules, the carrier is a faithful and complete extraction, fenced
+code blocks are skipped, and the emitter produces the exact hook payload shape.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = REPO / "scripts" / "build_style_artifacts.py"
+EMIT_SCRIPT = REPO / "scripts" / "emit_style_context.py"
+WORDING_SOURCE = REPO / "docs" / "style" / "wording-rules.md"
+CADENCE_SOURCE = REPO / "docs" / "style" / "cadence-rules.md"
+CARRIER = REPO / "docs" / "style" / "session-context.md"
+
+RULE_PREFIX = "RULE: "
+
+
+def extract_rule_lines(text):
+    """Every `RULE: ` line, verbatim (prefix stripped), skipping fenced blocks."""
+    rules = []
+    in_fence = False
+    for line in text.splitlines():
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if line.startswith(RULE_PREFIX):
+            rules.append(line[len(RULE_PREFIX) :])
+    return rules
+
+
+def run_build(args, cwd=REPO):
+    return subprocess.run(
+        [sys.executable, str(BUILD_SCRIPT), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestCarrierFreshness(unittest.TestCase):
+    def test_check_passes_in_the_real_tree(self):
+        result = run_build(["--check"])
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_check_fails_on_a_mutated_carrier(self):
+        with _fixture_tree() as tmp:
+            carrier = tmp / "docs" / "style" / "session-context.md"
+            carrier.write_text(
+                carrier.read_text(encoding="utf-8") + "stray\n", encoding="utf-8"
+            )
+            result = run_build(["--check", "--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("stale", result.stderr)
+
+    def test_check_fails_on_a_missing_carrier(self):
+        with _fixture_tree() as tmp:
+            (tmp / "docs" / "style" / "session-context.md").unlink()
+            result = run_build(["--check", "--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+
+    def test_write_regenerates_a_stale_carrier(self):
+        with _fixture_tree() as tmp:
+            carrier = tmp / "docs" / "style" / "session-context.md"
+            original = carrier.read_text(encoding="utf-8")
+            carrier.write_text("stale\n", encoding="utf-8")
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(carrier.read_text(encoding="utf-8"), original)
+
+    def test_write_is_a_noop_message_when_already_current(self):
+        with _fixture_tree() as tmp:
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("current", result.stdout)
+
+
+class TestSourceSelfCompliance(unittest.TestCase):
+    """The sources must obey the rules they define, at least where a rule is checkable."""
+
+    def _all_rule_lines(self):
+        lines = []
+        for source in (WORDING_SOURCE, CADENCE_SOURCE):
+            lines.extend(extract_rule_lines(source.read_text(encoding="utf-8")))
+        return lines
+
+    def test_each_rule_line_is_25_words_or_fewer(self):
+        for line in self._all_rule_lines():
+            with self.subTest(line=line):
+                word_count = len(line.split())
+                self.assertLessEqual(word_count, 25, f"{word_count} words: {line!r}")
+
+    def test_no_em_dash_in_any_rule_line(self):
+        for line in self._all_rule_lines():
+            with self.subTest(line=line):
+                self.assertNotIn("—", line)
+
+    def test_each_rule_is_one_physical_line(self):
+        # A RULE: line whose sentence spans multiple physical lines would never match
+        # the `line.startswith("RULE: ")` extraction test at all -- so the real risk is
+        # a rule that got wrapped and silently lost everything past the first line.
+        # Every extracted line must end with terminal punctuation to prove it is whole.
+        for line in self._all_rule_lines():
+            with self.subTest(line=line):
+                self.assertTrue(
+                    line.rstrip().endswith((".", '."')),
+                    f"rule does not end in terminal punctuation, possibly wrapped: {line!r}",
+                )
+
+    def test_sources_yield_at_least_one_rule_each(self):
+        self.assertTrue(extract_rule_lines(WORDING_SOURCE.read_text(encoding="utf-8")))
+        self.assertTrue(extract_rule_lines(CADENCE_SOURCE.read_text(encoding="utf-8")))
+
+
+class TestCarrierIntegrity(unittest.TestCase):
+    def test_banner_is_line_one_and_an_html_comment(self):
+        text = CARRIER.read_text(encoding="utf-8")
+        first_line = text.splitlines()[0]
+        self.assertTrue(first_line.startswith("<!--"))
+        self.assertIn("GENERATED from docs/style/wording-rules.md", first_line)
+
+    def test_every_source_rule_appears_verbatim_as_a_bullet(self):
+        carrier_text = CARRIER.read_text(encoding="utf-8")
+        for source in (WORDING_SOURCE, CADENCE_SOURCE):
+            for rule in extract_rule_lines(source.read_text(encoding="utf-8")):
+                with self.subTest(rule=rule):
+                    self.assertIn(f"- {rule}", carrier_text)
+
+    def test_bullet_count_matches_source_rule_count(self):
+        carrier_text = CARRIER.read_text(encoding="utf-8")
+        bullet_count = sum(
+            1 for line in carrier_text.splitlines() if line.startswith("- ")
+        )
+        source_count = sum(
+            len(extract_rule_lines(source.read_text(encoding="utf-8")))
+            for source in (WORDING_SOURCE, CADENCE_SOURCE)
+        )
+        self.assertEqual(bullet_count, source_count)
+
+    def test_carrier_contains_no_em_dash(self):
+        self.assertNotIn("—", CARRIER.read_text(encoding="utf-8"))
+
+    def test_carrier_ends_with_a_single_trailing_newline(self):
+        raw = CARRIER.read_bytes()
+        self.assertTrue(raw.endswith(b"\n"))
+        self.assertFalse(raw.endswith(b"\n\n"))
+
+
+class TestFencedBlockSafety(unittest.TestCase):
+    def test_rule_line_inside_a_fence_is_not_extracted(self):
+        with _fixture_tree() as tmp:
+            wording = tmp / "docs" / "style" / "wording-rules.md"
+            wording.write_text(
+                wording.read_text(encoding="utf-8")
+                + "\n```text\nRULE: this is inside a fence and must never be extracted.\n```\n",
+                encoding="utf-8",
+            )
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 0, result.stderr)
+            carrier_text = (tmp / "docs" / "style" / "session-context.md").read_text(
+                encoding="utf-8"
+            )
+            self.assertNotIn("this is inside a fence", carrier_text)
+
+
+class TestGeneratorErrorPaths(unittest.TestCase):
+    def test_missing_source_is_a_clear_error(self):
+        with _fixture_tree() as tmp:
+            (tmp / "docs" / "style" / "cadence-rules.md").unlink()
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("missing", result.stderr)
+            self.assertIn("cadence-rules.md", result.stderr)
+
+    def test_zero_rules_is_a_clear_error(self):
+        with _fixture_tree() as tmp:
+            wording = tmp / "docs" / "style" / "wording-rules.md"
+            wording.write_text("# no rules here\n\njust prose.\n", encoding="utf-8")
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("zero", result.stderr)
+
+
+class TestEmitter(unittest.TestCase):
+    def test_stdout_is_the_expected_hook_payload(self):
+        result = subprocess.run(
+            [sys.executable, str(EMIT_SCRIPT)], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["hookSpecificOutput"]["hookEventName"], "SessionStart")
+        self.assertEqual(
+            payload["hookSpecificOutput"]["additionalContext"],
+            CARRIER.read_text(encoding="utf-8"),
+        )
+
+    def test_missing_carrier_exits_zero_with_empty_stdout(self):
+        with _fixture_tree() as tmp:
+            (tmp / "docs" / "style" / "session-context.md").unlink()
+            script = tmp / "scripts" / "emit_style_context.py"
+            result = subprocess.run(
+                [sys.executable, str(script)], capture_output=True, text=True
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout, "")
+
+
+class _fixture_tree:
+    """A tmp dir laid out as docs/style/{wording,cadence,session-context} + scripts/.
+
+    Never mutates the real tree. The emitter's repo root is derived from its own file
+    location, so the fixture ships a copy of emit_style_context.py alongside the copied
+    build script to exercise that path-resolution behavior too.
+    """
+
+    def __enter__(self):
+        import tempfile
+
+        self._tmpdir = tempfile.mkdtemp()
+        tmp = Path(self._tmpdir)
+        (tmp / "docs" / "style").mkdir(parents=True)
+        (tmp / "scripts").mkdir(parents=True)
+        shutil.copy(WORDING_SOURCE, tmp / "docs" / "style" / "wording-rules.md")
+        shutil.copy(CADENCE_SOURCE, tmp / "docs" / "style" / "cadence-rules.md")
+        shutil.copy(BUILD_SCRIPT, tmp / "scripts" / "build_style_artifacts.py")
+        shutil.copy(EMIT_SCRIPT, tmp / "scripts" / "emit_style_context.py")
+        result = subprocess.run(
+            [sys.executable, str(tmp / "scripts" / "build_style_artifacts.py")],
+            cwd=tmp,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        return tmp
+
+    def __exit__(self, exc_type, exc, tb):
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_style_rules.py
+++ b/tests/test_style_rules.py
@@ -179,8 +179,22 @@ def raw_heading_count_outside_fences(text):
 
 
 def raw_rule_texts(text):
-    """RULE: line texts via a plain regex over raw lines, not the generator's function."""
-    return re.findall(r"^RULE: (.+)$", text, re.MULTILINE)
+    """RULE: line texts, skipping fenced blocks -- its own parity toggle, independent of
+    the generator's extract_rules. Without fence-awareness a fenced negative example that
+    starts with `RULE: ` would poison this oracle into expecting carrier text that must
+    never appear there.
+    """
+    texts = []
+    in_fence = False
+    for line in text.splitlines():
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if line.startswith("RULE: "):
+            texts.append(line[len("RULE: ") :])
+    return texts
 
 
 class TestCarrierIntegrity(unittest.TestCase):
@@ -223,6 +237,38 @@ class TestCarrierIntegrity(unittest.TestCase):
 
     def test_carrier_contains_no_em_dash(self):
         self.assertNotIn("—", CARRIER.read_text(encoding="utf-8"))
+
+    def test_fenced_rule_line_is_neither_in_the_carrier_nor_fails_integrity(self):
+        """A fenced negative example starting with `RULE: ` inside an existing section
+        must not appear in the carrier, and must not trip the oracle above -- proving
+        raw_rule_texts is fence-aware rather than trusting the generator's own skip.
+        """
+        with _fixture_tree() as tmp:
+            wording = tmp / "docs" / "style" / "wording-rules.md"
+            text = wording.read_text(encoding="utf-8")
+            poison = (
+                "\n```text\nRULE: this fenced line must never reach the carrier.\n```\n"
+            )
+            # Insert right after the first RULE: line's blank-line successor, still
+            # inside that same `##` section, so heading parity is untouched.
+            lines = text.splitlines()
+            insert_at = next(
+                i + 2 for i, line in enumerate(lines) if line.startswith("RULE: ")
+            )
+            lines[insert_at:insert_at] = poison.splitlines()
+            wording.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            carrier_text = (tmp / "docs" / "style" / "session-context.md").read_text(
+                encoding="utf-8"
+            )
+            self.assertNotIn(
+                "this fenced line must never reach the carrier", carrier_text
+            )
+            for rule_text in raw_rule_texts(text):
+                self.assertIn(f"- {rule_text}", carrier_text)
 
     def test_carrier_ends_with_a_single_trailing_newline(self):
         raw = CARRIER.read_bytes()
@@ -292,8 +338,13 @@ class TestHeadingParity(unittest.TestCase):
             text = wording.read_text(encoding="utf-8")
             # Drop exactly one RULE: line, leaving its `##` section headerless of a rule.
             lines = text.splitlines()
+            heading = None
             for i, line in enumerate(lines):
                 if line.startswith("RULE: "):
+                    for j in range(i, -1, -1):
+                        if lines[j].startswith("## "):
+                            heading = lines[j]
+                            break
                     del lines[i]
                     break
             wording.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -301,6 +352,56 @@ class TestHeadingParity(unittest.TestCase):
             result = run_build(["--repo-root", str(tmp)])
             self.assertEqual(result.returncode, 1)
             self.assertIn("sections", result.stderr)
+            self.assertIn(heading, result.stderr)
+
+    def test_zero_rule_lines_in_a_section_names_that_section(self):
+        """A section with zero RULE: lines raises naming that specific heading, not an
+        aggregate mismatch -- the per-section attribution the aggregate check missed.
+        """
+        with _fixture_tree() as tmp:
+            wording = tmp / "docs" / "style" / "wording-rules.md"
+            text = wording.read_text(encoding="utf-8")
+            lines = text.splitlines()
+            heading = None
+            for i, line in enumerate(lines):
+                if line.startswith("RULE: "):
+                    for j in range(i, -1, -1):
+                        if lines[j].startswith("## "):
+                            heading = lines[j]
+                            break
+                    del lines[i]
+                    break
+            wording.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("0 RULE", result.stderr)
+            self.assertIn(heading, result.stderr)
+
+    def test_two_rule_lines_in_a_section_names_that_section(self):
+        """A section with two RULE: lines raises naming that specific heading -- the
+        aggregate heading-count vs rule-count check this replaced would pass this case
+        outright whenever some other section happened to be short by one.
+        """
+        with _fixture_tree() as tmp:
+            wording = tmp / "docs" / "style" / "wording-rules.md"
+            text = wording.read_text(encoding="utf-8")
+            lines = text.splitlines()
+            heading = None
+            for i, line in enumerate(lines):
+                if line.startswith("RULE: "):
+                    for j in range(i, -1, -1):
+                        if lines[j].startswith("## "):
+                            heading = lines[j]
+                            break
+                    lines.insert(i, line)
+                    break
+            wording.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("2 RULE", result.stderr)
+            self.assertIn(heading, result.stderr)
 
 
 class TestGeneratorErrorPaths(unittest.TestCase):
@@ -335,6 +436,22 @@ class TestEmitter(unittest.TestCase):
         self.assertEqual(payload["hookSpecificOutput"]["additionalContext"], rest)
         self.assertNotIn(
             "GENERATED", payload["hookSpecificOutput"]["additionalContext"]
+        )
+
+    def test_additional_context_starts_with_the_style_banner(self):
+        """Pins the emitter's single-line banner strip: partition("\\n\\n") only removes
+        the GENERATED comment because it is exactly one line. A future multi-line banner
+        would leave stray banner text ahead of the real heading without this failing.
+        """
+        result = subprocess.run(
+            [sys.executable, str(EMIT_SCRIPT)], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertTrue(
+            payload["hookSpecificOutput"]["additionalContext"].startswith(
+                "# Session output style"
+            )
         )
 
     def test_missing_carrier_exits_zero_with_empty_stdout(self):

--- a/tests/test_style_rules.py
+++ b/tests/test_style_rules.py
@@ -11,6 +11,7 @@ code blocks are skipped, and the emitter produces the exact hook payload shape.
 """
 
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -112,43 +113,113 @@ class TestSourceSelfCompliance(unittest.TestCase):
         # A RULE: line whose sentence spans multiple physical lines would never match
         # the `line.startswith("RULE: ")` extraction test at all -- so the real risk is
         # a rule that got wrapped and silently lost everything past the first line.
-        # Every extracted line must end with terminal punctuation to prove it is whole.
-        for line in self._all_rule_lines():
-            with self.subTest(line=line):
-                self.assertTrue(
-                    line.rstrip().endswith((".", '."')),
-                    f"rule does not end in terminal punctuation, possibly wrapped: {line!r}",
-                )
+        # Every extracted line must end with terminal punctuation to prove it is whole,
+        # and the physical line right after it must be blank -- a wrapped rule leaves
+        # its continuation there instead.
+        for source in (WORDING_SOURCE, CADENCE_SOURCE):
+            lines = source.read_text(encoding="utf-8").splitlines()
+            for i, line in enumerate(lines):
+                if not line.startswith(RULE_PREFIX):
+                    continue
+                with self.subTest(source=source.name, line=line):
+                    rule = line[len(RULE_PREFIX) :]
+                    self.assertTrue(
+                        rule.rstrip().endswith((".", '."')),
+                        f"rule does not end in terminal punctuation, possibly wrapped: {rule!r}",
+                    )
+                    self.assertEqual(
+                        lines[i + 1],
+                        "",
+                        f"line after RULE: is not blank, possibly a wrapped continuation: {lines[i + 1]!r}",
+                    )
 
     def test_sources_yield_at_least_one_rule_each(self):
         self.assertTrue(extract_rule_lines(WORDING_SOURCE.read_text(encoding="utf-8")))
         self.assertTrue(extract_rule_lines(CADENCE_SOURCE.read_text(encoding="utf-8")))
 
+    def test_each_section_has_exactly_one_rule_and_one_check_line(self):
+        heading_re = re.compile(r"^## ")
+        check_re = re.compile(r"^\*\*(Check|Self-check):\*\*")
+        for source in (WORDING_SOURCE, CADENCE_SOURCE):
+            lines = source.read_text(encoding="utf-8").splitlines()
+            # Partition into sections starting at each `##` heading (source has no
+            # fenced headings, so no fence-tracking is needed here).
+            starts = [i for i, line in enumerate(lines) if heading_re.match(line)]
+            bounds = list(zip(starts, [*starts[1:], len(lines)], strict=True))
+            for start, end in bounds:
+                section = lines[start:end]
+                with self.subTest(source=source.name, heading=section[0]):
+                    rule_count = sum(
+                        1 for line in section if line.startswith(RULE_PREFIX)
+                    )
+                    check_count = sum(1 for line in section if check_re.match(line))
+                    self.assertEqual(
+                        rule_count, 1, f"{section[0]}: {rule_count} RULE: lines"
+                    )
+                    self.assertEqual(
+                        check_count,
+                        1,
+                        f"{section[0]}: {check_count} Check/Self-check lines",
+                    )
+
+
+def raw_heading_count_outside_fences(text):
+    """`^## ` headings outside fences, via a fresh scan -- independent of the module."""
+    count = 0
+    in_fence = False
+    for line in text.splitlines():
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        if re.match(r"^## ", line):
+            count += 1
+    return count
+
+
+def raw_rule_texts(text):
+    """RULE: line texts via a plain regex over raw lines, not the generator's function."""
+    return re.findall(r"^RULE: (.+)$", text, re.MULTILINE)
+
 
 class TestCarrierIntegrity(unittest.TestCase):
+    """Every check here is against an oracle independent of extract_rules.
+
+    Heading count is the real invariant the generator enforces (one RULE: line per `##`
+    section) -- checking bullet count against a reimplementation of the module's own
+    extraction would prove only that two copies of the same logic agree.
+    """
+
     def test_banner_is_line_one_and_an_html_comment(self):
         text = CARRIER.read_text(encoding="utf-8")
         first_line = text.splitlines()[0]
         self.assertTrue(first_line.startswith("<!--"))
         self.assertIn("GENERATED from docs/style/wording-rules.md", first_line)
 
-    def test_every_source_rule_appears_verbatim_as_a_bullet(self):
+    def test_heading_count_matches_bullet_count_per_source_section(self):
+        carrier_text = CARRIER.read_text(encoding="utf-8")
+        wording_section, cadence_section = _split_carrier_sections(carrier_text)
+        cases = (
+            (WORDING_SOURCE, wording_section),
+            (CADENCE_SOURCE, cadence_section),
+        )
+        for source, section in cases:
+            with self.subTest(source=source.name):
+                headings = raw_heading_count_outside_fences(
+                    source.read_text(encoding="utf-8")
+                )
+                bullets = sum(
+                    1 for line in section.splitlines() if line.startswith("- ")
+                )
+                self.assertEqual(headings, bullets)
+
+    def test_every_source_rule_text_appears_verbatim_in_the_carrier(self):
         carrier_text = CARRIER.read_text(encoding="utf-8")
         for source in (WORDING_SOURCE, CADENCE_SOURCE):
-            for rule in extract_rule_lines(source.read_text(encoding="utf-8")):
-                with self.subTest(rule=rule):
-                    self.assertIn(f"- {rule}", carrier_text)
-
-    def test_bullet_count_matches_source_rule_count(self):
-        carrier_text = CARRIER.read_text(encoding="utf-8")
-        bullet_count = sum(
-            1 for line in carrier_text.splitlines() if line.startswith("- ")
-        )
-        source_count = sum(
-            len(extract_rule_lines(source.read_text(encoding="utf-8")))
-            for source in (WORDING_SOURCE, CADENCE_SOURCE)
-        )
-        self.assertEqual(bullet_count, source_count)
+            for rule_text in raw_rule_texts(source.read_text(encoding="utf-8")):
+                with self.subTest(rule=rule_text):
+                    self.assertIn(f"- {rule_text}", carrier_text)
 
     def test_carrier_contains_no_em_dash(self):
         self.assertNotIn("—", CARRIER.read_text(encoding="utf-8"))
@@ -159,21 +230,77 @@ class TestCarrierIntegrity(unittest.TestCase):
         self.assertFalse(raw.endswith(b"\n\n"))
 
 
+def _split_carrier_sections(carrier_text):
+    """The carrier's `## Wording` and `## Cadence` bullet blocks, as raw text."""
+    wording_start = carrier_text.index("## Wording")
+    cadence_start = carrier_text.index("## Cadence")
+    return carrier_text[wording_start:cadence_start], carrier_text[cadence_start:]
+
+
 class TestFencedBlockSafety(unittest.TestCase):
     def test_rule_line_inside_a_fence_is_not_extracted(self):
         with _fixture_tree() as tmp:
             wording = tmp / "docs" / "style" / "wording-rules.md"
             wording.write_text(
                 wording.read_text(encoding="utf-8")
-                + "\n```text\nRULE: this is inside a fence and must never be extracted.\n```\n",
+                + "\n## Fenced example\n\n"
+                + "```text\nRULE: this is inside a fence and must never be extracted.\n```\n",
                 encoding="utf-8",
             )
+            # A heading with no live RULE: line (the real one is fenced) trips heading
+            # parity, which is the correct failure -- proves the fence really hid it
+            # from extraction rather than merely from some other check.
             result = run_build(["--repo-root", str(tmp)])
-            self.assertEqual(result.returncode, 0, result.stderr)
-            carrier_text = (tmp / "docs" / "style" / "session-context.md").read_text(
-                encoding="utf-8"
-            )
-            self.assertNotIn("this is inside a fence", carrier_text)
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("sections", result.stderr)
+
+    def test_unbalanced_fence_is_a_hard_error(self):
+        with _fixture_tree() as tmp:
+            wording = tmp / "docs" / "style" / "wording-rules.md"
+            lines = wording.read_text(encoding="utf-8").split("\n")
+            lines.insert(len(lines) // 2, "```")
+            wording.write_text("\n".join(lines), encoding="utf-8")
+
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("unbalanced", result.stderr)
+            self.assertIn("wording-rules.md", result.stderr)
+
+            check_result = run_build(["--check", "--repo-root", str(tmp)])
+            self.assertEqual(check_result.returncode, 1)
+            self.assertIn("unbalanced", check_result.stderr)
+
+    def test_reproduction_stray_fence_errors_instead_of_dropping_rules(self):
+        """The exact failure mode from review: a stray fence must not silently drop
+        rules past it -- it must fail the build instead of returning a partial carrier.
+        """
+        with _fixture_tree() as tmp:
+            wording = tmp / "docs" / "style" / "wording-rules.md"
+            lines = wording.read_text(encoding="utf-8").split("\n")
+            lines.insert(59, "```")
+            wording.write_text("\n".join(lines), encoding="utf-8")
+
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("unbalanced", result.stderr)
+
+
+class TestHeadingParity(unittest.TestCase):
+    def test_missing_rule_line_in_a_section_fails_the_build(self):
+        with _fixture_tree() as tmp:
+            wording = tmp / "docs" / "style" / "wording-rules.md"
+            text = wording.read_text(encoding="utf-8")
+            # Drop exactly one RULE: line, leaving its `##` section headerless of a rule.
+            lines = text.splitlines()
+            for i, line in enumerate(lines):
+                if line.startswith("RULE: "):
+                    del lines[i]
+                    break
+            wording.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+            result = run_build(["--repo-root", str(tmp)])
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("sections", result.stderr)
 
 
 class TestGeneratorErrorPaths(unittest.TestCase):
@@ -202,9 +329,12 @@ class TestEmitter(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         payload = json.loads(result.stdout)
         self.assertEqual(payload["hookSpecificOutput"]["hookEventName"], "SessionStart")
-        self.assertEqual(
-            payload["hookSpecificOutput"]["additionalContext"],
-            CARRIER.read_text(encoding="utf-8"),
+
+        carrier_text = CARRIER.read_text(encoding="utf-8")
+        banner, _, rest = carrier_text.partition("\n\n")
+        self.assertEqual(payload["hookSpecificOutput"]["additionalContext"], rest)
+        self.assertNotIn(
+            "GENERATED", payload["hookSpecificOutput"]["additionalContext"]
         )
 
     def test_missing_carrier_exits_zero_with_empty_stdout(self):


### PR DESCRIPTION
## What

Implements the portable output-discipline pattern for this repo: canonical style-rule sources with single-line `RULE:` forms, a generator that extracts them verbatim into one session carrier, a SessionStart hook that injects it into every new session, and CI-enforced freshness and self-compliance.

- `docs/style/wording-rules.md` (13 rules) and `docs/style/cadence-rules.md` (7 rules): each rule is a `##` section whose one-line `RULE:` sentence is the complete rule. Since the carrier ships only that line, any scoping a ban needs lives in the line itself (e.g. filler adjectives are banned "as boosters"). Checks are split by runnability: `**Check:**` for mechanically runnable assertions, `**Self-check:**` for model judgment.
- `scripts/build_style_artifacts.py` (stdlib, modeled on `sync_agent_rules.py`): extracts `RULE:` lines verbatim (no condensing) into generated `docs/style/session-context.md`; `--check` for freshness. The generator fails loudly on an unbalanced code fence and on any `##` section without exactly one `RULE:` line, so a malformed source can never silently drop rules from the carrier.
- `scripts/emit_style_context.py`: prints the structured SessionStart `additionalContext` JSON with the maintainer-facing GENERATED banner stripped; a missing carrier exits 0 so a broken hook never blocks session start.
- `.claude/settings.json` is now tracked (`.gitignore` `.claude/` → `.claude/*` + `!.claude/settings.json`) and carries the SessionStart hook, so activation applies on clone.
- `tests/test_style_rules.py` (23 tests / 102 subtests): freshness delegates to `--check`; every rule obeys its own 25-word cap and em-dash ban; carrier integrity is proven against an independent oracle (raw `##`-heading counts, not a re-extraction); unbalanced-fence and missing-RULE cases; emitter payload shape. Docs registry entries; root `AGENTS.md` pointer section (byte ratchet 20,436 → 20,685).

## Known gap

SessionStart context does not reach subagents, so this governs maintainer chat sessions only — none of the prose the shipped review agents emit to users. In this repo the agents are the product; bringing their output under a wording-rules contract is future work and deliberately out of this PR (their output format is benchmark-sensitive).

## Validation

- 1,410 pytest tests pass; scripts coverage 93.17% vs the 92.1 floor; pre-commit fully green.
- Mutation-verified: stale carrier, removed fence handling, unbalanced-fence guard, heading-parity guard, injected em-dash/overlong rule, and wrong hook event name each turn the suite red.
- Cold-start sentinel test (throwaway dir, same settings shape and JSON payload) returned the sentinel, proving injection on a brand-new session.
- The review's reproduction (stray fence dropping 13 rules to 3 silently) now exits 1 naming the unbalanced fence, and is pinned as a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DkugfQAn4UQTkbf3iu59cs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs, stdlib scripts, tests, and Claude Code hook config only; no runtime pipeline or review-agent output paths change.
> 
> **Overview**
> Adds a **session output style** pipeline: maintainer-authored `docs/style/wording-rules.md` (13 rules) and `cadence-rules.md` (7 rules), each `##` section with a single verbatim `RULE:` line, plus `scripts/build_style_artifacts.py` to generate `docs/style/session-context.md` (`--check` for CI-style freshness). The generator errors on unbalanced fences and on any section that does not have exactly one `RULE:` line, so malformed sources cannot silently drop rules.
> 
> **SessionStart injection:** tracked `.claude/settings.json` runs `scripts/emit_style_context.py`, which prints SessionStart `additionalContext` JSON (GENERATED banner stripped) and exits 0 with empty stdout if the carrier is missing so hooks never block startup. `.gitignore` now ignores `.claude/*` but keeps `!.claude/settings.json`.
> 
> **Guards:** `tests/test_style_rules.py` covers carrier freshness, source self-compliance (25-word cap, no em dash on rule lines), independent-oracle carrier integrity, fence/heading-parity failure modes, and emitter payload shape. `tests/test_docs_registry.py` allowlists the new `docs/style/*` files; root `AGENTS.md` gains a short pointer (byte ratchet adjusted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9eb66f5e975607c9a24e96e87c3123be92592e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->