### PR TITLE
feat(workflows): per-dimension required mechanism in the finding schema

### DIFF
--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -12,9 +12,9 @@ Subagent contracts. Each `.md` is a system prompt with enforced YAML frontmatter
   fails the agent. `tests/test_dimensions_registry.py` fails the build when the two drift.
 - **Declared-but-optional fields are not nullable.** A not-applicable value is *omitted*, never
   `null`; the platform types each property to a single type and a null burns retries.
-- **`required` is one flat list shared by every dimension.** A field a contract calls required for
-  its own dimension is contract-enforced, not schema-enforced. Do not fake it by appending a
-  single-dimension field to `FINDING_REQUIRED`.
+- **`required` is `FINDING_REQUIRED` plus per-row `requiredExtra`.** Required only when the
+  contract emits a field unconditionally (no OMIT branch); a multi-dimension agent requires it
+  only when every sibling dimension does too.
 - `dimension` — short name from agent output: `"bug"`, `"security"`, `"cross_file_impact"`, `"test_coverage"`, `"convention"`, `"intent"`, `"comment_accuracy"`, `"type_design"`, `"simplification"`. Never the agent name. `agent` is injected by the orchestrator at merge; agents do not emit it.
 - **Canonical fields** — every dispatch schema declares exactly these: `id`, `file`, `line_start`, `line_end`, `title`, `description`, `severity`, `confidence`, `dimension`, `origin`, `evidence`, `suggestion`, `claude_md_rule`, `cross_file_refs`.
 - **Per-dimension extras** — one entry on the owning registry row: `hidden_errors` (bug), `attack_vector` (security), `affected_consumers` (cross_file_impact), `criticality` + `failure_scenario` (test_coverage), `spec_text` (intent), `invalid_state_example` (type_design), `behavior_preserved` (simplification).

--- a/agents/CLAUDE.md
+++ b/agents/CLAUDE.md
@@ -16,9 +16,9 @@ Subagent contracts. Each `.md` is a system prompt with enforced YAML frontmatter
   fails the agent. `tests/test_dimensions_registry.py` fails the build when the two drift.
 - **Declared-but-optional fields are not nullable.** A not-applicable value is *omitted*, never
   `null`; the platform types each property to a single type and a null burns retries.
-- **`required` is one flat list shared by every dimension.** A field a contract calls required for
-  its own dimension is contract-enforced, not schema-enforced. Do not fake it by appending a
-  single-dimension field to `FINDING_REQUIRED`.
+- **`required` is `FINDING_REQUIRED` plus per-row `requiredExtra`.** Required only when the
+  contract emits a field unconditionally (no OMIT branch); a multi-dimension agent requires it
+  only when every sibling dimension does too.
 - `dimension` — short name from agent output: `"bug"`, `"security"`, `"cross_file_impact"`, `"test_coverage"`, `"convention"`, `"intent"`, `"comment_accuracy"`, `"type_design"`, `"simplification"`. Never the agent name. `agent` is injected by the orchestrator at merge; agents do not emit it.
 - **Canonical fields** — every dispatch schema declares exactly these: `id`, `file`, `line_start`, `line_end`, `title`, `description`, `severity`, `confidence`, `dimension`, `origin`, `evidence`, `suggestion`, `claude_md_rule`, `cross_file_refs`.
 - **Per-dimension extras** — one entry on the owning registry row: `hidden_errors` (bug), `attack_vector` (security), `affected_consumers` (cross_file_impact), `criticality` + `failure_scenario` (test_coverage), `spec_text` (intent), `invalid_state_example` (type_design), `behavior_preserved` (simplification).

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -199,6 +199,8 @@ Each finding is a JSON object with this shape:
 {"id": "simplify-<n>", "dimension": "simplification", "severity": "<high|medium|low>", "confidence": <0-100>, "file": "<path>", "line_start": <number>, "line_end": <number>, "title": "<one-line summary>", "description": "<single-paragraph prose explaining why the current code is harder to read than it needs to be; inline single-line before/after illustrations OK, no fenced code blocks, no multi-line snippets>", "evidence": "<specific code or context that supports this finding>", "suggestion": "<concrete simplification — must include before and after code snippets>", "behavior_preserved": "<confirmation that the simplification does not change behavior, or 'uncertain' if you cannot confirm>", "claude_md_rule": "<the documented project rule this finding violates, quoted with its source file (CLAUDE.md/REVIEW.md/AGENTS.md). OMIT this field entirely when no documented rule applies — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "cross_file_refs": ["<other files involved in this finding>"]}
 ```
 
+`behavior_preserved` is required by the dispatch schema — a finding without it is rejected at the StructuredOutput boundary and retried, so it must always be present.
+
 **Example:**
 
 [investigation of nested ternary in renderStatus — readability issue]

--- a/agents/conventions-and-intent.md
+++ b/agents/conventions-and-intent.md
@@ -269,9 +269,9 @@ Real violation — CLAUDE.md requires structured logging with error_id but handl
 [investigation of function naming convention — follows project pattern correctly]
 SKIP: function naming in utils.py — uses snake_case per CLAUDE.md section 3; no violation.
 
-For convention findings: the `claude_md_rule` field MUST be non-null and MUST quote the specific rule. Findings without a cited rule will be rejected — this is enforced by this contract, not by the dispatch schema (the schema's required list is shared by all dimensions), so omitting the field on the wrong dimension is correct while omitting it on this one is a contract violation.
+For convention findings: the `claude_md_rule` field MUST be non-null and MUST quote the specific rule. Findings without a cited rule will be rejected — this is enforced by this contract, not by the dispatch schema. This agent's dispatch mixes convention, intent, and comment_accuracy findings in ONE schema, so a per-dimension schema requirement is unsatisfiable here (a per-dimension `requiredExtra` mechanism exists, but only for single-dimension agents) — omitting the field on the wrong dimension is correct while omitting it on this one is a contract violation.
 
-For intent findings: the `spec_text` field MUST be non-null and MUST quote the specific spec text. Findings without a cited spec will be rejected — this is enforced by this contract, not by the dispatch schema (the schema's required list is shared by all dimensions), so omitting the field on the wrong dimension is correct while omitting it on this one is a contract violation.
+For intent findings: the `spec_text` field MUST be non-null and MUST quote the specific spec text. Findings without a cited spec will be rejected — this is enforced by this contract, not by the dispatch schema, for the same reason: this agent's mixed convention/intent/comment_accuracy dispatch can't schema-require a single-dimension field — omitting the field on the wrong dimension is correct while omitting it on this one is a contract violation.
 
 Only report findings with confidence >= 60. Be thorough but filter aggressively — quality over quantity. If you find no issues above the threshold, return an empty findings list.
 

--- a/agents/cross-file-impact.md
+++ b/agents/cross-file-impact.md
@@ -196,6 +196,8 @@ Each finding is a JSON object with this shape:
 {"id": "cross-file-<n>", "dimension": "cross_file_impact", "severity": "<critical|high|medium|low>", "confidence": <0-100>, "file": "<path of the changed file causing the impact>", "line_start": <number>, "line_end": <number>, "title": "<one-line summary>", "description": "<single-paragraph prose explaining what breaks and why — no code blocks, no multi-line snippets; affected files go in affected_consumers and cross_file_refs>", "evidence": "<specific code or context that supports this finding>", "suggestion": "<concrete fix — update the caller, implementor, or dependent>", "affected_consumers": ["<file paths of callers, implementors, or consumers that break>"], "claude_md_rule": "<the documented project rule this finding violates, quoted with its source file (CLAUDE.md/REVIEW.md/AGENTS.md). OMIT this field entirely when no documented rule applies — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "cross_file_refs": ["<other files involved in this finding>"]}
 ```
 
+`affected_consumers` is required by the dispatch schema — a finding without it is rejected at the StructuredOutput boundary and retried, so it must always be present.
+
 **Example:**
 
 [investigation of changed return type on getUserById — tracing callers]

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -240,6 +240,8 @@ Each finding is a JSON object with this shape:
 {"id": "security-<n>", "dimension": "security", "severity": "<critical|high|medium|low>", "confidence": <0-100>, "file": "<path>", "line_start": <number>, "line_end": <number>, "title": "<one-line summary>", "description": "<single-paragraph prose explaining the vulnerability and attack vector — no code blocks, no multi-line snippets; use the attack_vector field for the step-by-step exploit>", "evidence": "<specific code or context that supports this finding>", "suggestion": "<concrete fix or improvement>", "attack_vector": "<step-by-step description of how an attacker exploits this>", "claude_md_rule": "<the documented project rule this finding violates, quoted with its source file (CLAUDE.md/REVIEW.md/AGENTS.md). OMIT this field entirely when no documented rule applies — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "cross_file_refs": ["<other files involved in this finding>"]}
 ```
 
+`attack_vector` is required by the dispatch schema — a finding without it is rejected at the StructuredOutput boundary and retried, so it must always be present.
+
 **Example:**
 
 [investigation of SQL injection in user search endpoint]

--- a/agents/test-analyzer.md
+++ b/agents/test-analyzer.md
@@ -180,6 +180,8 @@ Each finding is a JSON object with this shape:
 {"id": "test-<n>", "dimension": "test_coverage", "severity": "<critical|high|medium|low>", "criticality": <1-10>, "confidence": <0-100>, "file": "<path of the production file with the untested behavior>", "line_start": <number>, "line_end": <number>, "title": "<one-line summary of the coverage gap>", "description": "<single-paragraph prose explaining what behavior is untested and why it matters — no code blocks, no multi-line snippets>", "evidence": "<specific code or context that shows the gap>", "suggestion": "<concrete test case or scenario to add, with example if helpful>", "failure_scenario": "<concrete example of a bug this test gap would fail to catch>", "claude_md_rule": "<the documented project rule this finding violates, quoted with its source file (CLAUDE.md/REVIEW.md/AGENTS.md). OMIT this field entirely when no documented rule applies — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "cross_file_refs": ["<test files or related files involved in this finding>"]}
 ```
 
+`criticality` and `failure_scenario` are required by the dispatch schema — a finding without either is rejected at the StructuredOutput boundary and retried, so both must always be present.
+
 **Example:**
 
 [investigation of missing error path test for processPayment()]

--- a/skills/code-gauntlet/references/report-format.md
+++ b/skills/code-gauntlet/references/report-format.md
@@ -57,18 +57,18 @@ The pipeline's declaration lives in `workflows/src/registry.js`. A field this ta
 
 ### Per-dimension fields
 
-| Field | Type | Dimension | Description |
-|-------|------|-----------|-------------|
-| `hidden_errors` | string | bug | Errors the fix would surface that the visible code path hides |
-| `attack_vector` | string | security | How the issue is exploited |
-| `affected_consumers` | array | cross_file_impact | Other call sites/files impacted by the change |
-| `criticality` | number | test_coverage | A 1-10 IMPACT scale, distinct from `confidence`'s 0-100 certainty scale, emitted as a number and never quoted. |
-| `failure_scenario` | string | test_coverage | Concrete scenario the missing coverage would miss |
-| `spec_text` | string | intent | The spec/requirement text the code is checked against |
-| `invalid_state_example` | string | type_design | A concrete value the current types allow but shouldn't |
-| `behavior_preserved` | string | simplification | Why the simplification is behavior-preserving |
+| Field | Type | Dimension | Required | Description |
+|-------|------|-----------|----------|-------------|
+| `hidden_errors` | string | bug | no | Errors the fix would surface that the visible code path hides |
+| `attack_vector` | string | security | yes | How the issue is exploited |
+| `affected_consumers` | array | cross_file_impact | yes | Other call sites/files impacted by the change |
+| `criticality` | number | test_coverage | yes | A 1-10 IMPACT scale, distinct from `confidence`'s 0-100 certainty scale, emitted as a number and never quoted. |
+| `failure_scenario` | string | test_coverage | yes | Concrete scenario the missing coverage would miss |
+| `spec_text` | string | intent | no | The spec/requirement text the code is checked against |
+| `invalid_state_example` | string | type_design | no | A concrete value the current types allow but shouldn't |
+| `behavior_preserved` | string | simplification | yes | Why the simplification is behavior-preserving |
 
-Per-dimension fields are optional and never nullable (a not-applicable value is OMITTED). `required` is one flat list shared by all dimensions, so a field a contract calls required for its own dimension is enforced by the agent contract prose, not the schema.
+A `yes` field is appended to that dimension's dispatch required list (FINDING_REQUIRED plus the row's `requiredExtra`, never the other way around — FINDING_REQUIRED itself never carries a per-dimension field): the platform rejects a finding missing it at the StructuredOutput boundary, and the agent retries. A `no` field is still contract-enforced by the agent's `.md` prose where its own dimension calls for it (e.g. `claude_md_rule` for convention findings), never by the schema — only a field the owning contract emits unconditionally (no OMIT branch) can be promoted to schema-required at all. Every per-dimension field is never nullable regardless: a not-applicable value is OMITTED, not emitted as null.
 
 ### Delivery-side fields — not produced by the review pipeline
 

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -205,7 +205,12 @@ def field_carries_omit_instruction(raw_block, field, source=None):
     if quoted:
         return "omit" in quoted.group(1).lower()
 
-    array_of_strings = re.match(r'\[\s*(?:"(?:[^"\\]|\\.)*"\s*,?\s*)*\]', rest)
+    # First-string-then-comma-separated-rest, not a single starred group with an optional
+    # comma: `(?:"…"\s*,?\s*)*` lets the engine partition inter-string whitespace ambiguously
+    # and backtrack exponentially on an unclosed array (CodeQL py/redos on PR #217).
+    array_of_strings = re.match(
+        r'\[\s*(?:"(?:[^"\\]|\\.)*"(?:\s*,\s*"(?:[^"\\]|\\.)*")*\s*)?\]', rest
+    )
     if array_of_strings:
         return "omit" in array_of_strings.group(0).lower()
 

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -119,6 +119,7 @@ def registry():
             "  dimensions: m.DIMENSIONS.map(d => ({"
             "    dimension: d.dimension, agentType: d.agentType,"
             "    extras: Object.fromEntries(Object.entries(d.schemaExtra || {}).map(([k, v]) => [k, t(v)])),"
+            "    requiredExtra: d.requiredExtra || [],"
             "  })),"
             "})))"
         )
