### PR TITLE
feat(report): strip suggested_fix_code from every report-path model input

### DIFF
--- a/skills/code-gauntlet/references/report-format.md
+++ b/skills/code-gauntlet/references/report-format.md
@@ -54,7 +54,7 @@ The pipeline's declaration lives in `workflows/src/registry.js`. A field this ta
 | `suggestion` | string | no | Prose fix advice; rendered by `post_review.py` as a "Suggested fix:" block. |
 | `claude_md_rule` | string | no | The cited project rule, quoted with its source file; required by contract for convention findings; OMITTED (never null) when no rule applies. |
 | `cross_file_refs` | array | no | Other files involved in the finding |
-| `suggested_fix_code` | string | no | Exact replacement source for `file:line_start-line_end`, emitted by discovery agents only when the fix is a byte-exact, drop-in replacement for exactly those lines. Delivery (`scripts/post_review.py`) runs a deterministic apply-check before ever rendering it as a committable GitHub/GitLab `suggestion` block (one-click apply) — non-string, stale, wrong-range, wrong-anchor, or oversized fails the check and the finding downgrades to the prose `suggestion` instead. On GitLab, the render-site apply range is the discussion anchor plus offsets, not the stated range directly — a span the anchor and offsets can't realize within GitLab's cap downgrades the same way. |
+| `suggested_fix_code` | string | no | Exact replacement source for `file:line_start-line_end`, emitted by discovery agents only when the fix is a byte-exact, drop-in replacement for exactly those lines. The report path never renders this field — the pipeline strips it from the report-writer's input before dispatch (`stripFixCode` in `workflows/src/stages.js`). The only rendered surface is delivery: `scripts/post_review.py` runs a deterministic apply-check before ever rendering it as a committable GitHub/GitLab `suggestion` block (one-click apply) — non-string, stale, wrong-range, wrong-anchor, or oversized fails the check and the finding downgrades to the prose `suggestion` instead. On GitLab, the render-site apply range is the discussion anchor plus offsets, not the stated range directly — a span the anchor and offsets can't realize within GitLab's cap downgrades the same way. |
 
 ### Per-dimension fields
 
@@ -135,18 +135,6 @@ Example: "This PR adds JWT-based authentication to the API layer. The token vali
 {If finding.claude_md_rule or finding.spec_text is present — the rule the finding is measured
 against. `agents/report-writer.md` instructs the same:}
 **Cited rule:** {finding.claude_md_rule or finding.spec_text}
-
-{If finding.suggested_fix_code is present — informational only, this template does not run
-delivery's apply-check, so render it as a PLAIN fenced code block, never a ```suggestion
-fence: a suggestion fence pasted into a PR comment is a one-click apply button, and nothing
-on the report path has gated this content the way `post_review.py` gates the Inline PR
-Comment Format below.}
-Proposed replacement for {finding.file}:{finding.line_start}-{finding.line_end} (not apply-checked):
-```
-
-{finding.suggested_fix_code}
-
-```
 
 ---
 
