### PR TITLE
fix(delivery): migrate post_review parse_diff_lines onto diff_lines.walk_diff (#163)

### DIFF
--- a/docs/duplication-register.md
+++ b/docs/duplication-register.md
@@ -40,9 +40,7 @@ reconcile to 116 pairs plus the ten tool-invisible relationships.
 
 ## Individually classified rows
 
-Thirty-nine rows: 29 `intentional-and-documented`, 9 `intentional-but-undocumented`, 1
-`accidental`. The `accidental` row postdates the scan basis above and is outside its 116-pair
-reconciliation.
+Forty rows: 30 `intentional-and-documented`, 10 `intentional-but-undocumented`.
 
 | Pair | Classification | Reason | Doc ref |
 | --- | --- | --- | --- |
@@ -85,7 +83,7 @@ reconciliation.
 | `workflows/src/stages.js:608-614` ↔ `:1275-1281` ↔ `:1439-1445` | intentional-but-undocumented | Declined in #110: only 2 of the ~6 lines are identical across the 8 sites; the remainder is per-stage extraction and defaults, and each parse is independently tested. Revisit only if a ninth stage or a change to the shared 2-line parse itself lands. | [#110](https://github.com/liatrio-labs/claude-code-gauntlet/issues/110) |
 | `tests/test_assemble_artifacts.py:503-513` ↔ `:1158-1168` | intentional-and-documented | Consolidated behind `assert_assemble_hard_failure` in #110. | [#110](https://github.com/liatrio-labs/claude-code-gauntlet/issues/110) |
 | `scripts/assemble_artifacts.py:658-676` (`assemble`) ↔ `scripts/materialize_artifacts.py:409-429` (`materialize`) | intentional-and-documented | The public wrapper whose only body is the last-resort guard over a private worker. Below the 60-token threshold, so jscpd missed it. Not shared: each side builds its own `_receipt` shape and names its own script in the error, and the guard belongs to whichever function promises the receipt. | `scripts/AGENTS.md:23-25` |
-| `scripts/post_review.py:234-421` ↔ `scripts/verify_findings.py:257-315` (the `parse_diff_lines` pair) | accidental | Two walks of the same unified-diff grammar, which carried the same two defects and were fixed twice. Half-consolidated behind `scripts/diff_lines.py`: the verify side now delegates the walk and keeps only its own header semantics, while `post_review.py` still holds its copy. Interim by sequencing — the poster's GitLab position fields (`old_line`, `new_files`, `old_paths`) migrate under their own tests rather than alongside this change, and until they do the poster's copy keeps reading git's encoded header paths (a space's trailing TAB, a C-quoted non-ASCII name) as the path itself. | [#163](https://github.com/liatrio-labs/claude-code-gauntlet/issues/163) |
+| `scripts/post_review.py` `is_line_valid` ↔ `scripts/verify_findings.py` `is_line_in_diff` | intentional-but-undocumented | Logic-identical four-line membership helpers (None passes through, exact key, then the `^[ab]/`-stripped key) over each boundary script's own mapping shape (dict vs set). Left separate so neither CLI imports the other's module — `verify_findings.py` resolves the repo root at import time. Revisit if a third copy appears. | — |
 
 ## Grouped patterns
 

--- a/scripts/diff_lines.py
+++ b/scripts/diff_lines.py
@@ -12,12 +12,14 @@ which lines are worth recording at all are decisions the two callers answer
 differently — folding them in here would need a platform flag and would put one
 caller's answer on the other's path.
 
-The event vocabulary is the UNION of what both retained parsers need, so some of
-it has no reader yet: the poster's own copy of this walk keys its GitLab position
-fields off ``---`` headers and reads a hunk's old count to recognise an added file
-(``@@ -0,0 +N,M @@``, the only added-file signal a verbatim-path diff carries).
-Narrowing the events to today's single caller would only have to be undone when
-that copy moves here; until then their coverage is this module's own tests.
+The event vocabulary is the UNION of what both retained parsers need. The poster
+(``scripts/post_review.py::parse_diff_lines``) is a live reader of all three shapes: it
+keys its GitLab position fields off ``---``/``+++`` headers, reads a hunk's old count to
+recognise an added file (``@@ -0,0 +N,M @@``, the only added-file signal a verbatim-path
+diff carries), and reads a line's ``text`` as the content oracle its suggested-fix
+apply-check needs. A hunk event's ``new_count`` and ``new_line`` are still carried for
+symmetry with the old side but are read only by this module's own tests — the poster has
+no use for them. HEADER SEMANTICS still stay in the callers, per the scope split above.
 
 No external dependencies. stdlib only.
 
@@ -53,7 +55,15 @@ class DiffEvent(NamedTuple):
     * ``"line"`` — a hunk-body line. ``new_line`` is set when the line exists on the new
       side and ``old_line`` when it exists on the old side: an added line carries only
       the former, a removed line only the latter, a context line both. ``\\ No newline
-      at end of file`` belongs to neither side and yields no event at all.
+      at end of file`` belongs to neither side and yields no event at all. ``text`` is
+      the line's body with the marker column removed — ``raw[1:]`` for a ``+``/``-``
+      line, and ``raw[1:]`` for a context line only when the raw line actually starts
+      with a space (a zero-prefixed bare context line is already bare; slicing it would
+      eat its first character instead of its marker). A removed line carries ``text``
+      too, despite having no ``new_line``: the walk stays lossless.
+
+    ``old_path`` / ``new_path`` / ``hunk`` events carry ``text=None`` — there is no body
+    line to hold text for.
     """
 
     kind: str
@@ -62,6 +72,7 @@ class DiffEvent(NamedTuple):
     new_line: int | None = None
     old_count: int | None = None
     new_count: int | None = None
+    text: str | None = None
 
 
 # Prefix-free on purpose: a header's `a/`/`b/` is diff syntax on one platform and a real
@@ -95,10 +106,14 @@ def _decode_header_path(field: str) -> str:
     timestamp column begins. And a path holding a control character, a quote, a
     backslash, or (unless ``core.quotePath=false``) a non-ASCII byte is written
     C-quoted as a whole, with the quotes OUTSIDE the synthetic prefix and the tab, if
-    any, after the closing quote: ``+++ "b/caf\\303\\251 x.py"<TAB>``. Neither
-    encoding is platform-specific — they are how git writes the header — so a caller
-    left to strip them itself would be re-deriving diff syntax to answer a question
-    about a path.
+    any, after the closing quote: ``+++ "b/caf\\303\\251 x.py"<TAB>``. Both encodings
+    are git's wire convention — how ``gh pr diff`` and plain ``git diff`` write a
+    header. ``glab mr diff`` reconstructs headers from the API with paths verbatim, so
+    on that producer the decode has nothing to undo and is a no-op for every path git
+    could not have encoded — it mis-reads only a name that itself carries a literal TAB
+    or is wrapped in double quotes, an accepted limitation (the poster's pre-migration
+    regex kept such a name raw; now the finding on it is demoted to summary-only rather
+    than anchored).
 
     A field that does not decode comes back verbatim: git never writes an escape this
     cannot read, so an undecodable field is not a path a finding could name either,
@@ -220,16 +235,24 @@ def walk_diff(diff_text: str) -> Iterator[DiffEvent]:
 
         if raw_line.startswith("+"):
             new_rem -= 1
-            yield DiffEvent("line", new_line=new_line)
+            yield DiffEvent("line", new_line=new_line, text=raw_line[1:])
             new_line += 1
         elif raw_line.startswith("-"):
             old_rem -= 1
-            yield DiffEvent("line", old_line=old_line)
+            yield DiffEvent("line", old_line=old_line, text=raw_line[1:])
             old_line += 1
         else:
-            # Context line (space- or zero-prefixed) — present on BOTH sides.
+            # Context line (space- or zero-prefixed) — present on BOTH sides. The
+            # marker column comes off only when it is really there: a blank context
+            # line is a lone space (content ""), but a zero-prefixed one is already
+            # bare and slicing it would eat its first character.
             old_rem -= 1
             new_rem -= 1
-            yield DiffEvent("line", old_line=old_line, new_line=new_line)
+            yield DiffEvent(
+                "line",
+                old_line=old_line,
+                new_line=new_line,
+                text=raw_line[1:] if raw_line.startswith(" ") else raw_line,
+            )
             new_line += 1
             old_line += 1

--- a/scripts/post_review.py
+++ b/scripts/post_review.py
@@ -97,10 +97,12 @@ import tempfile
 # swallowing a real ImportError raised from inside review_marker.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-# The idempotency checks READ the markers, and detect_prior_review.py is the only reader
-# (review_marker.py's contract). Importing its one state helper keeps this module
-# write-only: it must never grow a second parse of the signals it writes.
+# The detect_prior_review import below: the idempotency checks READ the markers, and
+# detect_prior_review.py is the only reader (review_marker.py's contract). Importing its
+# one state helper keeps this module write-only: it must never grow a second parse of the
+# signals it writes.
 from detect_prior_review import gitlab_prior_delivery_state
+from diff_lines import walk_diff
 from review_marker import SHA_RE, build_finding_marker, build_footer, is_sha_shaped
 
 # ---------------------------------------------------------------------------
@@ -266,8 +268,8 @@ def parse_diff_lines(platform, owner, repo, pr_number):
     * ``line_texts`` — a PARALLEL mapping over the SAME keys as ``valid_lines``, holding
       each line's NEW-SIDE TEXT with the diff's marker column removed. Parallel rather
       than folded into ``valid_lines``'s value so every existing consumer of that mapping
-      reads exactly what it read before. The parser already read this text off each
-      ``+``/context line and discarded it; it is the content oracle the
+      reads exactly what it read before. The walk already reads this text off each
+      ``+``/context line (``DiffEvent.text``); it is the content oracle the
       ``suggested_fix_code`` apply-check needs, and by construction it is the content the
       platform's anchor points at, at the same head SHA the position carries. ``git show``
       is not an alternative: the local HEAD is usually the base branch, a shallow clone has
@@ -276,21 +278,30 @@ def parse_diff_lines(platform, owner, repo, pr_number):
     Returns ``(None, None, None, None)`` when validation should be skipped (unknown
     platform or CLI failure). Callers must handle the ``None`` case.
 
-    Header syntax is read PER PLATFORM (see the compiled pair below): ``gh pr diff``
-    writes git's synthetic ``a/`` / ``b/`` prefixes, ``glab mr diff`` writes paths
-    verbatim. Every key returned therefore carries the platform's true spelling.
+    The unified-diff walk itself — header/hunk-body zone tracking, the old/new line
+    advance, and the wire spelling of a header path — is ``diff_lines.walk_diff``; this
+    function reads its events and keeps only what is local to this platform pair: which
+    prefix a header's decoded path carries (``a/``/``b/`` stripped for GitHub, kept
+    verbatim for GitLab, since there a leading ``a/`` is a real top-level directory), what
+    ``/dev/null`` means for ``current_file``/``current_file_is_new``, and the
+    ``new_files``/``old_paths`` bookkeeping described above.
 
-    The parser tracks each hunk's DECLARED old/new line budgets (a unified diff hunk
-    header states exactly how many lines of each side the hunk body contains) and only
-    matches file/hunk headers BETWEEN hunks. Well-formed git/gh/glab diffs always declare
-    correct counts, so the counts are trusted. Header matching is suspended inside a hunk
-    body because diff body lines collide with the header syntax: removing the SQL comment
-    ``-- deprecated: drop me`` renders as ``--- deprecated: drop me``, which the old-side
-    header regex swallows — silently desyncing ``old_line`` for every later line of the
-    hunk. Symmetrically an added ``++ x`` renders ``+++ x`` and would reset
-    ``current_file``. Suspending header matching also means non-header noise between
-    hunks (``diff --git …``, ``index …``, ``Binary files … differ``) is ignored instead of
-    being admitted as a fake context line.
+    Two behaviours change with this migration:
+
+    1. Header paths now arrive DECODED — the TAB terminator git appends after a path
+       containing a space, and the C-quoting git uses for a path holding a control
+       character or (by default) a non-ASCII byte, are both undone before this function
+       ever sees the path. A finding on such a path previously matched nothing in
+       ``valid_lines`` (the raw, still-encoded spelling was the key); it now matches its
+       diff line like any other path. The decode also runs on ``glab mr diff``'s verbatim
+       paths, where it has nothing of git's to undo and only mis-reads a TAB-bearing or
+       quote-wrapped name — an accepted limitation, see ``diff_lines._decode_header_path``.
+    2. A newline-terminated diff whose last hunk is cut short no longer mints a phantom
+       final line. The old hand-rolled loop walked the trailing empty string left by
+       splitting on the terminating newline as a context line — a key for a line the file
+       does not have, backed by an empty ``line_texts`` entry that would have fed the
+       apply-check a false oracle. ``walk_diff`` drops that trailing empty string instead
+       of walking it.
     """
     if platform == "github":
         stdout, stderr, rc = run_api(
@@ -318,131 +329,67 @@ def parse_diff_lines(platform, owner, repo, pr_number):
         )
         return None, None, None, None
 
-    # File-header regexes, chosen ONCE by platform — the platform cannot change inside
-    # the loop. `gh pr diff` emits git's synthetic prefixes (`a/` on the old side, `b/`
-    # on the new side): those are diff syntax and must come off. `glab mr diff` emits
-    # paths VERBATIM and never writes a synthetic prefix, so a leading `a/` there is a
-    # REAL top-level directory; stripping it truncated `a/`-rooted paths (`a/foo.py` ->
-    # `foo.py`) into keys and positions GitLab does not know, and every finding in such
-    # a repo was rejected. The catch-all group carries `/dev/null`, which only the GitHub
-    # shape ever writes — glab repeats the real path on both sides for an added or
-    # deleted file (tests/fixtures/glab_diff/ pins both shapes).
-    if platform == "github":
-        old_header_re = re.compile(r"^--- (?:a/)?(.+)$")
-        new_header_re = re.compile(r"^\+\+\+ (?:b/)?(.+)$")
-    else:
-        old_header_re = re.compile(r"^--- (.+)$")
-        new_header_re = re.compile(r"^\+\+\+ (.+)$")
-
     valid_lines = {}
     line_texts = {}
     new_files = set()
     old_paths = {}
     pending_old_path = None
     current_file = None
-    new_line = 0
-    old_line = 0
-    # Lines of each side still owed by the hunk currently being read. Both at 0 means
-    # "between hunks" — the only zone where a line may be read as a header.
-    old_rem = 0
-    new_rem = 0
     current_file_is_new = False
 
-    # Split on "\n" ONLY, never str.splitlines(): that also breaks on \x0c, \x0b, \x85 and
-    # U+2028/U+2029, which git treats as ordinary line CONTENT. A form feed inside a hunk
-    # body would become two parsed lines, draining the declared budgets one line early —
-    # flipping the header/body zone boundary and shipping a wrong old_line thereafter. The
-    # trailing "" a newline-terminated stream yields lands in the header zone and matches
-    # nothing.
-    for raw_line in stdout.split("\n"):
-        if old_rem <= 0 and new_rem <= 0:
-            # -- header zone -------------------------------------------------
-            # Old-side header: `--- a/path` (gh), `--- path` (glab), or `--- /dev/null`.
-            old_match = old_header_re.match(raw_line)
-            if old_match:
-                old_side = old_match.group(1)
-                current_file_is_new = old_side == "/dev/null"
-                # Held until the `+++` header names the new-side path this belongs to;
-                # for a rename the two differ and only this one is GitLab's `old_path`.
-                pending_old_path = None if current_file_is_new else old_side
-                continue
+    for event in walk_diff(stdout):
+        if event.kind == "old_path":
+            # `--- a/path` (gh, prefix stripped below), `--- path` (glab, kept
+            # verbatim — there a leading `a/` is a REAL top-level directory, and
+            # stripping it truncated `a/`-rooted paths into keys and positions
+            # GitLab does not know), or `--- /dev/null`.
+            old_side = event.path
+            if platform == "github":
+                old_side = old_side.removeprefix("a/")
+            current_file_is_new = old_side == "/dev/null"
+            # Held until the `+++` header names the new-side path this belongs to;
+            # for a rename the two differ and only this one is GitLab's `old_path`.
+            pending_old_path = None if current_file_is_new else old_side
+            continue
 
-            # New-side header: `+++ b/path` (gh), `+++ path` (glab), or `+++ /dev/null`.
-            file_match = new_header_re.match(raw_line)
-            if file_match:
-                path = file_match.group(1)
-                if path == "/dev/null":
-                    current_file = None  # deleted file — no new path to track
-                else:
-                    current_file = path
-                    if current_file_is_new:
-                        new_files.add(current_file)
-                    if pending_old_path is not None:
-                        old_paths[current_file] = pending_old_path
-                new_line = 0
-                old_line = 0
-                current_file_is_new = False
-                continue
-
-            # Hunk header: @@ -old_start[,old_count] +new_start[,new_count] @@
-            # A count is omitted only for a one-line side, so it defaults to 1.
-            hunk_match = re.match(
-                r"^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@", raw_line
-            )
-            if hunk_match:
-                old_start, old_count, new_start, new_count = hunk_match.groups()
-                old_line = int(old_start)
-                new_line = int(new_start)
-                old_rem = 1 if old_count is None else int(old_count)
-                new_rem = 1 if new_count is None else int(new_count)
-                # `@@ -0,0` means the old side of this file is empty: either the file is
-                # ADDED, or it pre-existed and was empty. Plain `glab mr diff` offers no
-                # discriminator between the two (it repeats the path on both
-                # `---`/`+++` lines and never writes /dev/null, so this is its ONLY
-                # added-file signal). We prefer the added-file reading: sending
-                # `old_path` into a genuinely new file is the documented HTTP 500,
-                # whereas omitting it for a pre-existing empty file is not.
-                if old_line == 0 and old_rem == 0 and current_file is not None:
+        if event.kind == "new_path":
+            # `+++ b/path` (gh, prefix stripped below), `+++ path` (glab, verbatim),
+            # or `+++ /dev/null`.
+            path = event.path
+            if platform == "github":
+                path = path.removeprefix("b/")
+            if path == "/dev/null":
+                current_file = None  # deleted file — no new path to track
+            else:
+                current_file = path
+                if current_file_is_new:
                     new_files.add(current_file)
-                continue
-
-            # Anything else between hunks (`diff --git …`, `index …`,
-            # `Binary files … differ`, mode lines) is noise — never a commentable line.
+                if pending_old_path is not None:
+                    old_paths[current_file] = pending_old_path
+            current_file_is_new = False
             continue
 
-        # -- hunk-body zone --------------------------------------------------
-        # Headers are NOT matched here: `--- <text>` / `+++ <text>` are body content.
-        # Budgets are consumed even when `current_file` is None (a deleted file's body
-        # must still drain, or its lines would be read as the next file's headers).
-        if raw_line.startswith("\\"):
-            # `\ No newline at end of file` belongs to neither side.
+        if event.kind == "hunk":
+            # `@@ -0,0` means the old side of this file is empty: either the file is
+            # ADDED, or it pre-existed and was empty. Plain `glab mr diff` offers no
+            # discriminator between the two (it repeats the path on both
+            # `---`/`+++` lines and never writes /dev/null, so this is its ONLY
+            # added-file signal). We prefer the added-file reading: sending
+            # `old_path` into a genuinely new file is the documented HTTP 500,
+            # whereas omitting it for a pre-existing empty file is not.
+            if (
+                event.old_line == 0
+                and event.old_count == 0
+                and current_file is not None
+            ):
+                new_files.add(current_file)
             continue
 
-        if raw_line.startswith("+"):
-            # Added line — new side only, so there is no old_line to record.
-            new_rem -= 1
-            if current_file is not None:
-                valid_lines[(current_file, new_line)] = None
-                line_texts[(current_file, new_line)] = raw_line[1:]
-            new_line += 1
-        elif raw_line.startswith("-"):
-            # Removed line — advances the OLD side only; not addressable by new_line.
-            old_rem -= 1
-            old_line += 1
-        else:
-            # Context line (space- or zero-prefixed) — present on BOTH sides. The
-            # marker column comes off only when it is really there: a blank context
-            # line is a lone space (content ""), but a zero-prefixed one is already
-            # bare and slicing it would eat its first character.
-            old_rem -= 1
-            new_rem -= 1
-            if current_file is not None:
-                valid_lines[(current_file, new_line)] = old_line
-                line_texts[(current_file, new_line)] = (
-                    raw_line[1:] if raw_line.startswith(" ") else raw_line
-                )
-            new_line += 1
-            old_line += 1
+        # event.kind == "line". A removed line carries no `new_line` — not
+        # addressable by the new side, so it records nothing here.
+        if event.new_line is not None and current_file is not None:
+            valid_lines[(current_file, event.new_line)] = event.old_line
+            line_texts[(current_file, event.new_line)] = event.text
 
     return valid_lines, new_files, old_paths, line_texts
 

--- a/tests/test_diff_lines.py
+++ b/tests/test_diff_lines.py
@@ -13,6 +13,8 @@ Covers:
   - hunk budgets: resolved counts, omitted counts, drain across files
   - hunk body: added/removed/context line numbering, header-shaped body content,
     `\\ No newline at end of file`, form feeds and friends, a body cut short
+  - line text: marker-column removal, the zero-prefixed context exception,
+    header/hunk events carry none
 """
 
 import os
@@ -189,9 +191,9 @@ class TestHunkHeaders(unittest.TestCase):
             events(diff),
             [
                 DiffEvent("hunk", old_line=10, new_line=20, old_count=2, new_count=3),
-                DiffEvent("line", old_line=10, new_line=20),
-                DiffEvent("line", new_line=21),
-                DiffEvent("line", old_line=11, new_line=22),
+                DiffEvent("line", old_line=10, new_line=20, text="ctx"),
+                DiffEvent("line", new_line=21, text="added"),
+                DiffEvent("line", old_line=11, new_line=22, text="tail"),
             ],
         )
 
@@ -205,7 +207,7 @@ class TestHunkHeaders(unittest.TestCase):
             events(diff),
             [
                 DiffEvent("hunk", old_line=0, new_line=1, old_count=0, new_count=1),
-                DiffEvent("line", new_line=1),
+                DiffEvent("line", new_line=1, text="only"),
             ],
         )
 
@@ -226,13 +228,13 @@ class TestHunkHeaders(unittest.TestCase):
             [
                 DiffEvent("new_path", path="b/multi.py"),
                 DiffEvent("hunk", old_line=1, new_line=1, old_count=2, new_count=3),
-                DiffEvent("line", old_line=1, new_line=1),
-                DiffEvent("line", new_line=2),
-                DiffEvent("line", old_line=2, new_line=3),
+                DiffEvent("line", old_line=1, new_line=1, text="a"),
+                DiffEvent("line", new_line=2, text="b"),
+                DiffEvent("line", old_line=2, new_line=3, text="c"),
                 DiffEvent("hunk", old_line=50, new_line=51, old_count=2, new_count=3),
-                DiffEvent("line", old_line=50, new_line=51),
-                DiffEvent("line", new_line=52),
-                DiffEvent("line", old_line=51, new_line=53),
+                DiffEvent("line", old_line=50, new_line=51, text="d"),
+                DiffEvent("line", new_line=52, text="e"),
+                DiffEvent("line", old_line=51, new_line=53, text="f"),
             ],
         )
 
@@ -249,10 +251,10 @@ class TestHunkBody(unittest.TestCase):
             events(diff),
             [
                 DiffEvent("hunk", old_line=7, new_line=7, old_count=3, new_count=3),
-                DiffEvent("line", old_line=7, new_line=7),
-                DiffEvent("line", old_line=8),
-                DiffEvent("line", new_line=8),
-                DiffEvent("line", old_line=9, new_line=9),
+                DiffEvent("line", old_line=7, new_line=7, text="ctx"),
+                DiffEvent("line", old_line=8, text="gone"),
+                DiffEvent("line", new_line=8, text="fresh"),
+                DiffEvent("line", old_line=9, new_line=9, text="tail"),
             ],
         )
 
@@ -265,9 +267,9 @@ class TestHunkBody(unittest.TestCase):
             events(diff),
             [
                 DiffEvent("hunk", old_line=1, new_line=1, old_count=2, new_count=2),
-                DiffEvent("line", old_line=1, new_line=1),
-                DiffEvent("line", old_line=2),
-                DiffEvent("line", new_line=2),
+                DiffEvent("line", old_line=1, new_line=1, text="a"),
+                DiffEvent("line", old_line=2, text="b"),
+                DiffEvent("line", new_line=2, text="b2"),
             ],
         )
 
@@ -288,9 +290,9 @@ class TestHunkBody(unittest.TestCase):
                 DiffEvent("old_path", path="a/schema.sql"),
                 DiffEvent("new_path", path="b/schema.sql"),
                 DiffEvent("hunk", old_line=1, new_line=1, old_count=3, new_count=2),
-                DiffEvent("line", old_line=1, new_line=1),
-                DiffEvent("line", old_line=2),
-                DiffEvent("line", old_line=3, new_line=2),
+                DiffEvent("line", old_line=1, new_line=1, text="CREATE TABLE t ("),
+                DiffEvent("line", old_line=2, text="-- deprecated: drop me"),
+                DiffEvent("line", old_line=3, new_line=2, text=");"),
             ],
         )
 
@@ -311,9 +313,9 @@ class TestHunkBody(unittest.TestCase):
                 DiffEvent("old_path", path="a/notes.md"),
                 DiffEvent("new_path", path="b/notes.md"),
                 DiffEvent("hunk", old_line=1, new_line=1, old_count=2, new_count=3),
-                DiffEvent("line", old_line=1, new_line=1),
-                DiffEvent("line", new_line=2),
-                DiffEvent("line", old_line=2, new_line=3),
+                DiffEvent("line", old_line=1, new_line=1, text="intro"),
+                DiffEvent("line", new_line=2, text="++ x marks a diff-of-a-diff"),
+                DiffEvent("line", old_line=2, new_line=3, text="outro"),
             ],
         )
 
@@ -329,11 +331,11 @@ class TestHunkBody(unittest.TestCase):
             events(diff),
             [
                 DiffEvent("hunk", old_line=1, new_line=1, old_count=4, new_count=3),
-                DiffEvent("line", old_line=1, new_line=1),
-                DiffEvent("line", old_line=2),
-                DiffEvent("line", new_line=2),
-                DiffEvent("line", old_line=3, new_line=3),
-                DiffEvent("line", old_line=4),
+                DiffEvent("line", old_line=1, new_line=1, text="head"),
+                DiffEvent("line", old_line=2, text="alpha\x0cbeta"),
+                DiffEvent("line", new_line=2, text="gamma"),
+                DiffEvent("line", old_line=3, new_line=3, text="middle"),
+                DiffEvent("line", old_line=4, text="omega"),
             ],
         )
 
@@ -350,8 +352,8 @@ class TestHunkBody(unittest.TestCase):
                 DiffEvent("old_path", path="a/f.py"),
                 DiffEvent("new_path", path="b/f.py"),
                 DiffEvent("hunk", old_line=1, new_line=1, old_count=4, new_count=4),
-                DiffEvent("line", old_line=1, new_line=1),
-                DiffEvent("line", new_line=2),
+                DiffEvent("line", old_line=1, new_line=1, text="ctx"),
+                DiffEvent("line", new_line=2, text="added"),
             ],
         )
 
@@ -363,8 +365,8 @@ class TestHunkBody(unittest.TestCase):
             events(diff),
             [
                 DiffEvent("hunk", old_line=1, new_line=1, old_count=2, new_count=2),
-                DiffEvent("line", old_line=1, new_line=1),
-                DiffEvent("line", new_line=2),
+                DiffEvent("line", old_line=1, new_line=1, text="ctx"),
+                DiffEvent("line", new_line=2, text="added"),
             ],
         )
 
@@ -377,9 +379,9 @@ class TestHunkBody(unittest.TestCase):
             events(diff),
             [
                 DiffEvent("hunk", old_line=1, new_line=1, old_count=3, new_count=3),
-                DiffEvent("line", old_line=1, new_line=1),
-                DiffEvent("line", old_line=2, new_line=2),
-                DiffEvent("line", new_line=3),
+                DiffEvent("line", old_line=1, new_line=1, text="a"),
+                DiffEvent("line", old_line=2, new_line=2, text=""),
+                DiffEvent("line", new_line=3, text="b"),
             ],
         )
 
@@ -410,16 +412,110 @@ class TestHunkBody(unittest.TestCase):
                 DiffEvent("old_path", path="a/gone.py"),
                 DiffEvent("new_path", path="/dev/null"),
                 DiffEvent("hunk", old_line=1, new_line=0, old_count=3, new_count=0),
-                DiffEvent("line", old_line=1),
-                DiffEvent("line", old_line=2),
-                DiffEvent("line", old_line=3),
+                DiffEvent("line", old_line=1, text="alpha"),
+                DiffEvent("line", old_line=2, text="beta"),
+                DiffEvent("line", old_line=3, text="gamma"),
                 DiffEvent("old_path", path="a/next.py"),
                 DiffEvent("new_path", path="b/next.py"),
                 DiffEvent("hunk", old_line=10, new_line=10, old_count=1, new_count=2),
-                DiffEvent("line", old_line=10, new_line=10),
-                DiffEvent("line", new_line=11),
+                DiffEvent("line", old_line=10, new_line=10, text="ctx"),
+                DiffEvent("line", new_line=11, text="added"),
             ],
         )
+
+
+# ---------------------------------------------------------------------------
+# Line text
+# ---------------------------------------------------------------------------
+
+
+class TestLineText(unittest.TestCase):
+    """``text`` is a ``"line"`` event's body with the marker column removed.
+
+    Every case above already pins ``text`` alongside the numbering it exercises;
+    these tests isolate the marker-stripping rule itself, one shape at a time.
+    """
+
+    def test_added_line_text_drops_the_leading_plus(self):
+        diff = "@@ -0,0 +1 @@\n+hello\n"
+        self.assertEqual(events(diff)[1], DiffEvent("line", new_line=1, text="hello"))
+
+    def test_removed_line_text_drops_the_leading_minus(self):
+        diff = "@@ -1 +0,0 @@\n-hello\n"
+        self.assertEqual(events(diff)[1], DiffEvent("line", old_line=1, text="hello"))
+
+    def test_context_line_text_drops_exactly_one_leading_space(self):
+        diff = "@@ -1 +1 @@\n  indented\n"
+        self.assertEqual(
+            events(diff)[1],
+            DiffEvent("line", old_line=1, new_line=1, text=" indented"),
+        )
+
+    def test_blank_context_line_written_as_a_lone_space_yields_empty_text(self):
+        # A unified diff spells a blank context line as a lone space — its content
+        # is the empty string, not a space.
+        diff = "@@ -1 +1 @@\n \n"
+        self.assertEqual(
+            events(diff)[1], DiffEvent("line", old_line=1, new_line=1, text="")
+        )
+
+    def test_zero_prefixed_bare_context_line_yields_empty_text_and_drains(self):
+        # Some producers write a blank context line with no marker column at all
+        # (the bare empty string). Slicing an empty string is safe and would also
+        # yield "" here, so this case alone does not distinguish sliced from
+        # unsliced — it only pins that the empty line still drains the hunk's
+        # declared budget, and that its text comes out as "" either way.
+        diff = "@@ -1,2 +1,2 @@\n\n ctx\n"
+        self.assertEqual(
+            events(diff),
+            [
+                DiffEvent("hunk", old_line=1, new_line=1, old_count=2, new_count=2),
+                DiffEvent("line", old_line=1, new_line=1, text=""),
+                DiffEvent("line", old_line=2, new_line=2, text="ctx"),
+            ],
+        )
+
+    def test_bare_context_line_with_content_keeps_its_first_character(self):
+        # A body line with no marker column at all is passed through, not sliced:
+        # slicing would eat a content character as if it were a marker.
+        diff = "@@ -1,2 +1,2 @@\nbare_ctx\n ctx\n"
+        self.assertEqual(
+            events(diff),
+            [
+                DiffEvent("hunk", old_line=1, new_line=1, old_count=2, new_count=2),
+                DiffEvent("line", old_line=1, new_line=1, text="bare_ctx"),
+                DiffEvent("line", old_line=2, new_line=2, text="ctx"),
+            ],
+        )
+
+    def test_leading_whitespace_after_the_marker_is_preserved_verbatim(self):
+        diff = "@@ -0,0 +1 @@\n+    indented_add\n"
+        self.assertEqual(
+            events(diff)[1], DiffEvent("line", new_line=1, text="    indented_add")
+        )
+
+    def test_form_feed_inside_the_text_is_preserved(self):
+        diff = "@@ -0,0 +1 @@\n+a\x0cb\n"
+        self.assertEqual(events(diff)[1], DiffEvent("line", new_line=1, text="a\x0cb"))
+
+    def test_no_newline_marker_yields_no_event(self):
+        diff = "@@ -1,2 +1,2 @@\n a\n\\ No newline at end of file\n b\n"
+        self.assertEqual(
+            events(diff),
+            [
+                DiffEvent("hunk", old_line=1, new_line=1, old_count=2, new_count=2),
+                DiffEvent("line", old_line=1, new_line=1, text="a"),
+                DiffEvent("line", old_line=2, new_line=2, text="b"),
+            ],
+        )
+
+    def test_header_and_hunk_events_carry_no_text(self):
+        diff = "--- a/f.py\n+++ b/f.py\n@@ -1 +1 @@\n ctx\n"
+        old_path, new_path, hunk, line = events(diff)
+        self.assertIsNone(old_path.text)
+        self.assertIsNone(new_path.text)
+        self.assertIsNone(hunk.text)
+        self.assertEqual(line.text, "ctx")
 
 
 if __name__ == "__main__":

--- a/tests/test_docs_registry.py
+++ b/tests/test_docs_registry.py
@@ -26,7 +26,7 @@ REPO = Path(__file__).resolve().parents[1]
 # many as fifty; extend the range here if it ever does.
 _ONES = ["", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
 _TENS = {30: "thirty", 40: "forty", 50: "fifty"}
-_NUMBER_WORDS = {50: "fifty"}
+_NUMBER_WORDS = {50: _TENS[50]}
 for _tens in (30, 40):
     _NUMBER_WORDS[_tens] = _TENS[_tens]
     for _i in range(1, 10):

--- a/tests/test_docs_registry.py
+++ b/tests/test_docs_registry.py
@@ -14,11 +14,24 @@ Scope: git-tracked files only (``git ls-files``), so gitignored local artifacts
 never fail the suite.
 """
 
+import re
 import subprocess
 import unittest
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
+
+# Spelled-out number words for the duplication register's row-count sentence
+# ("Forty rows: ..."). The table has never held fewer than thirty rows or as
+# many as fifty; extend the range here if it ever does.
+_ONES = ["", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine"]
+_TENS = {30: "thirty", 40: "forty", 50: "fifty"}
+_NUMBER_WORDS = {50: "fifty"}
+for _tens in (30, 40):
+    _NUMBER_WORDS[_tens] = _TENS[_tens]
+    for _i in range(1, 10):
+        _NUMBER_WORDS[_tens + _i] = f"{_TENS[_tens]}-{_ONES[_i]}"
+_WORD_TO_NUMBER = {word: number for number, word in _NUMBER_WORDS.items()}
 
 # Root-level markdown: community-health and contract files only. CHANGELOG.md is
 # semantic-release-generated. Review outputs (deep-review-*.md and kin) are
@@ -70,6 +83,48 @@ def tracked(pathspec):
     return [line for line in out.splitlines() if line]
 
 
+def _individually_classified_rows_section():
+    """Return ``(sentence, table_rows)`` for the duplication register's
+    "## Individually classified rows" section.
+
+    ``sentence`` is the prose line immediately preceding the table (skipping blank
+    lines). ``table_rows`` is one list of stripped cells per data row — the header
+    row (``| Pair | ... |``) and the separator row (``| --- | ... |``) are excluded.
+    The section is bounded below by the next ``## `` heading, so a later table
+    (e.g. "## Grouped patterns") is never mixed in.
+    """
+    text = (REPO / "docs" / "duplication-register.md").read_text()
+    lines = text.splitlines()
+    start = next(
+        i
+        for i, line in enumerate(lines)
+        if line.strip() == "## Individually classified rows"
+    )
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")),
+        len(lines),
+    )
+
+    sentence = None
+    in_table = False
+    table_rows = []
+    for line in lines[start + 1 : end]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("| Pair"):
+            in_table = True
+            continue
+        if in_table and stripped.startswith("| ---"):
+            continue
+        if in_table and stripped.startswith("|"):
+            table_rows.append([cell.strip() for cell in stripped.strip("|").split("|")])
+            continue
+        if sentence is None and not in_table:
+            sentence = stripped
+    return sentence, table_rows
+
+
 class TestDocsRegistry(unittest.TestCase):
     def test_every_tracked_docs_file_is_allowlisted(self):
         offenders = []
@@ -97,6 +152,65 @@ class TestDocsRegistry(unittest.TestCase):
             f"tracked root-level markdown outside the allowlist: {offenders}. "
             f"Review-run outputs stay untracked (gitignored). {POLICY}",
         )