@@ -162,6 +163,89 @@ def all_extras():
         for field in row["extras"]:
             owner[field] = row["dimension"]
     return owner
+
+
+def all_required_extras():
+    """The set of per-dimension fields that are dispatch-required somewhere (issue #66).
+
+    Every field with a non-empty requiredExtra currently lives on a single-dimension agent
+    (security, cross_file_impact, test_coverage, simplification), so the row-level set and the
+    post-intersection agentSpecs()-effective set agree; this helper reads the row-level
+    declaration directly, which is what report-format.md's per-field table documents.
+    """
+    required = set()
+    for row in registry()["dimensions"]:
+        required |= set(row["requiredExtra"])
+    return required
+
+
+def field_carries_omit_instruction(raw_block, field, source=None):
+    """True if `field`'s own value inside one raw ```json contract block mentions OMIT.
+
+    Scoped to the field's OWN value (not the whole block) so an OMIT instruction on a
+    neighbouring field in the same block — e.g. claude_md_rule sitting beside attack_vector —
+    can never false-positive this guard. Recognizes every value shape a contract block
+    actually uses: a quoted string placeholder (`"field": "<...>"`), an array of quoted
+    strings (`"field": ["<...>"]`, the affected_consumers shape — issue #66 promoted an
+    ARRAY field and the original version of this guard only handled a scalar, silently
+    never inspecting it), an unquoted angle-bracket placeholder (`"field": <1-10>`), and a
+    bare JSON literal (`"field": 9`, the criticality worked example).
+
+    A field present in the block whose value matches NONE of those shapes raises, naming
+    `source` (the file) and `field`, rather than returning False — this file's own
+    convention (see the module docstring): a silent skip is the one failure mode that would
+    let this guard quietly stop guarding.
+    """
+    key_match = re.compile(r'"' + re.escape(field) + r'"\s*:\s*').search(raw_block)
+    if not key_match:
+        return False
+    rest = raw_block[key_match.end() :]
+
+    quoted = re.match(r'"((?:[^"\\]|\\.)*)"', rest)
+    if quoted:
+        return "omit" in quoted.group(1).lower()
+
+    array_of_strings = re.match(r'\[\s*(?:"(?:[^"\\]|\\.)*"\s*,?\s*)*\]', rest)
+    if array_of_strings:
+        return "omit" in array_of_strings.group(0).lower()
+
+    angle_bracket = re.match(r"<[^>]*>", rest)
+    if angle_bracket:
+        return "omit" in angle_bracket.group(0).lower()
+
+    bare_literal = re.match(r"(?:-?\d+(?:\.\d+)?|true|false|null)\s*(?=[,}])", rest)
+    if bare_literal:
+        return False  # a bare number/bool/null cannot carry OMIT prose by construction
+
+    raise AssertionError(
+        f"field_carries_omit_instruction: {field!r} in "
+        f"{source or 'a contract block'} has a value shape this parser does not recognize "
+        "(not a quoted string, array-of-strings, angle-bracket placeholder, or bare "
+        f"literal) — extend the parser rather than silently return False: {rest[:80]!r}"
+    )
+
+
+# The exact canonical phrase every requiredExtra field's owning contract must use (F5, issue
+# #66) — pinned literally so a paraphrase silently stops matching this guard the same way a
+# grep for "suggestion" would (see the module docstring's warning against prose-frequency
+# checks). Matched per LINE, not per file, so the backticked field name(s) attributed to the
+# claim are exactly the ones sharing that sentence — a phrase on one line making no claim
+# about a field named three paragraphs away must not count as a claim about it.
+_DISPATCH_REQUIRED_PHRASE = "required by the dispatch schema"
+
+
+def dispatch_required_claims(name):
+    """Field names agents/<name>.md's prose claims are 'required by the dispatch schema'.
+
+    Scans line by line: a line containing the canonical phrase contributes every backticked
+    field name ON THAT LINE to the claimed set.
+    """
+    text = (REPO / "agents" / f"{name}.md").read_text()
+    claimed = set()
+    for line in text.splitlines():
+        if _DISPATCH_REQUIRED_PHRASE in line:
+            claimed |= set(_BACKTICKED_FIELD.findall(line))
+    return claimed
 
 
 def raw_contract_blocks(name):
@@ -329,6 +413,42 @@ class TestDimensionsRegistry(unittest.TestCase):
                 f"dimension {row['dimension']} names {row['agentType']}, "
                 f"but {path.relative_to(REPO)} does not exist",
             )