@@ -316,4 +304,4 @@ comments.
 
 ```
 
-**`suggested_fix_code` field:** Optional canonical field — instructed by all 7 discovery contracts, emitted only when the fix is a byte-exact drop-in replacement for `line_start..line_end`. `scripts/post_review.py` runs a deterministic apply-check before ever rendering it as a GitHub or GitLab `suggestion` block (one-click apply): the field must be a string, non-empty after redaction, ship a matching `line_end`, match a valid diff range, land at this render site's actual apply range, differ from the current text, and stay within the size bound. On GitLab that render-site range is the discussion anchor plus the `-m+n` offsets the poster derives from it, capped by GitLab's own offset limit — a span the anchor can't realize within that cap fails the check the same as any other mismatched range. Any failure strips the field from the render and the finding falls back to the prose `suggestion` field, with the reason recorded via `warn_skip`. See `references/delivery-guide.md` for the findings JSON schema used by `post_review.py`.
+**`suggested_fix_code` field:** Delivery is the only surface that ever renders this field, gated on `scripts/post_review.py`'s deterministic apply-check (field must be a string, non-empty after redaction, ship a matching `line_end`, match a valid diff range, land at this render site's actual apply range, differ from the current text, and stay within the size bound — on GitLab that render-site range is the discussion anchor plus the `-m+n` offsets the poster derives from it, capped by GitLab's own offset limit; any failure strips the field from the render and the finding falls back to the prose `suggestion` field, with the reason recorded via `warn_skip`). The report path never reaches this code at all — the pipeline strips `suggested_fix_code` from the report-writer's input before dispatch (`stripFixCode` in `workflows/src/stages.js`), so there is no report-path render to gate. See `references/delivery-guide.md` for the findings JSON schema used by `post_review.py`.

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -1052,5 +1052,33 @@ class TestDeliveryVocabularySurfaces(unittest.TestCase):
         )
 
 
+class TestFullReportTemplateRenderInstructions(unittest.TestCase):
+    """Pins the Full Report Template's render instructions to the report-path
+    mechanism: fields the pipeline strips before the report-writer's dispatch must
+    not be interpolated or referenced by the template that writer follows."""
+
+    def test_full_report_template_never_instructs_a_suggested_fix_code_render(self):
+        """Pins the docs to the #220 mechanism: the report path structurally strips
+        suggested_fix_code (stripFixCode in workflows/src/stages.js) before the
+        report-writer ever sees it, so no template instruction may ask for a render —
+        a reintroduced instruction here would tell a model to do something the field
+        can no longer supply.
+        """
+        region = full_report_template_region(REPORT_FORMAT.read_text(encoding="utf-8"))
+        self.assertNotIn(
+            "suggested_fix_code",
+            region,
+            "Full Report Template must not interpolate or reference suggested_fix_code "
+            "— the field never reaches the report-writer's input (stripped by "
+            "stripFixCode before dispatch); delivery is the only rendered surface.",
+        )
+        self.assertNotIn(
+            "not apply-checked",
+            region,
+            "the '(not apply-checked)' render instruction was the unvetted-render "
+            "capability #220 removed — it must not reappear in the template.",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -1948,7 +1948,9 @@ const FINDING_PROP_TYPES = {
   // (scripts/post_review.py) runs a deterministic apply-check before ever rendering it as a
   // committable ```suggestion fence, and downgrades to the prose `suggestion` on any failure
   // (non-string, stale/no-op, wrong range, wrong anchor, oversized, ...). A finding surviving
-  // to delivery with this field set is not a guarantee the fence ships.
+  // to delivery with this field set is not a guarantee the fence ships. The pipeline also
+  // strips the field from the report-writer's input (stripFixCode in stages.js), so delivery
+  // is the only surface it is ever rendered on.
   suggested_fix_code: 'string',
   cross_file_refs: { type: 'array', items: { type: 'string' } },
 };
@@ -3478,19 +3480,35 @@ function findingSchema(spec) {
   };
 }
 
-// discover(ctx, input) -> { findings, gaps, degraded, dispatched }
-// `dispatched` is the full fan-out list (every active agentType, whether it succeeded,
-// failed, or returned zero findings) — mergeStage() uses it so a zero-finding agent
-// stays distinguishable from one never dispatched at all (e.g. disabled via agentFlags).
-// Shared by both drop branches below: a dropped suggested_fix_code is always the
-// same operation (delete-and-report-whether-it-was-there), only the reason for
-// dropping it differs between the two call sites.
+// Shared by the two discover-side drop branches below and by stripFixCode: a dropped
+// suggested_fix_code is always the same operation (delete-and-report-whether-it-was-there),
+// only the reason for dropping it differs between call sites.
 function dropSuggestedFixCode(f) {
   if (!('suggested_fix_code' in f)) return false;
   delete f.suggested_fix_code;
   return true;
 }
 