+
+    def test_duplication_register_row_count_sentence_matches_table(self):
+        """The sentence above the "Individually classified rows" table (e.g.
+        "Forty rows: 30 `intentional-and-documented`, 10
+        `intentional-but-undocumented`.") must state the table's real total and
+        the real count for every classification the table actually contains — a
+        row added without updating the sentence is exactly the kind of drift this
+        guards against.
+
+        Tolerant of the classification set: only the counts the sentence names are
+        checked against the table, and the table's classifications must each be
+        named — an unnamed classification, not a fixed vocabulary, is the failure.
+        """
+        sentence, table_rows = _individually_classified_rows_section()
+        self.assertIsNotNone(sentence, "no row-count sentence found above the table")
+        self.assertTrue(table_rows, "no data rows found in the table")
+
+        table_counts = {}
+        for cells in table_rows:
+            classification = cells[1]
+            table_counts[classification] = table_counts.get(classification, 0) + 1
+        table_total = len(table_rows)
+
+        word_match = re.match(r"^([A-Za-z-]+) rows:", sentence)
+        self.assertIsNotNone(
+            word_match, f"sentence does not start with '<Word> rows:': {sentence!r}"
+        )
+        word = word_match.group(1).lower()
+        self.assertIn(
+            word,
+            _WORD_TO_NUMBER,
+            f"{word!r} is not a recognized spelled-out number 30-50: {sentence!r}",
+        )
+        sentence_total = _WORD_TO_NUMBER[word]
+
+        sentence_counts = {
+            classification: int(count)
+            for count, classification in re.findall(r"(\d+) `([\w-]+)`", sentence)
+        }
+
+        self.assertEqual(
+            sentence_total,
+            table_total,
+            f"sentence claims {sentence_total} rows ({word!r}) but the table has "
+            f"{table_total}: {sentence!r}",
+        )
+        self.assertEqual(
+            set(table_counts),
+            set(sentence_counts) & set(table_counts),
+            "sentence is missing a classification present in the table: "
+            f"table has {sorted(table_counts)}, sentence names {sorted(sentence_counts)}",
+        )
+        for classification, count in table_counts.items():
+            self.assertEqual(
+                sentence_counts.get(classification),
+                count,
+                f"sentence says {sentence_counts.get(classification)!r} "
+                f"`{classification}` rows but the table has {count}",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_post_review.py
+++ b/tests/test_post_review.py
@@ -4,7 +4,8 @@ Tests for scripts/post_review.py
 Covers:
   - detect_platform: GitHub SSH, GitHub HTTPS, GitLab SSH, GitLab HTTPS,
     unknown host, malformed URL
-  - parse_diff_lines: (post_review version) same diff parsing as verify_findings
+  - parse_diff_lines: (post_review version) platform header semantics over the shared
+    diff_lines.walk_diff
   - is_line_valid: exact match, stripped path, None valid_lines
   - render_comment_body: all severity emojis, with/without suggestion block
   - build_footer: metadata JSON in HTML comment
@@ -5505,6 +5506,132 @@ class TestParseDiffLinesLineTexts(unittest.TestCase):
         valid_lines, _, _, line_texts = parse_diff_lines("bitbucket", "o", "r", 1)
         self.assertIsNone(valid_lines)
         self.assertIsNone(line_texts)
+
+
+class TestParseDiffLinesHeaderDecoding(unittest.TestCase):
+    """``parse_diff_lines`` now walks headers through ``diff_lines.walk_diff``, which
+    undoes git's wire spelling of a header path (the TAB terminator after a path
+    containing a space, and C-quoting of control/non-ASCII bytes) BEFORE this module's
+    platform-specific ``a/``/``b/`` prefix strip runs.
+
+    Pre-migration, the hand-rolled regexes (``^--- (?:a/)?(.+)$`` and friends) captured
+    everything up to end-of-line verbatim: a trailing TAB stayed part of the key, and a
+    C-quoted path stayed a literal quoted-and-escaped string that no finding could ever
+    name. Cases (a), (b) and (d) below reproduce exactly that failure — each is reasoned
+    through against the pre-migration regex in its own docstring, and was confirmed to
+    fail by running it against ``git show origin/main:scripts/post_review.py``. Case (c)
+    does not regress under the old code (GitLab's header regex never stripped a prefix),
+    but pins the platform split itself — the direct regression test for "make the prefix
+    strip unconditional for GitLab too". It pins BOTH sides (an ``a/``- and a ``b/``-rooted
+    real directory each survive on their own file) and BOTH mappings the walk feeds
+    (``old_paths`` for the old side, ``line_texts`` for the new side), keyed
+    independently — the failure mode a shared walk could introduce is an unconditional
+    strip landing on only one side or only one mapping while the other still looks correct.
+    """
+
+    def _parse(self, diff, platform="github"):
+        with patch("scripts.post_review.run_api", return_value=(diff, "", 0)):
+            return parse_diff_lines(platform, "o", "r", 1)
+
+    def test_github_path_with_a_space_decodes_past_the_tab_terminator(self):
+        """git appends a TAB after a header path containing a space, so the field
+        does not run into the classic timestamp column.
+
+        Pre-migration: ``(?:a/)?(.+)$`` is greedy to end-of-line, so ``group(1)``
+        keeps the trailing ``"\\t"`` and the key lands as
+        ``("dir with space/x.py\\t", 1)`` — nothing a finding names ever matches it.
+        """
+        diff = (
+            "--- a/dir with space/x.py\t\n"
+            "+++ b/dir with space/x.py\t\n"
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+        valid_lines, _, _, _ = self._parse(diff, platform="github")
+        self.assertIn(("dir with space/x.py", 1), valid_lines)
+        self.assertNotIn(("dir with space/x.py\t", 1), valid_lines)
+
+    def test_github_c_quoted_non_ascii_path_decodes_then_strips_the_prefix(self):
+        """A non-ASCII path is C-quoted with the octal-escaped UTF-8 bytes; the
+        synthetic ``b/`` prefix sits INSIDE the quotes, so it must be stripped
+        AFTER decoding, not matched against the raw quoted text.
+
+        Pre-migration: the line does not start with ``b/`` (it starts with ``"``),
+        so ``(?:b/)?`` matches nothing and ``group(1)`` is the literal
+        ``'"b/caf\\\\303\\\\251.py"'`` — quotes, backslashes and octal digits as
+        themselves. The key that lands is that literal string, not ``café.py``.
+        """
+        diff = (
+            '--- "a/caf\\303\\251.py"\n'
+            '+++ "b/caf\\303\\251.py"\n'
+            "@@ -1 +1 @@\n"
+            "-old\n"
+            "+new\n"
+        )
+        valid_lines, _, _, _ = self._parse(diff, platform="github")
+        self.assertIn(("café.py", 1), valid_lines)
+
+    def test_gitlab_keeps_real_a_and_b_slash_directories(self):
+        """``glab mr diff`` writes paths verbatim: a leading ``a/`` OR ``b/`` there is a
+        real top-level directory, not git's synthetic prefix, so both must survive the
+        header decode and the (github-only) prefix strip. The old side is pinned through
+        ``old_paths``, the new side through ``valid_lines`` AND ``line_texts`` — the two
+        mappings are keyed independently."""
+        diff = (
+            "--- a/real/x.py\n+++ a/real/x.py\n@@ -1 +1 @@\n-old\n+new\n"
+            "--- b/real/y.py\n+++ b/real/y.py\n@@ -1 +1 @@\n-old\n+fresh\n"
+        )
+        valid_lines, _, old_paths, line_texts = self._parse(diff, platform="gitlab")
+        self.assertEqual(set(valid_lines), {("a/real/x.py", 1), ("b/real/y.py", 1)})
+        self.assertEqual(
+            old_paths, {"a/real/x.py": "a/real/x.py", "b/real/y.py": "b/real/y.py"}
+        )
+        self.assertEqual(line_texts[("a/real/x.py", 1)], "new")
+        self.assertEqual(line_texts[("b/real/y.py", 1)], "fresh")
+
+    def test_a_body_line_before_any_file_header_is_not_recorded(self):
+        """`current_file` is None until a `+++` header names one; a line read before that
+        has no path to key on and must record nothing."""
+        valid_lines, _, _, line_texts = self._parse("@@ -0,0 +1 @@\n+orphan\n")
+        self.assertEqual(valid_lines, {})
+        self.assertEqual(line_texts, {})
+
+    def test_gitlab_quoted_path_is_decoded_like_gits_wire_spelling(self):
+        """This pins a documented choice, not a requirement: the header decode in
+        ``diff_lines._decode_header_path`` runs on every producer, including GitLab's
+        verbatim-path ``glab mr diff`` output. So a literal quote-wrapped name in a
+        GitLab diff — which ``glab`` would never itself need to quote, but which this
+        walk cannot distinguish from git's own C-quoting — is decoded the same way a
+        real git wire-spelling would be. See the accepted-limitation note in
+        ``_decode_header_path``'s docstring for why this is not fixed."""
+        diff = '--- "notes"\n+++ "notes"\n@@ -1 +1,2 @@\n c\n+z\n'
+        valid_lines, _, _, _ = self._parse(diff, platform="gitlab")
+        self.assertIn(("notes", 1), valid_lines)
+
+    def test_github_renamed_file_old_path_is_decoded_before_recording(self):
+        """A rename's ``---`` header names the pre-rename path, recorded in
+        ``old_paths`` under the NEW path's key. Quoted, that pre-rename path must be
+        decoded — GitLab's ``position.old_path`` (#130) is a real filesystem path,
+        not git's C-quoted wire spelling of one.
+
+        Pre-migration: the old-side line does not start with ``a/`` (it starts with
+        ``"``), so the captured, un-decoded literal ``'"a/caf\\\\303\\\\251
+        old.py"'`` is what ``old_paths`` would carry — never a path the pre-rename
+        file actually had.
+        """
+        diff = (
+            'diff --git "a/caf\\303\\251 old.py" b/new.py\n'
+            "similarity index 100%\n"
+            'rename from "caf\\303\\251 old.py"\n'
+            "rename to new.py\n"
+            '--- "a/caf\\303\\251 old.py"\n'
+            "+++ b/new.py\n"
+            "@@ -1 +1 @@\n"
+            " ctx\n"
+        )
+        _, _, old_paths, _ = self._parse(diff, platform="github")
+        self.assertEqual(old_paths, {"new.py": "café old.py"})
 
 
 class TestSuggestedFixGate(unittest.TestCase):


### PR DESCRIPTION
Closes #163. Follow-up to #134; prerequisite for #226 (the walker now carries line text).

## What changes

- `scripts/diff_lines.py`: `DiffEvent` gains `text` — the body line with its marker column removed (`raw[1:]` for `+`/`-` lines; a context line loses its leading space only when it has one, so a zero-prefixed bare line is passed through whole). Removed lines carry text too: the walk stays lossless.
- `scripts/post_review.py::parse_diff_lines`: the hand-rolled split/regex/budget loop is gone; it reads `walk_diff` events and keeps only its platform header semantics (GitHub `a/`/`b/` strip, GitLab verbatim, `/dev/null`, the `@@ -0,0` added-file signal, `new_files`/`old_paths`). Signature and the four-value return are unchanged.
- `docs/duplication-register.md`: the `parse_diff_lines` row is removed; the count sentence is corrected (it was already stale: 40 rows at HEAD, not 39) and a new mechanism test in `tests/test_docs_registry.py` keeps it honest. One row added for the remaining `is_line_valid` ↔ `is_line_in_diff` shard.

## Proof obligation (from the issue)

The pre-existing `tests/test_post_review.py` suite passes **unchanged** (the diff to that file is pure addition: 0 deleted lines). `tests/test_diff_lines.py`'s whole-stream assertions gain `text=`; the glab fixture contract and GitLab position suites pass as before.

A reviewer ran a differential harness (HEAD vs branch, same process, 53 hand-built input classes + the four glab fixtures + 240k random diffs with and without a trailing newline). Exactly two divergence classes exist, both fixes, both named in the docstring:

1. Header paths arrive **decoded** (git's TAB terminator after a path containing a space, and C-quoting for non-ASCII/control characters). A finding on `dir with space/x.py` or `café.py` previously matched nothing; it now anchors. The decode also runs on `glab mr diff`'s verbatim paths, where it mis-reads only a name that itself carries a literal TAB or is quote-wrapped — documented as an accepted limitation in `_decode_header_path` and pinned by a test so the choice is visible.
2. A newline-terminated diff whose last hunk is cut short no longer mints a phantom final line (the old loop walked the trailing empty string as a context line, which would also have fed the apply-check an empty, false content oracle).

## Validation

- `python -m pytest tests/ -q`: 1559 passed. `pre-commit run --all-files`: clean. Scripts coverage 93.41% (floor 92.5).
- Two adversarial review rounds (3 opus lenses in isolated tree copies, then a fix pass). Mutation ledger, each red on the named test and restored byte-exact: unconditional `b/` strip on GitLab; unconditional `a/` strip; `line_texts` keyed on the stripped spelling; `current_file` guard dropped; context-line slice made unconditional; removed-line text dropped; `text` forced to `None`; `@@ -0,0` signal dropped; register count sentence falsified.

## Measurement note

Suites-only per the wave rule. Recall-relevant delta for the wave-end paired mini: findings on paths with spaces or non-ASCII names now anchor inline on both platforms where they previously degraded to the summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGDENPwjcBSjNTp3GgjFe3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub/GitLab diffs are parsed for inline comment positions and suggested-fix text. Wrong parsing would mis-anchor or drop review comments, but the public return shape is unchanged and existing poster tests are preserved.
> 
> **Overview**
> Finishes consolidating the poster's unified-diff walk onto `diff_lines.walk_diff`. `parse_diff_lines` now consumes walker events and keeps only platform header semantics (GitHub `a/`/`b/` strip, GitLab verbatim paths, `/dev/null`, added-file `@@ -0,0`).
> 
> `DiffEvent` now carries `text` (marker column stripped, including removed lines) so the poster can fill `line_texts` without a second parse. Two real fixes come with the switch: git TAB/C-quoted header paths decode before matching, so findings on spaced or non-ASCII names can anchor; a trailing empty split no longer mints a phantom last line.
> 
> The duplication register drops the accidental `parse_diff_lines` pair, records the remaining `is_line_valid`/`is_line_in_diff` helpers, and a new docs-registry test keeps the row-count sentence in sync. Existing `test_post_review` cases are unchanged; new tests pin header decoding and line-text rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ab4f17e1c13a2184a2745935c0595bf8a95036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->