+
+    def test_required_extra_is_a_subset_of_the_rows_own_schema_extra(self):
+        # issue #66 / F9: a requiredExtra entry must be a key of THIS row's own schemaExtra —
+        # never a canonical FINDING_PROP_TYPES field. Narrowed deliberately: a canonical field
+        # is, by definition, already emitted unconditionally by every dimension, so promoting
+        # it belongs in FINDING_REQUIRED directly, where the Canonical fields table's
+        # Required-column lockstep test actually looks — routed through one row's
+        # requiredExtra instead, a canonical promotion would be documented nowhere.
+        prop_types = set(registry()["propTypes"])
+        for row in registry()["dimensions"]:
+            declared = set(row["extras"])
+            for field in row["requiredExtra"]:
+                self.assertIn(
+                    field,
+                    declared,
+                    f"{row['dimension']}: requiredExtra names {field!r}, which is not a key "
+                    "of this row's own schemaExtra",
+                )
+                self.assertNotIn(
+                    field,
+                    prop_types,
+                    f"{row['dimension']}: requiredExtra names {field!r}, a canonical "
+                    "FINDING_PROP_TYPES field — promote it via FINDING_REQUIRED, not "
+                    "requiredExtra",
+                )
+
+    def test_required_extra_is_disjoint_from_finding_required(self):
+        required = set(registry()["required"])
+        for row in registry()["dimensions"]:
+            for field in row["requiredExtra"]:
+                self.assertNotIn(
+                    field,
+                    required,
+                    f"{row['dimension']}: {field!r} is already in FINDING_REQUIRED — "
+                    "requiredExtra must not repeat it",
+                )
 
 
 class TestContractSchemaLockstep(unittest.TestCase):
@@ -547,6 +667,125 @@ class TestContractSchemaLockstep(unittest.TestCase):
             "criticality must be declared number, not string",
         )
 
+    def test_required_extra_fields_carry_no_omit_instruction(self):
+        # issue #66's promotion rule: a field may only enter requiredExtra when its owning
+        # contract emits it UNCONDITIONALLY. If the contract still tells the model to OMIT the
+        # field under some circumstance, the schema-required declaration and the contract
+        # prose directly contradict each other — the model would be told two different things
+        # about the same field, and whichever branch the OMIT applies to produces a schema
+        # violation the platform retries forever.
+        offenders = []
+        for row in registry()["dimensions"]:
+            name = agent_name(row["agentType"])
+            for field in row["requiredExtra"]:
+                for raw in raw_contract_blocks(name):
+                    if field_carries_omit_instruction(
+                        raw, field, source=f"agents/{name}.md"
+                    ):
+                        offenders.append(f"{name}.{field} ({row['dimension']})")
+        self.assertEqual(
+            offenders,
+            [],
+            "these fields are declared requiredExtra in registry.js but their owning "
+            "contract still instructs an OMIT branch for them — either the field is not "
+            f"really unconditional (drop it from requiredExtra) or the contract prose is "
+            f"stale: {offenders}",
+        )
+
+    def test_field_carries_omit_instruction_parses_every_real_value_shape(self):
+        # Self-test for field_carries_omit_instruction's parser, synthetic and isolated from
+        # the live contracts so it pins the parser's behavior directly rather than through
+        # whatever shapes the current .md files happen to contain.
+        # Quoted-string value: OMIT text inside the string is detected.
+        self.assertTrue(
+            field_carries_omit_instruction(
+                '{"attack_vector": "<...>. OMIT this field entirely when N/A."}',
+                "attack_vector",
+            )
+        )
+        self.assertFalse(
+            field_carries_omit_instruction(
+                '{"attack_vector": "<always present>"}', "attack_vector"
+            )
+        )
+        # Array-of-strings value (the affected_consumers shape issue #66 promoted): the
+        # original version of this parser only matched a scalar and silently never
+        # inspected an array-valued field at all.
+        self.assertTrue(
+            field_carries_omit_instruction(
+                '{"affected_consumers": ["<...>. OMIT this field entirely when the impact '
+                'is local>"]}',
+                "affected_consumers",
+            )
+        )
+        self.assertFalse(
+            field_carries_omit_instruction(
+                '{"affected_consumers": ["<file paths>"]}', "affected_consumers"
+            )
+        )
+        # Unquoted angle-bracket placeholder (criticality's <1-10> template form).
+        self.assertFalse(
+            field_carries_omit_instruction('{"criticality": <1-10>}', "criticality")
+        )
+        self.assertTrue(
+            field_carries_omit_instruction(
+                '{"criticality": <1-10, OMIT if not applicable>}', "criticality"
+            )
+        )
+        # Bare JSON literal (criticality's worked-example form, "criticality":9) can never
+        # carry OMIT prose and must not raise.
+        self.assertFalse(
+            field_carries_omit_instruction(
+                '{"criticality":9,"confidence":90}', "criticality"
+            )
+        )
+        # A field absent from the block entirely is False, not an error.
+        self.assertFalse(
+            field_carries_omit_instruction('{"other_field": "x"}', "attack_vector")
+        )
+        # An unhandled value shape (a nested object, which no real contract emits) raises,
+        # naming the source and field, rather than silently returning False.
+        with self.assertRaises(AssertionError) as ctx:
+            field_carries_omit_instruction(
+                '{"weird_field": {"nested": "object"}}',
+                "weird_field",
+                source="agents/x.md",
+            )
+        self.assertIn("weird_field", str(ctx.exception))
+        self.assertIn("agents/x.md", str(ctx.exception))
+
+    def test_dispatch_required_contract_sentences_match_requiredExtra_exactly(self):
+        # F5, issue #66: bidirectional lockstep between the registry's requiredExtra and the
+        # contract prose sentences claiming a field is dispatch-required.
+        #   forward — every requiredExtra field's owning contract claims it (a promotion in
+        #             registry.js with no matching sentence is undocumented to the model).
+        #   reverse — no OTHER per-dimension field on that row is claimed dispatch-required
+        #             (a stale or bogus claim would tell the model something the schema does
+        #             not enforce).
+        for row in registry()["dimensions"]:
+            name = agent_name(row["agentType"])
+            claimed = dispatch_required_claims(name)
+            required = set(row["requiredExtra"])
+            extras = set(row["extras"])
+
+            missing = required - claimed
+            self.assertEqual(
+                missing,
+                set(),
+                f"agents/{name}.md never says {sorted(missing)} is "
+                f"{_DISPATCH_REQUIRED_PHRASE!r} though registry.js's requiredExtra promotes "
+                "it — add the canonical contract sentence",
+            )
+
+            over_claimed = (claimed & extras) - required
+            self.assertEqual(
+                over_claimed,
+                set(),
+                f"agents/{name}.md claims {sorted(over_claimed)} is "
+                f"{_DISPATCH_REQUIRED_PHRASE!r} but registry.js's requiredExtra does not "
+                "promote it — stale contract prose",
+            )
+
 
 class TestClaudeMdFieldLists(unittest.TestCase):
     """agents/AGENTS.md's two field enumerations are the human index of the registry."""
@@ -640,6 +879,20 @@ class TestReportFormatFieldTables(unittest.TestCase):
                 cells[1].lower(),
                 f"report-format.md marks {field} required={cells[1]!r}; "
                 f"FINDING_REQUIRED says {expected}",
+            )
+
+    def test_per_dimension_table_required_column_matches_registry(self):
+        # Mirrors test_canonical_table_required_column_matches_registry above, one column
+        # index over: the per-dimension table's cells are (Type, Dimension, Required,
+        # Description), so the Required column is cells[2].
+        required = all_required_extras()
+        for field, cells in table_named(report_format_tables(), "Per-dimension"):
+            expected = "yes" if field in required else "no"
+            self.assertEqual(
+                expected,
+                cells[2].lower(),
+                f"report-format.md marks {field} required={cells[2]!r}; "
+                f"registry.js requiredExtra says {expected}",
             )
 
     def test_per_dimension_table_matches_registry(self):

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -38,6 +38,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 import unittest
 from pathlib import Path
 
@@ -678,7 +679,8 @@ class TestContractSchemaLockstep(unittest.TestCase):
         # field under some circumstance, the schema-required declaration and the contract
         # prose directly contradict each other — the model would be told two different things
         # about the same field, and whichever branch the OMIT applies to produces a schema
-        # violation the platform retries forever.
+        # violation that burns the platform's capped retries (5) and, on exhaustion, fails
+        # the agent terminally and degrades every dimension it owns.
         offenders = []
         for row in registry()["dimensions"]:
             name = agent_name(row["agentType"])
@@ -758,6 +760,26 @@ class TestContractSchemaLockstep(unittest.TestCase):
             )
         self.assertIn("weird_field", str(ctx.exception))
         self.assertIn("agents/x.md", str(ctx.exception))
+
+    def test_field_carries_omit_instruction_array_parse_is_linear_time(self):
+        # Regression for the CodeQL py/redos finding fixed on PR #217: the original
+        # array-of-strings pattern (`(?:"…"\s*,?\s*)*`) backtracked exponentially because
+        # the optional comma let a whitespace run split ambiguously between the two `\s*`s
+        # on every iteration. The trigger is therefore a long UNCLOSED array of strings
+        # separated by whitespace WITHOUT commas (comma-separated input parses one way and
+        # cannot distinguish the two regex forms). The shipped
+        # first-string-then-comma-separated-rest form gives up on that input immediately
+        # and falls to the loud unrecognized-shape arm; the vulnerable form hangs.
+        pathological = '{"affected_consumers": [' + '"a" ' * 200 + "x"
+        start = time.perf_counter()
+        with self.assertRaises(AssertionError):
+            field_carries_omit_instruction(pathological, "affected_consumers")
+        self.assertLess(
+            time.perf_counter() - start,
+            1.0,
+            "array-of-strings OMIT parsing took over a second on an unclosed "
+            "whitespace-separated array — the backtracking-prone regex form is back",
+        )
 
     def test_dispatch_required_contract_sentences_match_requiredExtra_exactly(self):
         # F5, issue #66: bidirectional lockstep between the registry's requiredExtra and the

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -1874,15 +1874,21 @@ const FINDING_PROP_TYPES = {
   cross_file_refs: { type: 'array', items: { type: 'string' } },
 };
 