+// stripFixCode(findings) -> new array, same finding objects EXCEPT a shallow copy
+// wherever suggested_fix_code was present (dropSuggestedFixCode does the one delete
+// operation, on the copy — never the original). Used ONLY on the report path
+// (reportStage): the report-writer is a sampled model and no apply-check oracle exists
+// at report time, so the field must never reach a report-path prompt. selectDelivery /
+// writerPayload read the SAME finding objects reportStage was called with, unstripped —
+// delivery keeps the field for its own live-oracle apply-check (scripts/post_review.py).
+function stripFixCode(findings) {
+  return (findings || []).map((f) => {
+    if (!f || typeof f !== 'object' || !('suggested_fix_code' in f)) return f;
+    const copy = { ...f };
+    dropSuggestedFixCode(copy);
+    return copy;
+  });
+}
+
+// discover(ctx, input) -> { findings, gaps, degraded, dispatched }
+// `dispatched` is the full fan-out list (every active agentType, whether it succeeded,
+// failed, or returned zero findings) — mergeStage() uses it so a zero-finding agent
+// stays distinguishable from one never dispatched at all (e.g. disabled via agentFlags).
 // One parallel() call fanning out to every active AGENT. A null member -> gap AND
 // every dimension that agent covers is marked degraded: a null means the agent
 // terminally failed after the platform's schema retries (cap 5), so those dimensions