-// The subset findingItemSchema marks `required`. Deliberately NOT extended by this fix:
-// `required` is ONE flat list shared by every agent's dispatch schema (all nine dimensions —
-// a multi-dimension agent's findings arrive mixed in one dispatch), so a field that is
-// required for one dimension — claude_md_rule for convention, spec_text for intent,
-// criticality and failure_scenario for test_coverage — cannot be marked required here
-// without making it required for all nine. Those stay contract-required/schema-optional, enforced by the agent
-// .md prose, the same bucket hidden_errors and invalid_state_example already sit in. Adding a
-// per-dimension `requiredExtra` mechanism is tracked separately; do not fake it by appending
-// a single-dimension field to this array.
+// FINDING_REQUIRED stays the flat canonical list shared by every dispatch schema — it names
+// only fields every dimension emits, so it can never itself carry a single-dimension name.
+// Per-dimension requirements live one level down, on each DIMENSIONS row's `requiredExtra`
+// (issue #66): agentSpecs() intersects across a multi-dimension agent's rows, so a field
+// required for only ONE dimension of a shared dispatch (conventions-and-intent mixes
+// convention/intent/comment_accuracy in one schema) can never be enforced there — union
+// semantics would force fabrication on the sibling dimensions. Conditional schema enforcement
+// is not a provider-portable escape hatch: a TOP-LEVEL `oneOf`/`allOf`/`anyOf` in input_schema
+// is rejected outright (API 400, measured 2026-08-18); `if`/`then` nested inside `items` was
+// accepted AND enforced by the retry loop in that same measurement, but only on the first-party
+// API — unmeasured on Bedrock/Vertex, so this rule sticks to provider-portable constructs only.
+// So the promotion rule is narrow: only a field whose owning contract emits it UNCONDITIONALLY
+// (no "OMIT this field" branch) may be listed in requiredExtra; a genuinely conditional field
+// (claude_md_rule, spec_text, hidden_errors, invalid_state_example) stays contract-enforced,
+// the same retry-storm-avoidance class the OMIT-not-null rule already governs.
 const FINDING_REQUIRED = ['id', 'file', 'line_start', 'title', 'description', 'severity', 'confidence', 'dimension'];
 
 // `schemaExtra` declares the per-dimension finding fields BEYOND the canonical schema above —
@@ -1898,7 +1904,8 @@ const FINDING_REQUIRED = ['id', 'file', 'line_start', 'title', 'description', 's
 // simplification -> behavior_preserved. The pre-reconciliation declarations (type_design
 // encapsulation/invariants/enforcement/usefulness; simplification before/after) named fields
 // no agent ever emitted top-level and no code consumes — pure schema noise now removed.
-// Extras are OPTIONAL by construction (never in FINDING_REQUIRED) and NOT nullable: the
+// Extras are optional by default — a row promotes one to dispatch-required only through
+// `requiredExtra` below, never by touching FINDING_REQUIRED — and NOT nullable: the
 // platform schema contract pins `type` to a single string (no union types), so a
 // not-applicable extra must be OMITTED, never emitted as null — the agent contracts say
 // "OMIT this field", and a null here is the same retry-storm class as string confidence.
@@ -1906,25 +1913,41 @@ const FINDING_REQUIRED = ['id', 'file', 'line_start', 'title', 'description', 's
 // rows' extras (agentSpecs in stages.js), so scoping spec_text to the `intent` row still
 // makes it declarable on that agent's convention and comment_accuracy findings — the
 // per-dimension scoping is documentation of ownership, not an emission restriction.
+//
+// `requiredExtra` (issue #66) names the subset of a row's OWN `schemaExtra` — never a
+// canonical FINDING_PROP_TYPES field — that dimension's owning contract emits UNCONDITIONALLY —
+// no OMIT branch — so the schema can safely require them without ever rejecting a compliant
+// finding. Narrowed to schemaExtra deliberately: a canonical field, by definition, is one every
+// dimension emits unconditionally already, so its unconditional-ness belongs in
+// FINDING_REQUIRED directly, not re-declared piecemeal on a row-by-row requiredExtra — a
+// canonical promotion routed through here would be documented nowhere the Canonical fields
+// table's Required-column lockstep test looks. Populated by a full audit of
+// the seven contracts: security -> attack_vector, cross_file_impact -> affected_consumers,
+// test_coverage -> criticality + failure_scenario, simplification -> behavior_preserved. Every
+// other row is `[]`: bug's hidden_errors, conventions-and-intent's claude_md_rule/spec_text,
+// and type_design's invalid_state_example all carry an explicit OMIT branch in their contract
+// (conventions-and-intent additionally can't promote a single-dimension field at all — see the
+// agentSpecs comment in stages.js), so they stay contract-enforced. findingItemSchema
+// (stages.js) appends a spec's effective requiredExtra onto FINDING_REQUIRED per dispatch.
 const DIMENSIONS = [
-  { dimension: 'bug', agentType: 'code-gauntlet:bug-detector', conditionalFlag: null, schemaExtra: { hidden_errors: 'string' }, modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
-  { dimension: 'security', agentType: 'code-gauntlet:security-reviewer', conditionalFlag: null, schemaExtra: { attack_vector: 'string' }, modelOverride: 'opus', promptExtra: SECURITY_SWEEP_PROMPT_EXTRA },
+  { dimension: 'bug', agentType: 'code-gauntlet:bug-detector', conditionalFlag: null, schemaExtra: { hidden_errors: 'string' }, requiredExtra: [], modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
+  { dimension: 'security', agentType: 'code-gauntlet:security-reviewer', conditionalFlag: null, schemaExtra: { attack_vector: 'string' }, requiredExtra: ['attack_vector'], modelOverride: 'opus', promptExtra: SECURITY_SWEEP_PROMPT_EXTRA },
   { dimension: 'cross_file_impact', agentType: 'code-gauntlet:cross-file-impact', conditionalFlag: DEEP,
-    schemaExtra: { affected_consumers: { type: 'array', items: { type: 'string' } } }, modelOverride: null, promptExtra: null },
+    schemaExtra: { affected_consumers: { type: 'array', items: { type: 'string' } } }, requiredExtra: ['affected_consumers'], modelOverride: null, promptExtra: null },
   { dimension: 'test_coverage', agentType: 'code-gauntlet:test-analyzer', conditionalFlag: DEEP,
     // criticality is a 1-10 IMPACT scale (agents/test-analyzer.md); bound it in the schema
     // fragment so StructuredOutput rejects 0/-5/999 the same way items is required on arrays.
     // confidence stays unbound here and is clamped later — validators adjust it at runtime.
     schemaExtra: { criticality: { type: 'number', minimum: 1, maximum: 10 }, failure_scenario: 'string' },
-    modelOverride: null, promptExtra: null },
-  { dimension: 'convention', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP, schemaExtra: {}, modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
+    requiredExtra: ['criticality', 'failure_scenario'], modelOverride: null, promptExtra: null },
+  { dimension: 'convention', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP, schemaExtra: {}, requiredExtra: [], modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
   { dimension: 'intent', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP,
-    schemaExtra: { spec_text: 'string' }, modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
-  { dimension: 'comment_accuracy', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP, schemaExtra: {}, modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
+    schemaExtra: { spec_text: 'string' }, requiredExtra: [], modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
+  { dimension: 'comment_accuracy', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP, schemaExtra: {}, requiredExtra: [], modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
   { dimension: 'type_design', agentType: 'code-gauntlet:type-design-analyzer', conditionalFlag: DEEP,
-    schemaExtra: { invalid_state_example: 'string' }, modelOverride: null, promptExtra: null },
+    schemaExtra: { invalid_state_example: 'string' }, requiredExtra: [], modelOverride: null, promptExtra: null },
   { dimension: 'simplification', agentType: 'code-gauntlet:code-simplifier', conditionalFlag: DEEP,
-    schemaExtra: { behavior_preserved: 'string' }, modelOverride: null, promptExtra: null },
+    schemaExtra: { behavior_preserved: 'string' }, requiredExtra: ['behavior_preserved'], modelOverride: null, promptExtra: null },
 ];
 
 const AGENTS = [...new Set(DIMENSIONS.map((d) => d.agentType))];
@@ -3183,24 +3206,69 @@ function summarizeMergePrompt(inp, partials) {
 
 // --- Phase 2: Discover ------------------------------------------------------
 
+// intersectRequiredExtra(rows) -> string[] (issue #66). The safe algebra for a multi-dimension
+// agent's effective requiredExtra: a field is dispatch-required only if EVERY row (dimension)
+// sharing that agent's one dispatch requires it. Union semantics would be unsafe — promoting a
+// single-dimension's required field (e.g. a hypothetical convention-only requirement) onto the
+// whole conventions-and-intent dispatch would reject every intent/comment_accuracy finding that
+// correctly omits it. Order-independent (sorted) so the result never depends on DIMENSIONS row
+// iteration order. Exported standalone so the intersection can be exercised with synthetic rows
+// without needing to mutate the module-level registry.
+//
+// registry.test.js's sibling-parity test ("rows sharing an agentType declare identical
+// requiredExtra sets") is the actual AUTHORITY that keeps this safe on the real registry: it
+// fails the build the moment a multi-dimension agent's rows disagree, so on a healthy tree this
+// intersection is an IDENTITY (every sibling already agrees, so nothing is ever actually
+// dropped). This function is not what makes divergence safe — that guard is. It is the
+// fail-safe ALGEBRA underneath: if a divergence somehow reached runtime anyway (a bypassed
+// guard, a registry built by different code some day), the intersection still degrades safely
+// — dropping the disputed field from `required` — instead of the union's failure mode, which
+// would force every compliant OMIT-ing finding on a sibling dimension to fabricate a value it
+// was correctly told to omit.
+function intersectRequiredExtra(rows) {
+  if (!rows || rows.length === 0) return [];
+  let acc = new Set(rows[0].requiredExtra || []);
+  for (const row of rows.slice(1)) {
+    const next = new Set(row.requiredExtra || []);
+    acc = new Set([...acc].filter((f) => next.has(f)));
+  }
+  return [...acc].sort();
+}
+
 // Group DIMENSIONS by agentType, unioning each agent's per-dimension schemaExtra into
 // one finding schema. One task per unique AGENT (7) — agents covering several
 // dimensions (conventions-and-intent -> convention/intent/comment_accuracy) dispatch once.
-function agentSpecs() {
+// `requiredExtra` on the returned spec is the INTERSECTION of that agent's rows' requiredExtra
+// (intersectRequiredExtra above), not a union like schemaExtra — see the registry.js note on
+// why a per-dimension required field cannot safely promote onto sibling dimensions.
+//
+// Takes `dims` (defaults to the module-level DIMENSIONS) so the intersection-through-grouping
+// seam can be exercised with synthetic rows in tests, independent of the real registry. Agent
+// order is derived from `dims` itself (`[...new Set(dims.map(d => d.agentType))]`), NOT from
+// the module-level AGENTS constant — mapping over AGENTS here would look up entries by an
+// agentType a synthetic `dims` never populated and return undefined specs. For the default
+// call this produces the byte-identical order AGENTS already pins (see registry.test.js).
+function agentSpecs(dims = DIMENSIONS) {
   const byAgent = new Map();
-  for (const d of DIMENSIONS) {
-    if (!byAgent.has(d.agentType)) byAgent.set(d.agentType, { agentType: d.agentType, dimensions: [], schemaExtra: {}, conditionalFlags: [], promptExtra: null });
+  for (const d of dims) {
+    if (!byAgent.has(d.agentType)) byAgent.set(d.agentType, { agentType: d.agentType, dimensions: [], schemaExtra: {}, conditionalFlags: [], promptExtra: null, rows: [] });
     const spec = byAgent.get(d.agentType);
     spec.dimensions.push(d.dimension);
     Object.assign(spec.schemaExtra, d.schemaExtra || {});
     spec.conditionalFlags.push(d.conditionalFlag);
+    spec.rows.push(d);
     // promptExtra is scoped per AGENT, not per dimension — every DIMENSIONS row for a
     // multi-dimension agent is expected to carry the same value (see registry.js), so a
     // truthy value on any of an agent's rows sets it for the whole spec.
     if (d.promptExtra) spec.promptExtra = d.promptExtra;
   }
-  // Preserve AGENTS order (derived from DIMENSIONS) so dispatch order is deterministic.
-  return AGENTS.map((a) => byAgent.get(a));
+  const order = [...new Set(dims.map((d) => d.agentType))];
+  return order.map((a) => {
+    const spec = byAgent.get(a);
+    spec.requiredExtra = intersectRequiredExtra(spec.rows);
+    delete spec.rows;
+    return spec;
+  });
 }
 
 // An agent is active when at least one of its dimensions is enabled. A dimension is
@@ -3287,13 +3355,28 @@ function allActiveDimensionsDegraded(dispatched, degraded) {
 // affected_consumers are declared); the shorthand keeps the common case terse while the
 // fragment form supports arrays the platform's schema validator requires `items` on.
 // schemaExtra wins on a key collision — a dimension may narrow a canonical field, never the
-// reverse — and `required` is always the flat FINDING_REQUIRED (see its note in registry.js).
-function findingItemSchema(schemaExtra) {
+// reverse. `required` is FINDING_REQUIRED plus the dispatch's effective `requiredExtra`
+// (issue #66, agentSpecs' intersection) — empty for bug-detector, conventions-and-intent and
+// type-design-analyzer, so those three dispatch the byte-identical flat list they always did.
+//
+// The promotion's blast radius (why registry.js's requiredExtra comment demands
+// contract-UNCONDITIONAL fields only): a `required` array is a hard StructuredOutput
+// constraint on every element of `findings`, so ONE finding omitting a required field makes
+// the whole `{ findings, complete, total_seen }` envelope a schema violation, not just that
+// one finding — the platform retries the WHOLE agent dispatch (cap 5) with the validation
+// error fed back. If retries exhaust, `parallel()` resolves that member to null and discover()
+// treats it as a terminal agent failure: EVERY dimension that agent owns degrades (see
+// discover's null-member handling below), not just the dimension whose field was missing.
+// A conditionally-omitted field (claude_md_rule, spec_text, hidden_errors,
+// invalid_state_example) promoted here would make that omission — which the contract itself
+// tells the model to do — a self-inflicted retry storm on every dimension the agent covers.
+function findingItemSchema(schemaExtra, requiredExtra) {
   const props = {};
   for (const [k, t] of Object.entries({ ...FINDING_PROP_TYPES, ...(schemaExtra || {}) })) {
     props[k] = typeof t === 'string' ? { type: t } : t;
   }
-  return { type: 'object', properties: props, required: FINDING_REQUIRED, additionalProperties: false };
+  const required = requiredExtra && requiredExtra.length ? [...FINDING_REQUIRED, ...requiredExtra] : FINDING_REQUIRED;
+  return { type: 'object', properties: props, required, additionalProperties: false };
 }
 
 // Canonical finding schema (per-dimension schemaExtra unioned on top), wrapped in the
@@ -3307,7 +3390,7 @@ function findingSchema(spec) {
     properties: {
       findings: {
         type: 'array',
-        items: findingItemSchema(spec.schemaExtra),
+        items: findingItemSchema(spec.schemaExtra, spec.requiredExtra),
       },
       complete: { type: 'boolean' },
       total_seen: { type: 'number' },

--- a/workflows/src/registry.js
+++ b/workflows/src/registry.js
@@ -65,15 +65,21 @@ export const FINDING_PROP_TYPES = {
   cross_file_refs: { type: 'array', items: { type: 'string' } },
 };
 
-// The subset findingItemSchema marks `required`. Deliberately NOT extended by this fix:
-// `required` is ONE flat list shared by every agent's dispatch schema (all nine dimensions —
-// a multi-dimension agent's findings arrive mixed in one dispatch), so a field that is
-// required for one dimension — claude_md_rule for convention, spec_text for intent,
-// criticality and failure_scenario for test_coverage — cannot be marked required here
-// without making it required for all nine. Those stay contract-required/schema-optional, enforced by the agent
-// .md prose, the same bucket hidden_errors and invalid_state_example already sit in. Adding a
-// per-dimension `requiredExtra` mechanism is tracked separately; do not fake it by appending
-// a single-dimension field to this array.
+// FINDING_REQUIRED stays the flat canonical list shared by every dispatch schema — it names
+// only fields every dimension emits, so it can never itself carry a single-dimension name.
+// Per-dimension requirements live one level down, on each DIMENSIONS row's `requiredExtra`
+// (issue #66): agentSpecs() intersects across a multi-dimension agent's rows, so a field
+// required for only ONE dimension of a shared dispatch (conventions-and-intent mixes
+// convention/intent/comment_accuracy in one schema) can never be enforced there — union
+// semantics would force fabrication on the sibling dimensions. Conditional schema enforcement
+// is not a provider-portable escape hatch: a TOP-LEVEL `oneOf`/`allOf`/`anyOf` in input_schema
+// is rejected outright (API 400, measured 2026-08-18); `if`/`then` nested inside `items` was
+// accepted AND enforced by the retry loop in that same measurement, but only on the first-party
+// API — unmeasured on Bedrock/Vertex, so this rule sticks to provider-portable constructs only.
+// So the promotion rule is narrow: only a field whose owning contract emits it UNCONDITIONALLY
+// (no "OMIT this field" branch) may be listed in requiredExtra; a genuinely conditional field
+// (claude_md_rule, spec_text, hidden_errors, invalid_state_example) stays contract-enforced,
+// the same retry-storm-avoidance class the OMIT-not-null rule already governs.
 export const FINDING_REQUIRED = ['id', 'file', 'line_start', 'title', 'description', 'severity', 'confidence', 'dimension'];
 
 // `schemaExtra` declares the per-dimension finding fields BEYOND the canonical schema above —
@@ -89,7 +95,8 @@ export const FINDING_REQUIRED = ['id', 'file', 'line_start', 'title', 'descripti
 // simplification -> behavior_preserved. The pre-reconciliation declarations (type_design
 // encapsulation/invariants/enforcement/usefulness; simplification before/after) named fields
 // no agent ever emitted top-level and no code consumes — pure schema noise now removed.
-// Extras are OPTIONAL by construction (never in FINDING_REQUIRED) and NOT nullable: the
+// Extras are optional by default — a row promotes one to dispatch-required only through
+// `requiredExtra` below, never by touching FINDING_REQUIRED — and NOT nullable: the
 // platform schema contract pins `type` to a single string (no union types), so a
 // not-applicable extra must be OMITTED, never emitted as null — the agent contracts say
 // "OMIT this field", and a null here is the same retry-storm class as string confidence.
@@ -97,25 +104,41 @@ export const FINDING_REQUIRED = ['id', 'file', 'line_start', 'title', 'descripti
 // rows' extras (agentSpecs in stages.js), so scoping spec_text to the `intent` row still
 // makes it declarable on that agent's convention and comment_accuracy findings — the
 // per-dimension scoping is documentation of ownership, not an emission restriction.
+//
+// `requiredExtra` (issue #66) names the subset of a row's OWN `schemaExtra` — never a
+// canonical FINDING_PROP_TYPES field — that dimension's owning contract emits UNCONDITIONALLY —
+// no OMIT branch — so the schema can safely require them without ever rejecting a compliant
+// finding. Narrowed to schemaExtra deliberately: a canonical field, by definition, is one every
+// dimension emits unconditionally already, so its unconditional-ness belongs in
+// FINDING_REQUIRED directly, not re-declared piecemeal on a row-by-row requiredExtra — a
+// canonical promotion routed through here would be documented nowhere the Canonical fields
+// table's Required-column lockstep test looks. Populated by a full audit of
+// the seven contracts: security -> attack_vector, cross_file_impact -> affected_consumers,
+// test_coverage -> criticality + failure_scenario, simplification -> behavior_preserved. Every
+// other row is `[]`: bug's hidden_errors, conventions-and-intent's claude_md_rule/spec_text,
+// and type_design's invalid_state_example all carry an explicit OMIT branch in their contract
+// (conventions-and-intent additionally can't promote a single-dimension field at all — see the
+// agentSpecs comment in stages.js), so they stay contract-enforced. findingItemSchema
+// (stages.js) appends a spec's effective requiredExtra onto FINDING_REQUIRED per dispatch.
 export const DIMENSIONS = [
-  { dimension: 'bug', agentType: 'code-gauntlet:bug-detector', conditionalFlag: null, schemaExtra: { hidden_errors: 'string' }, modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
-  { dimension: 'security', agentType: 'code-gauntlet:security-reviewer', conditionalFlag: null, schemaExtra: { attack_vector: 'string' }, modelOverride: 'opus', promptExtra: SECURITY_SWEEP_PROMPT_EXTRA },
+  { dimension: 'bug', agentType: 'code-gauntlet:bug-detector', conditionalFlag: null, schemaExtra: { hidden_errors: 'string' }, requiredExtra: [], modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
+  { dimension: 'security', agentType: 'code-gauntlet:security-reviewer', conditionalFlag: null, schemaExtra: { attack_vector: 'string' }, requiredExtra: ['attack_vector'], modelOverride: 'opus', promptExtra: SECURITY_SWEEP_PROMPT_EXTRA },
   { dimension: 'cross_file_impact', agentType: 'code-gauntlet:cross-file-impact', conditionalFlag: DEEP,
-    schemaExtra: { affected_consumers: { type: 'array', items: { type: 'string' } } }, modelOverride: null, promptExtra: null },
+    schemaExtra: { affected_consumers: { type: 'array', items: { type: 'string' } } }, requiredExtra: ['affected_consumers'], modelOverride: null, promptExtra: null },
   { dimension: 'test_coverage', agentType: 'code-gauntlet:test-analyzer', conditionalFlag: DEEP,
     // criticality is a 1-10 IMPACT scale (agents/test-analyzer.md); bound it in the schema
     // fragment so StructuredOutput rejects 0/-5/999 the same way items is required on arrays.
     // confidence stays unbound here and is clamped later — validators adjust it at runtime.
     schemaExtra: { criticality: { type: 'number', minimum: 1, maximum: 10 }, failure_scenario: 'string' },
-    modelOverride: null, promptExtra: null },
-  { dimension: 'convention', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP, schemaExtra: {}, modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
+    requiredExtra: ['criticality', 'failure_scenario'], modelOverride: null, promptExtra: null },
+  { dimension: 'convention', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP, schemaExtra: {}, requiredExtra: [], modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
   { dimension: 'intent', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP,
-    schemaExtra: { spec_text: 'string' }, modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
-  { dimension: 'comment_accuracy', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP, schemaExtra: {}, modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
+    schemaExtra: { spec_text: 'string' }, requiredExtra: [], modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
+  { dimension: 'comment_accuracy', agentType: 'code-gauntlet:conventions-and-intent', conditionalFlag: DEEP, schemaExtra: {}, requiredExtra: [], modelOverride: null, promptExtra: TYPO_NAMING_SWEEP_PROMPT_EXTRA },
   { dimension: 'type_design', agentType: 'code-gauntlet:type-design-analyzer', conditionalFlag: DEEP,
-    schemaExtra: { invalid_state_example: 'string' }, modelOverride: null, promptExtra: null },
+    schemaExtra: { invalid_state_example: 'string' }, requiredExtra: [], modelOverride: null, promptExtra: null },
   { dimension: 'simplification', agentType: 'code-gauntlet:code-simplifier', conditionalFlag: DEEP,
-    schemaExtra: { behavior_preserved: 'string' }, modelOverride: null, promptExtra: null },
+    schemaExtra: { behavior_preserved: 'string' }, requiredExtra: ['behavior_preserved'], modelOverride: null, promptExtra: null },
 ];
 
 export const AGENTS = [...new Set(DIMENSIONS.map((d) => d.agentType))];

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -260,24 +260,69 @@ function summarizeMergePrompt(inp, partials) {
 
 // --- Phase 2: Discover ------------------------------------------------------
 
+// intersectRequiredExtra(rows) -> string[] (issue #66). The safe algebra for a multi-dimension
+// agent's effective requiredExtra: a field is dispatch-required only if EVERY row (dimension)
+// sharing that agent's one dispatch requires it. Union semantics would be unsafe — promoting a
+// single-dimension's required field (e.g. a hypothetical convention-only requirement) onto the
+// whole conventions-and-intent dispatch would reject every intent/comment_accuracy finding that
+// correctly omits it. Order-independent (sorted) so the result never depends on DIMENSIONS row
+// iteration order. Exported standalone so the intersection can be exercised with synthetic rows
+// without needing to mutate the module-level registry.
+//
+// registry.test.js's sibling-parity test ("rows sharing an agentType declare identical
+// requiredExtra sets") is the actual AUTHORITY that keeps this safe on the real registry: it
+// fails the build the moment a multi-dimension agent's rows disagree, so on a healthy tree this
+// intersection is an IDENTITY (every sibling already agrees, so nothing is ever actually
+// dropped). This function is not what makes divergence safe — that guard is. It is the
+// fail-safe ALGEBRA underneath: if a divergence somehow reached runtime anyway (a bypassed
+// guard, a registry built by different code some day), the intersection still degrades safely
+// — dropping the disputed field from `required` — instead of the union's failure mode, which
+// would force every compliant OMIT-ing finding on a sibling dimension to fabricate a value it
+// was correctly told to omit.
+export function intersectRequiredExtra(rows) {
+  if (!rows || rows.length === 0) return [];
+  let acc = new Set(rows[0].requiredExtra || []);
+  for (const row of rows.slice(1)) {
+    const next = new Set(row.requiredExtra || []);
+    acc = new Set([...acc].filter((f) => next.has(f)));
+  }
+  return [...acc].sort();
+}
+
 // Group DIMENSIONS by agentType, unioning each agent's per-dimension schemaExtra into
 // one finding schema. One task per unique AGENT (7) — agents covering several
 // dimensions (conventions-and-intent -> convention/intent/comment_accuracy) dispatch once.
-export function agentSpecs() {
+// `requiredExtra` on the returned spec is the INTERSECTION of that agent's rows' requiredExtra
+// (intersectRequiredExtra above), not a union like schemaExtra — see the registry.js note on
+// why a per-dimension required field cannot safely promote onto sibling dimensions.
+//
+// Takes `dims` (defaults to the module-level DIMENSIONS) so the intersection-through-grouping
+// seam can be exercised with synthetic rows in tests, independent of the real registry. Agent
+// order is derived from `dims` itself (`[...new Set(dims.map(d => d.agentType))]`), NOT from
+// the module-level AGENTS constant — mapping over AGENTS here would look up entries by an
+// agentType a synthetic `dims` never populated and return undefined specs. For the default
+// call this produces the byte-identical order AGENTS already pins (see registry.test.js).
+export function agentSpecs(dims = DIMENSIONS) {
   const byAgent = new Map();
-  for (const d of DIMENSIONS) {
-    if (!byAgent.has(d.agentType)) byAgent.set(d.agentType, { agentType: d.agentType, dimensions: [], schemaExtra: {}, conditionalFlags: [], promptExtra: null });
+  for (const d of dims) {
+    if (!byAgent.has(d.agentType)) byAgent.set(d.agentType, { agentType: d.agentType, dimensions: [], schemaExtra: {}, conditionalFlags: [], promptExtra: null, rows: [] });
     const spec = byAgent.get(d.agentType);
     spec.dimensions.push(d.dimension);
     Object.assign(spec.schemaExtra, d.schemaExtra || {});
     spec.conditionalFlags.push(d.conditionalFlag);
+    spec.rows.push(d);
     // promptExtra is scoped per AGENT, not per dimension — every DIMENSIONS row for a
     // multi-dimension agent is expected to carry the same value (see registry.js), so a
     // truthy value on any of an agent's rows sets it for the whole spec.
     if (d.promptExtra) spec.promptExtra = d.promptExtra;
   }
-  // Preserve AGENTS order (derived from DIMENSIONS) so dispatch order is deterministic.
-  return AGENTS.map((a) => byAgent.get(a));
+  const order = [...new Set(dims.map((d) => d.agentType))];
+  return order.map((a) => {
+    const spec = byAgent.get(a);
+    spec.requiredExtra = intersectRequiredExtra(spec.rows);
+    delete spec.rows;
+    return spec;
+  });
 }
 
 // An agent is active when at least one of its dimensions is enabled. A dimension is
@@ -364,13 +409,28 @@ export function allActiveDimensionsDegraded(dispatched, degraded) {
 // affected_consumers are declared); the shorthand keeps the common case terse while the
 // fragment form supports arrays the platform's schema validator requires `items` on.
 // schemaExtra wins on a key collision — a dimension may narrow a canonical field, never the
-// reverse — and `required` is always the flat FINDING_REQUIRED (see its note in registry.js).
-function findingItemSchema(schemaExtra) {
+// reverse. `required` is FINDING_REQUIRED plus the dispatch's effective `requiredExtra`
+// (issue #66, agentSpecs' intersection) — empty for bug-detector, conventions-and-intent and
+// type-design-analyzer, so those three dispatch the byte-identical flat list they always did.
+//
+// The promotion's blast radius (why registry.js's requiredExtra comment demands
+// contract-UNCONDITIONAL fields only): a `required` array is a hard StructuredOutput
+// constraint on every element of `findings`, so ONE finding omitting a required field makes
+// the whole `{ findings, complete, total_seen }` envelope a schema violation, not just that
+// one finding — the platform retries the WHOLE agent dispatch (cap 5) with the validation
+// error fed back. If retries exhaust, `parallel()` resolves that member to null and discover()
+// treats it as a terminal agent failure: EVERY dimension that agent owns degrades (see
+// discover's null-member handling below), not just the dimension whose field was missing.
+// A conditionally-omitted field (claude_md_rule, spec_text, hidden_errors,
+// invalid_state_example) promoted here would make that omission — which the contract itself
+// tells the model to do — a self-inflicted retry storm on every dimension the agent covers.
+function findingItemSchema(schemaExtra, requiredExtra) {
   const props = {};
   for (const [k, t] of Object.entries({ ...FINDING_PROP_TYPES, ...(schemaExtra || {}) })) {
     props[k] = typeof t === 'string' ? { type: t } : t;
   }
-  return { type: 'object', properties: props, required: FINDING_REQUIRED, additionalProperties: false };
+  const required = requiredExtra && requiredExtra.length ? [...FINDING_REQUIRED, ...requiredExtra] : FINDING_REQUIRED;
+  return { type: 'object', properties: props, required, additionalProperties: false };
 }
 
 // Canonical finding schema (per-dimension schemaExtra unioned on top), wrapped in the
@@ -384,7 +444,7 @@ function findingSchema(spec) {
     properties: {
       findings: {
         type: 'array',
-        items: findingItemSchema(spec.schemaExtra),
+        items: findingItemSchema(spec.schemaExtra, spec.requiredExtra),
       },
       complete: { type: 'boolean' },
       total_seen: { type: 'number' },

--- a/workflows/test/finding_schema.test.js
+++ b/workflows/test/finding_schema.test.js
@@ -90,18 +90,32 @@ test('every declared field reaches the dispatch with the registry-declared type'
   }
 });
 
-test('required is the flat FINDING_REQUIRED — no per-dimension extra sneaks into it', async () => {
+test('required is FINDING_REQUIRED plus each dispatch\'s effective requiredExtra — exact per-agent table', async () => {
+  // issue #66: a field required by ALL dimensions sharing a dispatch is promoted into that
+  // dispatch's `required`; FINDING_REQUIRED itself stays the flat, per-dimension-free base
+  // every dispatch's required list is built from.
   const schemas = await discoverySchemas();
-  // A field required for ONE dimension cannot be marked required here: `required` is the one
-  // flat list shared by every agent's dispatch schema, so marking (say) criticality required
-  // would reject every non-test finding at its own dispatch.
-  const extras = new Set(DIMENSIONS.flatMap((d) => Object.keys(d.schemaExtra || {})));
+  const expectedExtras = {
+    'code-gauntlet:bug-detector': [],
+    'code-gauntlet:security-reviewer': ['attack_vector'],
+    'code-gauntlet:cross-file-impact': ['affected_consumers'],
+    'code-gauntlet:test-analyzer': ['criticality', 'failure_scenario'],
+    'code-gauntlet:conventions-and-intent': [],
+    'code-gauntlet:type-design-analyzer': [],
+    'code-gauntlet:code-simplifier': ['behavior_preserved'],
+  };
   for (const spec of agentSpecs()) {
     const { required } = schemas[spec.agentType].properties.findings.items;
-    assert.deepEqual(required, FINDING_REQUIRED, `${spec.agentType}: required list drifted`);
-    for (const field of required) {
-      assert.ok(!extras.has(field), `${field} is a per-dimension extra and must not be required`);
-    }
+    assert.deepEqual(
+      required.slice(0, FINDING_REQUIRED.length),
+      FINDING_REQUIRED,
+      `${spec.agentType}: FINDING_REQUIRED must be an exact prefix of the dispatched required list`,
+    );
+    assert.deepEqual(
+      required,
+      [...FINDING_REQUIRED, ...expectedExtras[spec.agentType]],
+      `${spec.agentType}: required list does not match FINDING_REQUIRED + expected requiredExtra`,
+    );
   }
 });
 
@@ -244,9 +258,11 @@ test('the fields issue #47 added are declared, on the right agents, with the rig
   const conventions = props('code-gauntlet:conventions-and-intent');
   assert.equal(conventions.spec_text.type, 'string', 'intent -> spec_text');
 
-  // None of the five may be required: required is flat across all dimensions.
+  // None of the five may enter the FLAT FINDING_REQUIRED list — criticality and
+  // failure_scenario ARE dispatch-required (issue #66), but through test_coverage's
+  // requiredExtra, never by touching this canonical, per-dimension-free base list.
   for (const field of ['suggestion', 'claude_md_rule', 'criticality', 'failure_scenario', 'spec_text']) {
-    assert.ok(!FINDING_REQUIRED.includes(field), `${field} must stay schema-optional`);
+    assert.ok(!FINDING_REQUIRED.includes(field), `${field} must stay out of FINDING_REQUIRED — per-dimension promotion goes through requiredExtra, not here`);
   }
 
   // suggested_fix_code is deliberately NOT implemented: post_review.py renders it if a caller

--- a/workflows/test/registry.test.js
+++ b/workflows/test/registry.test.js
@@ -1,7 +1,8 @@
 // registry.test.js — DIMENSIONS registry + resolvePolicy (S5) unit tests.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { DIMENSIONS, AGENTS, AGENT_LABELS, resolvePolicy } from '../src/registry.js';
+import { DIMENSIONS, AGENTS, AGENT_LABELS, FINDING_PROP_TYPES, FINDING_REQUIRED, resolvePolicy } from '../src/registry.js';
+import { intersectRequiredExtra, agentSpecs } from '../src/stages.js';
 
 test('7 unique discovery agents', () => { assert.equal(AGENTS.length, 7); });
 test('conventions-and-intent covers 3 dimensions', () => {
@@ -110,4 +111,108 @@ test('promptExtra: security sweep on security-reviewer, typo/naming on bug + con
 // label — this is the guard that would.
 test('AGENT_LABELS key set is exactly AGENTS — a new agent needs a label too', () => {
   assert.deepEqual(Object.keys(AGENT_LABELS).sort(), [...AGENTS].sort());
+});
+
+// --- requiredExtra (issue #66) ----------------------------------------------------
+
+test('every DIMENSIONS row declares requiredExtra as an array of field-name strings', () => {
+  for (const d of DIMENSIONS) {
+    assert.ok(Array.isArray(d.requiredExtra), `${d.dimension}: requiredExtra must be an array`);
+    for (const field of d.requiredExtra) {
+      assert.equal(typeof field, 'string', `${d.dimension}: requiredExtra entries must be strings`);
+    }
+  }
+});
+
+test('every requiredExtra entry is a key of its own row\'s schemaExtra — never a canonical FINDING_PROP_TYPES field', () => {
+  // F9: narrowed deliberately. A canonical field is, by definition, already emitted
+  // unconditionally by every dimension — its promotion belongs in FINDING_REQUIRED directly,
+  // not smuggled in piecemeal through one row's requiredExtra, where the Canonical fields
+  // table's Required-column lockstep test would never see it.
+  for (const d of DIMENSIONS) {
+    const declared = new Set(Object.keys(d.schemaExtra || {}));
+    for (const field of d.requiredExtra) {
+      assert.ok(declared.has(field), `${d.dimension}: requiredExtra names "${field}", which is not a key of this row's own schemaExtra`);
+      assert.ok(!(field in FINDING_PROP_TYPES), `${d.dimension}: requiredExtra names "${field}", a canonical field — promote it via FINDING_REQUIRED, not requiredExtra`);
+    }
+  }
+});
+
+test('requiredExtra entries are disjoint from FINDING_REQUIRED', () => {
+  for (const d of DIMENSIONS) {
+    for (const field of d.requiredExtra) {
+      assert.ok(!FINDING_REQUIRED.includes(field), `${d.dimension}: "${field}" is already in FINDING_REQUIRED — do not duplicate it in requiredExtra`);
+    }
+  }
+});
+
+test('rows sharing an agentType declare identical requiredExtra sets — a silent per-row drop must fail the build', () => {
+  // agentSpecs() intersects, but the registry itself should never author a divergence in the
+  // first place: a row whose requiredExtra differs from its siblings would have that field
+  // silently dropped by the intersection, declared but unenforced with no signal anywhere.
+  const seen = new Map();
+  for (const d of DIMENSIONS) {
+    const key = [...d.requiredExtra].sort().join(',');
+    if (seen.has(d.agentType)) {
+      assert.equal(
+        key,
+        seen.get(d.agentType),
+        `${d.agentType}: rows disagree on requiredExtra (${d.dimension} says [${key}]) — the ` +
+          'intersection would silently drop the difference instead of failing loud',
+      );
+    } else {
+      seen.set(d.agentType, key);
+    }
+  }
+});
+
+test('intersectRequiredExtra: a field required by only one of an agent\'s rows is not enforced', () => {
+  assert.deepEqual(intersectRequiredExtra([{ requiredExtra: ['x'] }, { requiredExtra: [] }]), []);
+});
+
+test('intersectRequiredExtra: a field required by every row of an agent stays enforced', () => {
+  assert.deepEqual(intersectRequiredExtra([{ requiredExtra: ['x'] }, { requiredExtra: ['x'] }]), ['x']);
+});
+
+test('intersectRequiredExtra: empty rows list yields empty result', () => {
+  assert.deepEqual(intersectRequiredExtra([]), []);
+});
+
+// agentSpecs(dims) end-to-end (F2): the call site that actually threads intersectRequiredExtra
+// into a dispatch spec is worth testing directly — a regression that replaces
+// `intersectRequiredExtra(spec.rows)` with e.g. first-row-verbatim leaves every OTHER test in
+// this suite green today, because every real agentType's rows already agree (the sibling-parity
+// test above enforces that on the live registry, making the intersection an identity there).
+test('agentSpecs(dims) default call matches AGENTS order exactly', () => {
+  assert.deepEqual(agentSpecs().map((s) => s.agentType), AGENTS);
+});
+
+test('agentSpecs(dims): a field required by only one of two synthetic rows sharing an agentType is NOT in the spec\'s requiredExtra', () => {
+  const dims = [
+    { agentType: 'synthetic:agent', dimension: 'dim_a', conditionalFlag: null, schemaExtra: {}, requiredExtra: ['x'], promptExtra: null },
+    { agentType: 'synthetic:agent', dimension: 'dim_b', conditionalFlag: null, schemaExtra: {}, requiredExtra: [], promptExtra: null },
+  ];
+  const specs = agentSpecs(dims);
+  assert.equal(specs.length, 1);
+  assert.deepEqual(specs[0].requiredExtra, []);
+});
+
+test('agentSpecs(dims): a field required by every row sharing an agentType IS in the spec\'s requiredExtra', () => {
+  const dims = [
+    { agentType: 'synthetic:agent', dimension: 'dim_a', conditionalFlag: null, schemaExtra: {}, requiredExtra: ['x'], promptExtra: null },
+    { agentType: 'synthetic:agent', dimension: 'dim_b', conditionalFlag: null, schemaExtra: {}, requiredExtra: ['x'], promptExtra: null },
+  ];
+  const specs = agentSpecs(dims);
+  assert.equal(specs.length, 1);
+  assert.deepEqual(specs[0].requiredExtra, ['x']);
+});
+
+test('agentSpecs(dims): order is derived from dims itself, not the module-level AGENTS constant', () => {
+  // A synthetic agentType AGENTS never heard of must still produce a real spec (not
+  // undefined) — the bug F2 guards against: mapping over the module-level AGENTS here would
+  // look this agentType up and return undefined.
+  const dims = [{ agentType: 'synthetic:only-here', dimension: 'dim_z', conditionalFlag: null, schemaExtra: {}, requiredExtra: [], promptExtra: null }];
+  const specs = agentSpecs(dims);
+  assert.deepEqual(specs.map((s) => s.agentType), ['synthetic:only-here']);
+  assert.ok(specs[0], 'spec must be a real object, not undefined');
 });


### PR DESCRIPTION
Closes #66.

## What

`findingItemSchema` always emitted the flat `FINDING_REQUIRED`, so every field an agent contract called REQUIRED was enforced by prose alone. This adds the per-dimension mechanism the `FINDING_REQUIRED` comment tracked:

- Every `DIMENSIONS` row carries `requiredExtra` (registry.js), the subset of that row's own `schemaExtra` its contract emits unconditionally.
- `agentSpecs(dims = DIMENSIONS)` computes the per-agent effective list as the **intersection** across the agent's rows and `findingItemSchema` appends it to `FINDING_REQUIRED` — for the discovery dispatch only, the one boundary that carries finding items by value (requirement 2 is satisfied by construction: verify echoes per-id deltas, never findings).
- Agents with an empty effective list (`bug-detector`, `conventions-and-intent`, `type-design-analyzer`) dispatch the byte-identical flat list they always did, pinned by test.

## Promotion judgment (requirement 3)

A full quote-backed audit of the seven contracts classified every extra plus `claude_md_rule`:

| Field | Dimension | Verdict | Why |
|---|---|---|---|
| `attack_vector` | security | **promoted** | no OMIT branch; the contract's own exclusion list already bars findings without a concrete vector |
| `affected_consumers` | cross_file_impact | **promoted** | no OMIT branch; `required` forces key presence, not a non-empty list |
| `criticality`, `failure_scenario` | test_coverage | **promoted** | rating fields assigned to every finding, no omit branch (the issue's two named unconditional fields) |
| `behavior_preserved` | simplification | **promoted** | contract supplies a sanctioned fallback (`'uncertain'`) instead of ever permitting omission |
| `claude_md_rule`, `spec_text` | convention / intent | **stays contract-enforced** | required for ONE dimension of the conventions-and-intent dispatch, which mixes three dimensions in one schema — unsatisfiable per-dimension there |
| `hidden_errors`, `invalid_state_example` | bug / type_design | **stays contract-enforced** | explicit OMIT branches; schema-requiring them forces fabrication (the retry-storm class the omit-not-null rule exists to prevent) |

Conditional schema enforcement was measured, not assumed (2026-08-18, CLI 2.1.235, first-party API): a top-level `oneOf`/`allOf`/`anyOf` in input_schema is rejected outright (API 400); `if`/`then` nested inside `items` was accepted AND enforced by the retry loop (first attempt omitting the conditional field was rejected with `must match "then" schema` and retried). It stays out of this PR because it is unmeasured on Bedrock/Vertex — the same provider-400 class as #179 — and one such 400 would degrade the agent's whole dimension set. Follow-up filed as an option.

## Drift guards (both runtimes)

- `requiredExtra` must be a subset of the row's **own** `schemaExtra` (a field every dimension emits belongs in `FINDING_REQUIRED`, not per-dimension promotion) and disjoint from `FINDING_REQUIRED`.
- Sibling-parity: rows sharing an agentType must declare identical `requiredExtra` sets — the intersection is the fail-safe algebra, the parity test the authority, so declared-but-unenforced fails the build.
- OMIT-drift guard: a promoted field whose owning contract (re)gains an OMIT branch fails the build; the value parser handles every contract value shape and **raises** on an unrecognized one instead of silently skipping.
- Bidirectional contract-sentence lockstep on the canonical phrase "required by the dispatch schema": every promoted field's contract must state it; no unpromoted field may claim it.
- report-format.md's per-dimension table gained a Required column, locked to the registry.

## Review and verification

Two adversarial rounds (design/tests/docs lenses). The review round mutation-proved two real holes that were then fixed: the OMIT guard was vacuous for the array-valued `affected_consumers`, and replacing the `agentSpecs` intersection call site with first-row-verbatim left the whole suite green (closed by parameterizing `agentSpecs(dims)` plus an end-to-end synthetic-rows test).

Ten mechanism mutations verified red across the two rounds (threading dropped, union-instead-of-intersection, row emptied, Python bridge stops serializing, Required cell flipped, array-shape OMIT injection, call-site first-row-verbatim, contract sentence deleted, bogus sentence added, canonical-field promotion) — each restored to green.

Gates: tests/ 1420 passed (coverage 93.18 ≥ 92.1), bench/tests 537 passed (88.48 ≥ 87), JS 836/836 (98.92/86.65/98.42 ≥ 98/85.7/97.4; functions headroom is 1.0pp at the one-decimal rounding the last ratchet used, so floors unchanged), bundle byte-fresh, pre-commit all hooks green.

## Measurement

Suites-only per the wave rule. Recall-relevant delta for the Wave 5 wave-end paired mini: five fields are now schema-required at their dispatch, so a finding omitting one burns platform schema retries (cap 5) and persistent non-compliance would degrade that agent's dimensions — pre-#47 evidence says models emit these fields spontaneously, and each promoted field is one the contract already made mandatory, so the expected live delta is enforcement of already-instructed behavior, not new rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CeXNjP9RtZpvE28LCXzmdR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes StructuredOutput validation for four discovery agents—omitting a promoted field can exhaust retries and degrade those dimensions—but behavior matches existing contract requirements and multi-dimension safety is guarded by intersection plus sibling-parity tests.
> 
> **Overview**
> Discovery finding schemas used a single flat `FINDING_REQUIRED`, so dimension-specific fields (e.g. `attack_vector`, `criticality`) were only enforced in agent prose. This PR adds **`requiredExtra`** on each `DIMENSIONS` row and appends the agent’s effective list to `required` in `findingItemSchema` — **`FINDING_REQUIRED` plus `requiredExtra`**, not a global bump.
> 
> **Promoted** (unconditional in contract): `attack_vector`, `affected_consumers`, `criticality`, `failure_scenario`, `behavior_preserved`. **Not promoted**: fields with OMIT branches or mixed-dimension agents (`claude_md_rule`, `spec_text`, etc.). Multi-dimension agents use **`intersectRequiredExtra`** so a field is required only if every sibling row agrees; `agentSpecs(dims)` is parameterized for tests.
> 
> Agent contracts gain canonical “required by the dispatch schema” sentences; **report-format.md** adds a per-dimension **Required** column. **Python/JS tests** guard registry↔contract drift (OMIT vs required, dispatch sentence lockstep, ReDoS-safe OMIT parsing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda2aa4269356e82fe1cf550baba1fed1f1bc745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->