@@ -5203,7 +5221,15 @@ function consolidateForReport(findings) {
 // which segments answer first (issue #38, S2).
 async function reportStage(ctx, input) {
   const c = ctx || defaultCtx();
-  const inp = typeof input === 'string' ? JSON.parse(input) : (input || {});
+  const parsed = typeof input === 'string' ? JSON.parse(input) : (input || {});
+  // Strip suggested_fix_code before ANY report-path consumer reads findings/unverified
+  // (dimensionsTable, consolidateForReport, the oversized-payload size check, chunking,
+  // dispatchReportSegment's segInp, minimalReport, reportPrompt) — the report-writer is
+  // a sampled model, so no apply-check oracle exists at report time to vet a rendered
+  // patch. stripFixCode copies; the caller's original finding objects (and therefore
+  // selectDelivery/writerPayload) are untouched and still carry the field for delivery's
+  // own live-oracle apply-check (issue #220).
+  const inp = { ...parsed, findings: stripFixCode(parsed.findings), unverified: stripFixCode(parsed.unverified) };
   const policy = inp.policy || {};
   const model = modelFor('code-gauntlet:report-writer', policy);
 

--- a/workflows/src/registry.js
+++ b/workflows/src/registry.js
@@ -68,7 +68,9 @@ export const FINDING_PROP_TYPES = {
   // (scripts/post_review.py) runs a deterministic apply-check before ever rendering it as a
   // committable ```suggestion fence, and downgrades to the prose `suggestion` on any failure
   // (non-string, stale/no-op, wrong range, wrong anchor, oversized, ...). A finding surviving
-  // to delivery with this field set is not a guarantee the fence ships.
+  // to delivery with this field set is not a guarantee the fence ships. The pipeline also
+  // strips the field from the report-writer's input (stripFixCode in stages.js), so delivery
+  // is the only surface it is ever rendered on.
   suggested_fix_code: 'string',
   cross_file_refs: { type: 'array', items: { type: 'string' } },
 };

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -453,19 +453,35 @@ function findingSchema(spec) {
   };
 }
 
-// discover(ctx, input) -> { findings, gaps, degraded, dispatched }
-// `dispatched` is the full fan-out list (every active agentType, whether it succeeded,
-// failed, or returned zero findings) — mergeStage() uses it so a zero-finding agent
-// stays distinguishable from one never dispatched at all (e.g. disabled via agentFlags).
-// Shared by both drop branches below: a dropped suggested_fix_code is always the
-// same operation (delete-and-report-whether-it-was-there), only the reason for
-// dropping it differs between the two call sites.
+// Shared by the two discover-side drop branches below and by stripFixCode: a dropped
+// suggested_fix_code is always the same operation (delete-and-report-whether-it-was-there),
+// only the reason for dropping it differs between call sites.
 function dropSuggestedFixCode(f) {
   if (!('suggested_fix_code' in f)) return false;
   delete f.suggested_fix_code;
   return true;
 }
 
+// stripFixCode(findings) -> new array, same finding objects EXCEPT a shallow copy
+// wherever suggested_fix_code was present (dropSuggestedFixCode does the one delete
+// operation, on the copy — never the original). Used ONLY on the report path
+// (reportStage): the report-writer is a sampled model and no apply-check oracle exists
+// at report time, so the field must never reach a report-path prompt. selectDelivery /
+// writerPayload read the SAME finding objects reportStage was called with, unstripped —
+// delivery keeps the field for its own live-oracle apply-check (scripts/post_review.py).
+export function stripFixCode(findings) {
+  return (findings || []).map((f) => {
+    if (!f || typeof f !== 'object' || !('suggested_fix_code' in f)) return f;
+    const copy = { ...f };
+    dropSuggestedFixCode(copy);
+    return copy;
+  });
+}
+
+// discover(ctx, input) -> { findings, gaps, degraded, dispatched }
+// `dispatched` is the full fan-out list (every active agentType, whether it succeeded,
+// failed, or returned zero findings) — mergeStage() uses it so a zero-finding agent
+// stays distinguishable from one never dispatched at all (e.g. disabled via agentFlags).
 // One parallel() call fanning out to every active AGENT. A null member -> gap AND
 // every dimension that agent covers is marked degraded: a null means the agent
 // terminally failed after the platform's schema retries (cap 5), so those dimensions
@@ -2178,7 +2194,15 @@ function consolidateForReport(findings) {
 // which segments answer first (issue #38, S2).
 export async function reportStage(ctx, input) {
   const c = ctx || defaultCtx();
-  const inp = typeof input === 'string' ? JSON.parse(input) : (input || {});
+  const parsed = typeof input === 'string' ? JSON.parse(input) : (input || {});
+  // Strip suggested_fix_code before ANY report-path consumer reads findings/unverified
+  // (dimensionsTable, consolidateForReport, the oversized-payload size check, chunking,
+  // dispatchReportSegment's segInp, minimalReport, reportPrompt) — the report-writer is
+  // a sampled model, so no apply-check oracle exists at report time to vet a rendered
+  // patch. stripFixCode copies; the caller's original finding objects (and therefore
+  // selectDelivery/writerPayload) are untouched and still carry the field for delivery's
+  // own live-oracle apply-check (issue #220).
+  const inp = { ...parsed, findings: stripFixCode(parsed.findings), unverified: stripFixCode(parsed.unverified) };
   const policy = inp.policy || {};
   const model = modelFor('code-gauntlet:report-writer', policy);
 

--- a/workflows/test/stages_dimensions.test.js
+++ b/workflows/test/stages_dimensions.test.js
@@ -3,10 +3,11 @@
 // of the Phase 8 model. Unit tests call dimensionsSummaryTable directly with synthetic
 // inputs and assert exact rendered strings; the reportStage-level tests at the bottom
 // reuse the ctx-mock pattern from pipeline_run.test.js to check the plumbing
-// (reportPrompt / minimalReport) around it.
+// (reportPrompt / minimalReport) around it. Also covers stripFixCode and reportStage's
+// report-path suggested_fix_code strip (issue #220).
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { dimensionsSummaryTable, reportStage } from '../src/stages.js';
+import { dimensionsSummaryTable, reportStage, stripFixCode } from '../src/stages.js';
 import { AGENTS, AGENT_LABELS } from '../src/registry.js';
 import { makeFinding } from './helpers/pipelineMock.js';
 
@@ -337,4 +338,110 @@ test('reportStage: a writer throw degrades to the minimal report, which renders 
   assert.ok(primaryIdx >= 0, 'the primary is rendered as a top-level bullet');
   assert.match(lines[primaryIdx + 1], /Corroborating: security-reviewer \(security, confidence 70\)/);
   assert.ok(!out.report.includes(`- [MEDIUM] ${corroborator.title}`), 'the corroborator is not rendered as its own top-level bullet');
+});
+
+// --- stripFixCode (issue #220) -----------------------------------------------
+//
+// The report-writer is a sampled model: no apply-check oracle exists at report time,
+// so suggested_fix_code must never reach the report path. stripFixCode is the copy-
+// based mechanism reportStage rebinds its input through before any consumer reads it.
+
+test('stripFixCode: strips suggested_fix_code from a finding that carries it', () => {
+  const f = makeFinding('F1', { suggested_fix_code: 'const x = 1;' });
+  const [out] = stripFixCode([f]);
+  assert.equal(out.suggested_fix_code, undefined);
+  assert.ok(!('suggested_fix_code' in out), 'the key itself must be gone, not just falsy');
+});
+
+test('stripFixCode: a finding without the field is returned as the SAME object (no copy made)', () => {
+  const f = makeFinding('F1');
+  const [out] = stripFixCode([f]);
+  assert.equal(out, f, 'no suggested_fix_code present -> identity passthrough, not a copy');
+});
+
+test('stripFixCode: a finding carrying the field is copied — the original object is untouched', () => {
+  const f = makeFinding('F1', { suggested_fix_code: 'const x = 1;' });
+  const [out] = stripFixCode([f]);
+  assert.notEqual(out, f, 'a stripped finding must be a copy, never the mutated original');
+  assert.equal(f.suggested_fix_code, 'const x = 1;', 'the caller\'s original object keeps the field — delivery reads the same objects reportStage was called with');
+});
+
+test('stripFixCode: every other field survives untouched on the copy', () => {
+  const f = makeFinding('F1', { suggested_fix_code: 'const x = 1;', suggestion: 'do this instead' });
+  const [out] = stripFixCode([f]);
+  assert.equal(out.id, 'F1');
+  assert.equal(out.suggestion, 'do this instead');
+  assert.equal(out.file, f.file);
+  assert.equal(out.description, f.description);
+});
+
+test('stripFixCode: absent/empty input does not throw', () => {
+  assert.deepEqual(stripFixCode(undefined), []);
+  assert.deepEqual(stripFixCode([]), []);
+});
+
+test('stripFixCode: primitive/null members pass through unchanged and do not throw', () => {
+  // 'x' in 'str' throws TypeError — a primitive element in a replayed checkpoint's
+  // findings must not turn stripFixCode's guard into an unhandled throw.
+  assert.deepEqual(stripFixCode([null, 'oops', 7]), [null, 'oops', 7]);
+});
+
+// --- reportStage strips suggested_fix_code before any consumer reads it (#220) ----
+
+test('reportStage: the dispatched prompt carries no suggested_fix_code occurrence, from either the findings or the unverified bucket', async () => {
+  let capturedPrompt = null;
+  const ctx = {
+    agent: async (prompt) => { capturedPrompt = prompt; return { report: '# r' }; },
+    parallel: async () => [],
+  };
+  const findings = [makeFinding('B1', { dimension: 'bug', severity: 'high', suggested_fix_code: 'const patched = true;' })];
+  const unverified = [makeFinding('B2', { dimension: 'bug', severity: 'low', suggested_fix_code: 'const alsoPatched = true;' })];
+  await reportStage(ctx, { findings, unverified, stats: {}, dimensions: { dispatched: AGENTS, degraded: [] } });
+
+  assert.equal(typeof capturedPrompt, 'string');
+  // A raw '!includes(\'suggested_fix_code\')' check over-pins: filterFindings legitimately
+  // stamps suggested_fix_code_removed_by / suggested_fix_code_removal_reason on findings,
+  // and those field NAMES can legitimately reach the prompt. What must never reach it is
+  // the stripped CODE PAYLOAD itself.
+  assert.ok(!capturedPrompt.includes('const patched = true;'), 'the report-writer prompt must not contain the stripped fix-code payload');
+  assert.ok(!capturedPrompt.includes('const alsoPatched = true;'), 'the report-writer prompt must not contain the stripped unverified fix-code payload');
+  const body = resultsBody(capturedPrompt);
+  assert.ok(!('suggested_fix_code' in body.findings[0]), 'the findings bucket in the parsed prompt body must not carry the field');
+  assert.ok(!('suggested_fix_code' in body.unverified[0]), 'the unverified bucket in the parsed prompt body must not carry the field');
+});
+
+test('reportStage: the caller\'s original finding objects still carry suggested_fix_code after the stage returns (delivery invariance)', async () => {
+  const ctx = {
+    agent: async () => ({ report: '# r' }),
+    parallel: async () => [],
+  };
+  const finding = makeFinding('B1', { dimension: 'bug', severity: 'high', suggested_fix_code: 'const patched = true;' });
+  const unverifiedFinding = makeFinding('B2', { dimension: 'bug', severity: 'low', suggested_fix_code: 'const alsoPatched = true;' });
+  const findings = [finding];
+  const unverified = [unverifiedFinding];
+  await reportStage(ctx, { findings, unverified, stats: {}, dimensions: { dispatched: AGENTS, degraded: [] } });
+
+  assert.equal(finding.suggested_fix_code, 'const patched = true;', 'the caller\'s findings array is unmutated — selectDelivery/writerPayload read this same object');
+  assert.equal(unverifiedFinding.suggested_fix_code, 'const alsoPatched = true;', 'the caller\'s unverified array is unmutated');
+});
+
+test('reportStage: a segmented report strips suggested_fix_code from every segment\'s prompt', async () => {
+  const prompts = [];
+  const ctx = {
+    agent: async (prompt, opts) => { prompts.push(prompt); return { report: `body ${opts.label}` }; },
+    parallel: async (thunks) => Promise.all(thunks.map((t) => t())),
+  };
+  const big = Array.from({ length: 80 }, (_, i) => makeFinding(`F${i}`, {
+    description: 'x'.repeat(2000), dimension: 'bug', severity: 'high', suggested_fix_code: `const patch${i} = true;`,
+  }));
+  await reportStage(ctx, { findings: big, unverified: [], stats: {}, dimensions: { dispatched: AGENTS, degraded: [] } });
+
+  assert.ok(prompts.length > 1, 'fixture must segment for this test to be meaningful');
+  for (const p of prompts) {
+    // Distinctive PATCH PAYLOAD substring, not the field name (see #220 over-pin note above).
+    assert.ok(!p.includes('const patch'), 'every segment prompt must be free of the stripped fix-code payload');
+    for (const f of resultsBody(p).findings) {
+      assert.ok(!('suggested_fix_code' in f), 'no finding in any segment\'s parsed prompt body may carry the field');
+    }
+  }
 });


### PR DESCRIPTION
## What

The report path can no longer render `suggested_fix_code` at all: `reportStage` strips the field
from the report-writer's input (new `stripFixCode`, copy-based, built on `dropSuggestedFixCode`),
and `references/report-format.md` drops the "(not apply-checked)" render instruction. Delivery is
now the field's only rendered surface, gated by `post_review.py`'s existing apply-check against
its live oracle — delivered comment bytes and bench candidate bytes are byte-identical to main.

Closes #220.

## Why this shape

#220 asked for a report-side apply-check and flagged the open decision: where can a check run
when the report renderer is a model? The design went through two red-team rounds (four
independent opus reviews) before implementation; the full memos are summarized here because they
eliminated every other placement:

- **Verify-stage compute** (v1): dead. `VERIFY_SLICE_FIELDS` deliberately omits
  `suggested_fix_code`; adding it would push unbounded escape-dense patches through the
  content-proofed artifact-writer transcription channel, where one mangled backslash costs a
  whole slice its verification (`deterministic: true`, no retry). Also, a
  `from scripts.post_review import …` in `verify_findings.py` raises `ModuleNotFoundError` in
  the shipped invocation (`sys.path[0]` is `scripts/`, repo root absent) while staying green
  under pytest.
- **Strip at the verify boundary** (v1): not fail-closed — `runPhase` replays checkpointed
  phases (`buildResumeCheckpoints` carries every phase's output; `PERSISTED_RESUME_PHASES`
  replays `challenge` straight into `reportInput`), bypassing any verify-time strip. And an
  in-place strip would also strip delivery's input: verify's pinned Phase-2 diff and delivery's
  live diff diverge (incremental mode's bounded diff, moved PR heads), so it would delete fences
  delivery's own stronger check would have kept — a delivery regression and a moved
  bench-scored surface.
- **Phase 8 deterministic gate + code-rendered section** (v2): the render half survives review
  but is blocked on a correct file-based oracle. `post_review.py`'s diff parser is CLI-shaped
  and cannot parse the pinned `args.diffPath` (three producers; git-diff TAB termination and
  C-quoting; no platform value exists at the call site), and a findings.json rewrite collides
  with the persist plan's `expect[]` checksums, `assemble_artifacts` re-derivation, and
  `materialize_artifacts` self-healing. That capability is split into #226 (blocked on
  #163, the walker line-text migration) with all review-established requirements recorded there.

What remains is the structural core both red-team rounds converged on: the model never receives
the field, so no template instruction, writer improvisation, or replay can render unvetted patch
bytes, and the dishonest-label state is unreachable. The strip is copy-based at `reportStage`
entry — upstream of `dimensionsSummaryTable`, `consolidateForReport`, the oversized-payload
sizing, chunking, `minimalReport`, and `reportPrompt` (both buckets, every segment) — while
`selectDelivery`/`writeArtifacts` keep reading the caller's unstripped objects.

## Accepted residuals (named, not hidden)

- A `report`-phase checkpoint replayed from a pre-change run carries pre-change bytes with the
  old honest "(not apply-checked)" label — no false claim is possible.
- The Phase 8 orchestrator is a model with disk access reading findings.json; the template no
  longer instructs any patch render, which is the same trust posture as every other Phase 8
  rule.
- Unverified-bucket patches stop rendering too (they were never vetted; prose `suggestion`
  still renders).
- Pre-existing, unchanged: `suggested_fix_code_removed_by`/`_removal_reason` filter stamps can
  reach the report-writer prompt as metadata; carries no patch bytes. Recorded in #226.

## Verification

- Full gates green locally (and expected in CI): pytest `tests/` 1542 passed (scripts+.github
  coverage 93.45% ≥ 92.5), `bench/tests/` 539 passed (88.48% ≥ 87.5), `node --test` 864 passed
  (98.94 / 86.70 / 98.45 ≥ 98 / 85.7 / 97.4 + presence check), bundle byte-identical to a fresh
  build, `pre-commit run --all-files` clean.
- Mutation ledger (every mechanism, byte-verified restores): strip call removed → 2 JS tests
  red; `stripFixCode` neutered to identity → 4 JS tests red; partial strip (`unverified` left
  raw) → 1 JS test red; copy discipline neutered → 2 JS tests red (delivery invariance is
  genuinely pinned); template block restored → the new
  `TestFullReportTemplateRenderInstructions` pin red; old `!f ||` guard restored → the
  primitive-passthrough test red (TypeError).
- Two adversarial implementation-review rounds (four opus reviews); round 1's one minor (the
  guard could throw on primitive members in a replayed checkpoint, escaping the non-fatal
  report contract) and six nits fixed in the amended commit; round 2 verified the fixes.

## Notes for the wave record

- Suites-only per the Wave 5 rule: recall/noise surfaces unmoved — delivery payload and bench
  candidate bytes are byte-identical (bench scores `post-review-payload.json`; the report is
  not a scored surface).
- JS functions coverage headroom measured locally at 1.05 pp (98.45 vs 97.4 floor), pre-existing
  on main (98.44); per policy a ratchet belongs in a housekeeping PR keyed to this PR's CI
  measurement, not here.
- Adjacent issue filed: #226 (render apply-checked patches via a read-only Phase 8 gate;
  blocked on #163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ReTwprjW1UMgw5vyyqoTS
