### PR TITLE
refactor(agents): generate dispatch-requirement contract sentences from the registry (#238)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         if: matrix.python-version == '3.12'
         run: |
           COVERAGE_FILE="$(mktemp -d)/.coverage" python -m pytest tests/ -q \
-            --cov=scripts --cov=.github --cov-fail-under=92.7
+            --cov=scripts --cov=.github --cov-fail-under=92.9
 
   js-lint:
     name: Run Workflow JS Lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ repo tree (an in-tree data file trips the bench plugin-mutation guard):
 
 ```bash
 COVERAGE_FILE="$(mktemp -d)/.coverage" python -m pytest tests/ -q \
-  --cov=scripts --cov=.github --cov-fail-under=92.7
+  --cov=scripts --cov=.github --cov-fail-under=92.9
 
 COVERAGE_FILE="$(mktemp -d)/.coverage" python -m pytest bench/tests/ -q \
   --cov=bench --cov-fail-under=87.5
@@ -73,9 +73,9 @@ LCOV="$(mktemp -d)/js-coverage.lcov" && node --test --experimental-test-coverage
   && node workflows/test/tools/check_coverage_presence.mjs "$LCOV"
 ```
 
-Floors: Python 92.7 / 87.5 (scripts raised 2026-08-19 from the #219 PR CI measurement:
-93.37, then 2026-08-24 to 92.6 from the #231 PR CI measurement: 93.54, and again 2026-08-24 to
-92.7 from the #236 PR CI measurement: 93.67; bench raised 2026-08-19 from the #219 run:
+Floors: Python 92.9 / 87.5 (scripts raised 2026-08-19 from the #219 PR CI measurement:
+93.37, then 2026-08-24 to 92.6 (#231: 93.54), to 92.7 (#236: 93.67), and 2026-08-25 to 92.9
+(#238: 93.91); bench raised 2026-08-19 from the #219 run:
 88.29); JS 98 / 85.7 / 97.4 (lines pinned
 2026-08-03 from first green CI: 98.61; branches/functions raised 2026-08-18
 from the #62 PR measurement: 86.7/98.4). Policy: a floor sits no more than 1.0 pp below the CI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ LCOV="$(mktemp -d)/js-coverage.lcov" && node --test --experimental-test-coverage
 
 Floors: Python 92.9 / 87.5 (scripts raised 2026-08-19 from the #219 PR CI measurement:
 93.37, then 2026-08-24 to 92.6 (#231: 93.54), to 92.7 (#236: 93.67), and 2026-08-25 to 92.9
-(#238: 93.91); bench raised 2026-08-19 from the #219 run:
+(#238: 93.84); bench raised 2026-08-19 from the #219 run:
 88.29); JS 98 / 85.7 / 97.4 (lines pinned
 2026-08-03 from first green CI: 98.61; branches/functions raised 2026-08-18
 from the #62 PR measurement: 86.7/98.4). Policy: a floor sits no more than 1.0 pp below the CI

--- a/agents/code-simplifier.md
+++ b/agents/code-simplifier.md
@@ -199,7 +199,9 @@ Each finding is a JSON object with this shape:
 {"id": "simplify-<n>", "dimension": "simplification", "severity": "<high|medium|low>", "confidence": <0-100>, "file": "<path>", "line_start": <number>, "line_end": <number>, "title": "<one-line summary>", "description": "<single-paragraph prose explaining why the current code is harder to read than it needs to be; inline single-line before/after illustrations OK, no fenced code blocks, no multi-line snippets>", "evidence": "<specific code or context that supports this finding>", "suggestion": "<concrete simplification — must include before and after code snippets>", "suggested_fix_code": "<exact replacement source for lines line_start..line_end of file — complete lines, byte-exact including indentation, no ellipsis or placeholders; emitting this REQUIRES line_end (set line_end == line_start for a single-line fix): the block replaces exactly those lines. OMIT this field entirely unless the replacement is a complete, correct, drop-in substitute for exactly those lines — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "behavior_preserved": "<confirmation that the simplification does not change behavior, or 'uncertain' if you cannot confirm>", "claude_md_rule": "<the documented project rule this finding violates, quoted with its source file (CLAUDE.md/REVIEW.md/AGENTS.md). OMIT this field entirely when no documented rule applies — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "cross_file_refs": ["<other files involved in this finding>"]}
 ```
 
+<!-- generated-from-registry: do not edit; scripts/generate_contract_requirements.py -->
 `behavior_preserved` is required by the dispatch schema — a finding without it is rejected at the StructuredOutput boundary and retried, so it must always be present.
+<!-- /generated-from-registry -->
 
 **Example:**
 

--- a/agents/conventions-and-intent.md
+++ b/agents/conventions-and-intent.md
@@ -269,9 +269,11 @@ Real violation — CLAUDE.md requires structured logging with error_id but handl
 [investigation of function naming convention — follows project pattern correctly]
 SKIP: function naming in utils.py — uses snake_case per CLAUDE.md section 3; no violation.
 
+<!-- generated-from-registry: do not edit; scripts/generate_contract_requirements.py -->
 For convention findings: the `claude_md_rule` field MUST be non-null and MUST quote the specific rule. Findings without a cited rule will be rejected. `claude_md_rule` is a dimension-conditional dispatch requirement. On a dispatch that targets the first-party API directly (no third-party provider, no gateway), the schema enforces it specifically for findings whose dimension is convention — sibling intent/comment_accuracy findings correctly omit it — and this contract is the enforcement floor on every run, including third-party providers and gateway sessions where the schema stays flat. This agent's dispatch mixes convention, intent, and comment_accuracy findings in ONE schema, so a dimension-blind schema requirement (the flat `requiredExtra` mechanism, which only single-dimension agents can use) was never an option here — omitting the field on the wrong dimension is correct while omitting it on this one is a contract violation.
 
 For intent findings: the `spec_text` field MUST be non-null and MUST quote the specific spec text. Findings without a cited spec will be rejected. `spec_text` is a dimension-conditional dispatch requirement, on the same terms as claude_md_rule above: enforced by the schema for findings whose dimension is intent only on a first-party-direct dispatch, and by this contract as the floor everywhere else — omitting the field on the wrong dimension is correct while omitting it on this one is a contract violation.
+<!-- /generated-from-registry -->
 
 Only report findings with confidence >= 60. Be thorough but filter aggressively — quality over quantity. If you find no issues above the threshold, return an empty findings list.
 

--- a/agents/cross-file-impact.md
+++ b/agents/cross-file-impact.md
@@ -196,7 +196,9 @@ Each finding is a JSON object with this shape:
 {"id": "cross-file-<n>", "dimension": "cross_file_impact", "severity": "<critical|high|medium|low>", "confidence": <0-100>, "file": "<path of the changed file causing the impact>", "line_start": <number>, "line_end": <number>, "title": "<one-line summary>", "description": "<single-paragraph prose explaining what breaks and why — no code blocks, no multi-line snippets; affected files go in affected_consumers and cross_file_refs>", "evidence": "<specific code or context that supports this finding>", "suggestion": "<concrete fix — update the caller, implementor, or dependent>", "suggested_fix_code": "<exact replacement source for lines line_start..line_end of file — complete lines, byte-exact including indentation, no ellipsis or placeholders; emitting this REQUIRES line_end (set line_end == line_start for a single-line fix): the block replaces exactly those lines. OMIT this field entirely unless the replacement is a complete, correct, drop-in substitute for exactly those lines — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "affected_consumers": ["<file paths of callers, implementors, or consumers that break>"], "claude_md_rule": "<the documented project rule this finding violates, quoted with its source file (CLAUDE.md/REVIEW.md/AGENTS.md). OMIT this field entirely when no documented rule applies — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "cross_file_refs": ["<other files involved in this finding>"]}
 ```
 
+<!-- generated-from-registry: do not edit; scripts/generate_contract_requirements.py -->
 `affected_consumers` is required by the dispatch schema — a finding without it is rejected at the StructuredOutput boundary and retried, so it must always be present.
+<!-- /generated-from-registry -->
 
 **Example:**
 

--- a/agents/security-reviewer.md
+++ b/agents/security-reviewer.md
@@ -240,7 +240,9 @@ Each finding is a JSON object with this shape:
 {"id": "security-<n>", "dimension": "security", "severity": "<critical|high|medium|low>", "confidence": <0-100>, "file": "<path>", "line_start": <number>, "line_end": <number>, "title": "<one-line summary>", "description": "<single-paragraph prose explaining the vulnerability and attack vector — no code blocks, no multi-line snippets; use the attack_vector field for the step-by-step exploit>", "evidence": "<specific code or context that supports this finding>", "suggestion": "<concrete fix or improvement>", "suggested_fix_code": "<exact replacement source for lines line_start..line_end of file — complete lines, byte-exact including indentation, no ellipsis or placeholders; emitting this REQUIRES line_end (set line_end == line_start for a single-line fix): the block replaces exactly those lines. OMIT this field entirely unless the replacement is a complete, correct, drop-in substitute for exactly those lines — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "attack_vector": "<step-by-step description of how an attacker exploits this>", "claude_md_rule": "<the documented project rule this finding violates, quoted with its source file (CLAUDE.md/REVIEW.md/AGENTS.md). OMIT this field entirely when no documented rule applies — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "cross_file_refs": ["<other files involved in this finding>"]}
 ```
 
+<!-- generated-from-registry: do not edit; scripts/generate_contract_requirements.py -->
 `attack_vector` is required by the dispatch schema — a finding without it is rejected at the StructuredOutput boundary and retried, so it must always be present.
+<!-- /generated-from-registry -->
 
 **Example:**
 

--- a/agents/test-analyzer.md
+++ b/agents/test-analyzer.md
@@ -180,7 +180,9 @@ Each finding is a JSON object with this shape:
 {"id": "test-<n>", "dimension": "test_coverage", "severity": "<critical|high|medium|low>", "criticality": <1-10>, "confidence": <0-100>, "file": "<path of the production file with the untested behavior>", "line_start": <number>, "line_end": <number>, "title": "<one-line summary of the coverage gap>", "description": "<single-paragraph prose explaining what behavior is untested and why it matters — no code blocks, no multi-line snippets>", "evidence": "<specific code or context that shows the gap>", "suggestion": "<concrete test case or scenario to add, with example if helpful>", "suggested_fix_code": "<exact replacement source for lines line_start..line_end of file — complete lines, byte-exact including indentation, no ellipsis or placeholders; emitting this REQUIRES line_end (set line_end == line_start for a single-line fix): the block replaces exactly those lines. OMIT this field entirely unless the replacement is a complete, correct, drop-in substitute for exactly those lines — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "failure_scenario": "<concrete example of a bug this test gap would fail to catch>", "claude_md_rule": "<the documented project rule this finding violates, quoted with its source file (CLAUDE.md/REVIEW.md/AGENTS.md). OMIT this field entirely when no documented rule applies — never emit null (the dispatch schema types it string, and a null burns structured-output retries)>", "cross_file_refs": ["<test files or related files involved in this finding>"]}
 ```
 
-`criticality` and `failure_scenario` are required by the dispatch schema — a finding without either is rejected at the StructuredOutput boundary and retried, so both must always be present.
+<!-- generated-from-registry: do not edit; scripts/generate_contract_requirements.py -->
+`criticality` and `failure_scenario` are required by the dispatch schema — a finding missing any of them is rejected at the StructuredOutput boundary and retried, so all must always be present.
+<!-- /generated-from-registry -->
 
 **Example:**
 

--- a/scripts/generate_contract_requirements.py
+++ b/scripts/generate_contract_requirements.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Generate the dispatch-requirement sentences in agent contracts from the registry.
+
+WHY THIS EXISTS — issue #238.
+
+`workflows/src/registry.js` is the single authority for which fields are dispatch-required
+(`requiredExtra`, unconditional) or dimension-conditionally required (`requiredWhenDimension`).
+Before this script, the English sentences telling each agent's model about that requirement
+were hand-written prose in `agents/*.md`, kept honest only by a pytest equality test that
+diffed the prose against the registry. That is the shape this repo's own design rule forbids
+("Add more text" is a design smell) applied to itself: the registry could grow a new required
+field and nothing would force the matching sentence to exist except a test someone had to run.
+
+This script closes the loop the way `scripts/sync_agent_rules.py` closes AGENTS.md ⇄ CLAUDE.md:
+the registry is the source, the sentences are a generated, marker-fenced block, and a freshness
+test runs this script in `--check` mode so drift fails the build instead of a hand-authored
+lockstep comparison.
+
+Two anchor phrases are machine-parsed elsewhere (see `docs/machine-parsed-strings.md` and
+`tests/test_dimensions_registry.py`): "required by the dispatch schema" (requiredExtra sense)
+and "dimension-conditional dispatch requirement" (requiredWhenDimension sense). Both are baked
+into the templates below verbatim — changing their wording here is changing the contract.
+
+Usage:
+    python3 scripts/generate_contract_requirements.py           # write the generated blocks
+    python3 scripts/generate_contract_requirements.py --check   # exit 1 if any target is stale
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+MARKER_OPEN = (
+    "<!-- generated-from-registry: do not edit; "
+    "scripts/generate_contract_requirements.py -->"
+)
+MARKER_CLOSE = "<!-- /generated-from-registry -->"
+
+REPORT_FORMAT_REL = "skills/code-gauntlet/references/report-format.md"
+
+# English phrasing for fields that carry a dimension-conditional requirement. Not derivable
+# from the registry (it has no room for prose nouns) — kept as the one small hand-authored
+# table the templates below parameterize on.
+_CONDITIONAL_NOUNS = {
+    "claude_md_rule": ("rule", "rule"),
+    "spec_text": ("spec text", "spec"),
+}
+
+
+def load_registry(repo_root=REPO_ROOT):
+    """The live schema declaration, imported from the ESM source (mirrors the test helper)."""
+    node_src = (
+        "const t = v => typeof v === 'string' ? v : v.type;"
+        "import('./workflows/src/registry.js').then(m => console.log(JSON.stringify({"
+        "  required: m.FINDING_REQUIRED,"
+        "  canonicalFields: Object.keys(m.FINDING_PROP_TYPES),"
+        "  dimensions: m.DIMENSIONS.map(d => ({"
+        "    dimension: d.dimension, agentType: d.agentType,"
+        "    requiredExtra: d.requiredExtra || [],"
+        "    requiredWhenDimension: d.requiredWhenDimension || [],"
+        "    extraFields: Object.keys(d.schemaExtra || {}),"
+        "  })),"
+        "})))"
+    )
+    out = subprocess.run(
+        ["node", "--input-type=module", "-e", node_src],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(out.stdout)
+
+
+def agent_name(agent_type):
+    """'code-gauntlet:bug-detector' -> 'bug-detector'."""
+    return agent_type.split(":", 1)[1]
+
+
+def dispatch_required_sentence(fields):
+    """The requiredExtra-sense sentence for one or more fields on the same agent row.
+
+    Generalized over field count rather than hardcoding either/both wording for exactly
+    two — a third field promoted to requiredExtra must not silently render an ungrammatical
+    (or, worse, a truncated/wrong) sentence.
+    """
+    if len(fields) == 1:
+        return (
+            f"`{fields[0]}` is required by the dispatch schema — a finding without it is "
+            "rejected at the StructuredOutput boundary and retried, so it must always be "
+            "present."
+        )
+    backticked = [f"`{f}`" for f in fields]
+    if len(backticked) == 2:
+        joined = f"{backticked[0]} and {backticked[1]}"
+    else:
+        joined = ", ".join(backticked[:-1]) + f", and {backticked[-1]}"
+    return (
+        f"{joined} are required by the dispatch schema — a finding missing any of them is "
+        "rejected at the StructuredOutput boundary and retried, so all must always be "
+        "present."
+    )
+
+
+def _conditional_paragraph(field, dimension, siblings, all_dims, first_field):
+    noun, noun2 = _CONDITIONAL_NOUNS[field]
+    lead = (
+        f"For {dimension} findings: the `{field}` field MUST be non-null and MUST quote "
+        f"the specific {noun}. Findings without a cited {noun2} will be rejected. "
+        f"`{field}` is a dimension-conditional dispatch requirement"
+    )
+    if field == first_field:
+        sib = "/".join(siblings)
+        dims = ", ".join(all_dims[:-1]) + f", and {all_dims[-1]}"
+        body = (
+            ". On a dispatch that targets the first-party API directly (no third-party "
+            "provider, no gateway), the schema enforces it specifically for findings whose "
+            f"dimension is {dimension} — sibling {sib} findings correctly omit it — and this "
+            "contract is the enforcement floor on every run, including third-party providers "
+            "and gateway sessions where the schema stays flat. This agent's dispatch mixes "
+            f"{dims} findings in ONE schema, so a dimension-blind schema requirement (the flat "
+            "`requiredExtra` mechanism, which only single-dimension agents can use) was never "
+            "an option here — omitting the field on the wrong dimension is correct while "
+            "omitting it on this one is a contract violation."
+        )
+    else:
+        body = (
+            f", on the same terms as {first_field} above: enforced by the schema for findings "
+            f"whose dimension is {dimension} only on a first-party-direct dispatch, and by "
+            "this contract as the floor everywhere else — omitting the field on the wrong "
+            "dimension is correct while omitting it on this one is a contract violation."
+        )
+    return lead + body
+
+
+def conditional_paragraphs(agent_rows):
+    """The dimension-conditional paragraphs for one multi-dimension agent, in row order.
+
+    `agent_rows` is the list of that agentType's DIMENSIONS rows (registry order).
+    """
+    all_dims = [row["dimension"] for row in agent_rows]
+    conditional_fields = [
+        (row["dimension"], field)
+        for row in agent_rows
+        for field in row["requiredWhenDimension"]
+    ]
+    first_field = conditional_fields[0][1] if conditional_fields else None
+    paragraphs = []
+    for dimension, field in conditional_fields:
+        siblings = [d for d in all_dims if d != dimension]
+        paragraphs.append(
+            _conditional_paragraph(field, dimension, siblings, all_dims, first_field)
+        )
+    return paragraphs
+
+
+def wrap_block(body):
+    return f"{MARKER_OPEN}\n{body}\n{MARKER_CLOSE}"
+
+
+_EXISTING_BLOCK = re.compile(
+    re.escape(MARKER_OPEN) + r"\n.*?\n" + re.escape(MARKER_CLOSE), re.DOTALL
+)
+
+# First-run anchors: the hand-written text this script's block replaces the first time it
+# runs on a file that has never been generated. Matched loosely (DOTALL, non-greedy) so a
+# reword before this script existed still gets swallowed into the first generated block.
+_SINGLE_SENTENCE_ANCHOR = re.compile(
+    r"`[a-z_]+`(?: and `[a-z_]+`)? (?:is|are) required by the dispatch schema[^\n]*"
+)
+_CONDITIONAL_ANCHOR = re.compile(
+    r"For convention findings:.*?\n\nFor intent findings:.*?(?=\n\n)", re.DOTALL
+)
+
+
+def splice(text, anchor_re, body):
+    """Replace the existing generated block, or (first run) the anchor text, with `body`.
+
+    Fails loudly rather than silently leaving stale text behind. Two marker counts are
+    checked before anything else: more than one MARKER_OPEN (a second block would be
+    invisible to the single-block regex below and go stale forever) and an OPEN/CLOSE
+    count mismatch (an orphaned marker — hand-edited or typo'd — that would otherwise
+    make a subsequent `--check` call the file current while real debris sits in it).
+    """
+    open_count = text.count(MARKER_OPEN)
+    close_count = text.count(MARKER_CLOSE)
+    if open_count > 1 or open_count != close_count:
+        raise SystemExit(
+            f"malformed generated-block markers ({open_count} open, {close_count} close) "
+            "— expected exactly one matched pair or none; fix by hand before regenerating"
+        )
+    new_block = wrap_block(body)
+    if open_count == 1:
+        replaced, count = _EXISTING_BLOCK.subn(new_block, text, count=1)
+        if count != 1:
+            raise SystemExit("found MARKER_OPEN but block regex did not match")
+        return replaced
+    match = anchor_re.search(text)
+    if not match:
+        raise SystemExit(
+            "no generated block and no recognizable anchor text to replace"
+        )
+    return text[: match.start()] + new_block + text[match.end() :]
+
+
+def single_dimension_targets(registry):
+    """{relative agent path: sentence} for the four single-field/dual-field requiredExtra agents."""
+    targets = {}
+    for row in registry["dimensions"]:
+        fields = row["requiredExtra"]
+        if not fields:
+            continue
+        path = f"agents/{agent_name(row['agentType'])}.md"
+        targets[path] = dispatch_required_sentence(fields)
+    return targets
+
+
+def conventions_and_intent_target(registry):
+    rows = [
+        r
+        for r in registry["dimensions"]
+        if r["agentType"] == "code-gauntlet:conventions-and-intent"
+    ]
+    paragraphs = conditional_paragraphs(rows)
+    return "agents/conventions-and-intent.md", "\n\n".join(paragraphs)
+
+
+def known_fields(registry):
+    """Every field name the registry declares anywhere — canonical or per-dimension."""
+    fields = set(registry["canonicalFields"])
+    for row in registry["dimensions"]:
+        fields.update(row["extraFields"])
+    return fields
+
+
+def field_required_status(field, registry):
+    """'yes' / 'conditional' / 'no' — the tri-state Required column value for `field`."""
+    if field in registry["required"]:
+        return "yes"
+    for row in registry["dimensions"]:
+        if field in row["requiredExtra"]:
+            return "yes"
+    for row in registry["dimensions"]:
+        if field in row["requiredWhenDimension"]:
+            return "conditional"
+    return "no"
+
+
+_CANONICAL_ROW = re.compile(r"^(\| `([a-z_]+)` \| \w+ \| )(yes|no|conditional)( \|.*)$")
+_PERDIM_ROW = re.compile(
+    r"^(\| `([a-z_]+)` \| \w+ \| \w+ \| )(yes|no|conditional)( \|.*)$"
+)
+
+
+def rewrite_required_column(text, registry):
+    """Rewrite only the Required cell of rows whose first cell names a registry-known field."""
+    known = known_fields(registry)
+    out_lines = []
+    for line in text.splitlines():
+        rewritten = line
+        for pattern in (_CANONICAL_ROW, _PERDIM_ROW):
+            m = pattern.match(line)
+            if m:
+                field = m.group(2)
+                if field not in known:
+                    break
+                status = field_required_status(field, registry)
+                rewritten = m.group(1) + status + m.group(4)
+                break
+        out_lines.append(rewritten)
+    text_out = "\n".join(out_lines)
+    if text.endswith("\n"):
+        text_out += "\n"
+    return text_out
+
+
+def compute_targets(repo_root):
+    registry = load_registry(repo_root)
+    targets = {}
+    for rel_path, sentence in single_dimension_targets(registry).items():
+        anchor = _SINGLE_SENTENCE_ANCHOR
+        targets[rel_path] = ("splice", anchor, sentence)
+    ci_path, ci_body = conventions_and_intent_target(registry)
+    targets[ci_path] = ("splice", _CONDITIONAL_ANCHOR, ci_body)
+    targets[REPORT_FORMAT_REL] = ("table", None, registry)
+    return targets
+
+
+def apply_targets(repo_root, check_only=False):
+    stale = []
+    for rel_path, (kind, anchor, payload) in compute_targets(repo_root).items():
+        abs_path = os.path.join(repo_root, rel_path)
+        with open(abs_path, encoding="utf-8") as handle:
+            current = handle.read()
+        if kind == "splice":
+            expected = splice(current, anchor, payload)
+        else:
+            expected = rewrite_required_column(current, payload)
+        if expected == current:
+            continue
+        stale.append(rel_path)
+        if not check_only:
+            with open(abs_path, "w", encoding="utf-8") as handle:
+                handle.write(expected)
+    return stale
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=REPO_ROOT)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report stale generated blocks without writing",
+    )
+    args = parser.parse_args(argv)
+
+    stale = apply_targets(args.repo_root, check_only=args.check)
+    if not stale:
+        print("contract requirement sentences are current")
+        return 0
+    if args.check:
+        sys.stderr.write(
+            f"stale generated contract requirements: {', '.join(stale)}\n"
+            "run: python3 scripts/generate_contract_requirements.py\n"
+        )
+        return 1
+    print(f"regenerated: {', '.join(stale)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/generate_contract_requirements.py
+++ b/scripts/generate_contract_requirements.py
@@ -171,7 +171,8 @@ _EXISTING_BLOCK = re.compile(
 # runs on a file that has never been generated. Matched loosely (DOTALL, non-greedy) so a
 # reword before this script existed still gets swallowed into the first generated block.
 _SINGLE_SENTENCE_ANCHOR = re.compile(
-    r"`[a-z_]+`(?: and `[a-z_]+`)? (?:is|are) required by the dispatch schema[^\n]*"
+    r"`[a-z_]+`(?:, `[a-z_]+`)*(?:,? and `[a-z_]+`)? (?:is|are) required by the dispatch "
+    r"schema[^\n]*"
 )
 _CONDITIONAL_ANCHOR = re.compile(
     r"For convention findings:.*?\n\nFor intent findings:.*?(?=\n\n)", re.DOTALL

--- a/tests/test_dimensions_registry.py
+++ b/tests/test_dimensions_registry.py
@@ -956,45 +956,55 @@ class TestContractSchemaLockstep(unittest.TestCase):
             "whitespace-separated array — the backtracking-prone regex form is back",
         )
 
-    def test_dispatch_required_contract_sentences_match_requiredExtra_exactly(self):
-        # F5, issue #66: bidirectional lockstep between the registry's requiredExtra and the
-        # contract prose sentences claiming a field is dispatch-required.
-        #   forward — every requiredExtra field's owning contract claims it (a promotion in
-        #             registry.js with no matching sentence is undocumented to the model).
-        #   reverse — no OTHER per-dimension field on that row is claimed dispatch-required
-        #             (a stale or bogus claim would tell the model something the schema does
-        #             not enforce).
+    def test_generated_contract_requirements_are_not_stale(self):
+        # issue #238: the requiredExtra/requiredWhenDimension contract sentences (previously
+        # hand-written prose, kept honest by two lockstep equality tests here) are now
+        # GENERATED from the registry by scripts/generate_contract_requirements.py, the same
+        # protocol as scripts/sync_agent_rules.py for the CLAUDE.md twins. Delegating to the
+        # generator's own --check means this test cannot itself drift from what the generator
+        # considers current.
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO / "scripts" / "generate_contract_requirements.py"),
+                "--check",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"generated contract requirement sentences are stale: {result.stderr.strip()}",
+        )
+
+    def test_contract_sentences_match_registry_in_both_directions(self):
+        # Adversarial-review regression on issue #238's freshness test: that test only
+        # diffs the files `generate_contract_requirements.py` itself targets, so a
+        # hand-typed sentence added to a file the generator DOES NOT touch — e.g. an
+        # over-claim like "`hidden_errors` is required by the dispatch schema" pasted into
+        # agents/bug-detector.md, whose registry row has requiredExtra: [] — passes
+        # `--check` and the whole suite silently. This is the equality check the original
+        # #66/#218 lockstep tests ran (deleted when the freshness test was added); restored
+        # here as ONE bidirectional test across every agent so it cannot drift back into
+        # a forward-only or file-scoped guard.
+        #   requiredExtra sense: for every row, contract claims == row's requiredExtra.
+        #   requiredWhenDimension sense: for every agentType, contract claims == the UNION
+        #     of that agentType's rows' requiredWhenDimension (the sentence lives once in
+        #     the shared agent .md file, not per-dimension).
         for row in registry()["dimensions"]:
             name = agent_name(row["agentType"])
             claimed = dispatch_required_claims(name)
             required = set(row["requiredExtra"])
-            extras = set(row["extras"])
-
-            missing = required - claimed
             self.assertEqual(
-                missing,
-                set(),
-                f"agents/{name}.md never says {sorted(missing)} is "
-                f"{_DISPATCH_REQUIRED_PHRASE!r} though registry.js's requiredExtra promotes "
-                "it — add the canonical contract sentence",
+                claimed & set(row["extras"]),
+                required,
+                f"agents/{name}.md's {_DISPATCH_REQUIRED_PHRASE!r} claims for this row's "
+                f"own extras are {sorted(claimed & set(row['extras']))} but registry.js's "
+                f"requiredExtra is {sorted(required)} — add, remove, or correct the "
+                "contract sentence",
             )
 
-            over_claimed = (claimed & extras) - required
-            self.assertEqual(
-                over_claimed,
-                set(),
-                f"agents/{name}.md claims {sorted(over_claimed)} is "
-                f"{_DISPATCH_REQUIRED_PHRASE!r} but registry.js's requiredExtra does not "
-                "promote it — stale contract prose",
-            )
-
-    def test_dimension_conditional_contract_sentences_match_requiredWhenDimension(self):
-        # issue #218, [v3] red-team finding 5: the sibling lockstep for the
-        # dimension-conditional phrase, grouped by AGENT rather than by row — the prose
-        # sentence lives once in the shared agent .md file, not per-dimension, so what it
-        # claims is compared against the UNION of that agentType's rows'
-        # requiredWhenDimension, exactly as the design documents ("fields claimed under it
-        # must equal the union of the agent's rows' requiredWhenDimension").
         by_agent = {}
         for row in registry()["dimensions"]:
             by_agent.setdefault(row["agentType"], set()).update(

--- a/tests/test_generate_contract_requirements.py
+++ b/tests/test_generate_contract_requirements.py
@@ -111,6 +111,24 @@ class TestSplice(unittest.TestCase):
         self.assertNotIn("v1", second)
         self.assertEqual(second.count(gen.MARKER_OPEN), 1)
 
+    def test_anchor_matches_the_generators_own_output_for_every_field_count(self):
+        # A stripped marker block must be recoverable from the sentence the generator
+        # itself wrote — including the Oxford-comma join for three or more fields. Full
+        # equality, not marker presence: an anchor that only matches from the final
+        # backticked field would still splice, leaving the leading field list as debris.
+        for fields in (["a"], ["a", "b"], ["a", "b", "c"], ["a", "b", "c", "d"]):
+            sentence = gen.dispatch_required_sentence(fields)
+            out = gen.splice(
+                f"before\n{sentence}\nafter\n",
+                gen._SINGLE_SENTENCE_ANCHOR,
+                sentence,
+            )
+            self.assertEqual(
+                out,
+                f"before\n{gen.wrap_block(sentence)}\nafter\n",
+                f"anchor mis-spanned the {len(fields)}-field sentence",
+            )
+
     def test_no_anchor_and_no_marker_raises(self):
         with self.assertRaises(SystemExit):
             gen.splice(

--- a/tests/test_generate_contract_requirements.py
+++ b/tests/test_generate_contract_requirements.py
@@ -1,0 +1,338 @@
+"""Unit tests for scripts/generate_contract_requirements.py's pure functions (issue #238).
+
+These exercise the generator in isolation from the live registry: fixture-shaped registry
+dicts and small file fragments, so a regression in the splice/table-rewrite/sentence-render
+logic fails here without needing `node` or the real agent files.
+"""
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+
+from scripts import generate_contract_requirements as gen  # noqa: E402
+
+
+class TestDispatchRequiredSentence(unittest.TestCase):
+    def test_single_field(self):
+        sentence = gen.dispatch_required_sentence(["attack_vector"])
+        self.assertIn("`attack_vector` is required by the dispatch schema", sentence)
+        self.assertIn("it must always be present", sentence)
+
+    def test_two_fields(self):
+        sentence = gen.dispatch_required_sentence(["criticality", "failure_scenario"])
+        self.assertIn(
+            "`criticality` and `failure_scenario` are required by the dispatch schema",
+            sentence,
+        )
+        self.assertIn("all must always be present", sentence)
+
+    def test_three_fields_does_not_render_either_both_wording(self):
+        sentence = gen.dispatch_required_sentence(["a", "b", "c"])
+        self.assertIn("`a`, `b`, and `c` are required by the dispatch schema", sentence)
+        self.assertIn("all must always be present", sentence)
+        self.assertNotIn("either", sentence)
+        self.assertNotIn("both", sentence)
+
+
+class TestConditionalParagraphs(unittest.TestCase):
+    def setUp(self):
+        self.rows = [
+            {"dimension": "convention", "requiredWhenDimension": ["claude_md_rule"]},
+            {"dimension": "intent", "requiredWhenDimension": ["spec_text"]},
+            {"dimension": "comment_accuracy", "requiredWhenDimension": []},
+        ]
+
+    def test_first_field_carries_full_explanation(self):
+        paragraphs = gen.conditional_paragraphs(self.rows)
+        self.assertEqual(len(paragraphs), 2)
+        first = paragraphs[0]
+        self.assertIn("For convention findings:", first)
+        self.assertIn(
+            "`claude_md_rule` is a dimension-conditional dispatch requirement.", first
+        )
+        self.assertIn(
+            "sibling intent/comment_accuracy findings correctly omit it", first
+        )
+        self.assertIn(
+            "convention, intent, and comment_accuracy findings in ONE schema", first
+        )
+
+    def test_second_field_refers_back_to_first(self):
+        paragraphs = gen.conditional_paragraphs(self.rows)
+        second = paragraphs[1]
+        self.assertIn("For intent findings:", second)
+        self.assertIn(
+            "`spec_text` is a dimension-conditional dispatch requirement, on the same terms "
+            "as claude_md_rule above",
+            second,
+        )
+        # The unconditional phrase must never appear as a substring of the conditional one.
+        self.assertNotIn("required by the dispatch schema", second)
+
+    def test_no_conditional_fields_yields_no_paragraphs(self):
+        rows = [{"dimension": "bug", "requiredWhenDimension": []}]
+        self.assertEqual(gen.conditional_paragraphs(rows), [])
+
+
+class TestSplice(unittest.TestCase):
+    def test_first_run_replaces_anchor_text(self):
+        text = (
+            "before\n`x` is required by the dispatch schema — stale wording.\nafter\n"
+        )
+        out = gen.splice(
+            text,
+            gen._SINGLE_SENTENCE_ANCHOR,
+            "`x` is required by the dispatch schema — new wording.",
+        )
+        self.assertIn(gen.MARKER_OPEN, out)
+        self.assertIn(gen.MARKER_CLOSE, out)
+        self.assertIn("new wording", out)
+        self.assertNotIn("stale wording", out)
+        self.assertTrue(out.startswith("before\n"))
+        self.assertTrue(out.endswith("after\n"))
+
+    def test_second_run_replaces_existing_block(self):
+        first = gen.splice(
+            "before\n`x` is required by the dispatch schema — old.\nafter\n",
+            gen._SINGLE_SENTENCE_ANCHOR,
+            "`x` is required by the dispatch schema — v1.",
+        )
+        second = gen.splice(
+            first,
+            gen._SINGLE_SENTENCE_ANCHOR,
+            "`x` is required by the dispatch schema — v2.",
+        )
+        self.assertIn("v2", second)
+        self.assertNotIn("v1", second)
+        self.assertEqual(second.count(gen.MARKER_OPEN), 1)
+
+    def test_no_anchor_and_no_marker_raises(self):
+        with self.assertRaises(SystemExit):
+            gen.splice(
+                "nothing relevant here\n", gen._SINGLE_SENTENCE_ANCHOR, "irrelevant"
+            )
+
+    def test_two_marker_blocks_raises_instead_of_silently_leaving_one_stale(self):
+        text = (
+            f"{gen.MARKER_OPEN}\nfirst\n{gen.MARKER_CLOSE}\n\n"
+            f"{gen.MARKER_OPEN}\nsecond\n{gen.MARKER_CLOSE}\n"
+        )
+        with self.assertRaises(SystemExit):
+            gen.splice(text, gen._SINGLE_SENTENCE_ANCHOR, "new")
+
+    def test_open_without_close_raises(self):
+        text = f"before\n{gen.MARKER_OPEN}\nbody\nafter\n"
+        with self.assertRaises(SystemExit):
+            gen.splice(text, gen._SINGLE_SENTENCE_ANCHOR, "new")
+
+    def test_close_without_open_raises(self):
+        text = f"before\nbody\n{gen.MARKER_CLOSE}\nafter\n"
+        with self.assertRaises(SystemExit):
+            gen.splice(text, gen._SINGLE_SENTENCE_ANCHOR, "new")
+
+    def test_typoed_open_marker_leaves_orphaned_close_and_raises(self):
+        # A hand edit that corrupts the open marker's bytes (a typo) makes `MARKER_OPEN
+        # in text` False, but the real MARKER_CLOSE debris is still there — exactly the
+        # tamper case that used to make a second --check silently call the file current.
+        typoed_open = gen.MARKER_OPEN.replace("do not edit", "do NOT edit")
+        text = f"before\n{typoed_open}\nbody\n{gen.MARKER_CLOSE}\nafter\n"
+        with self.assertRaises(SystemExit):
+            gen.splice(text, gen._SINGLE_SENTENCE_ANCHOR, "new")
+
+
+class TestFieldRequiredStatus(unittest.TestCase):
+    def setUp(self):
+        self.registry = {
+            "required": ["id", "file"],
+            "canonicalFields": ["id", "file", "claude_md_rule"],
+            "dimensions": [
+                {
+                    "dimension": "security",
+                    "requiredExtra": ["attack_vector"],
+                    "requiredWhenDimension": [],
+                    "extraFields": ["attack_vector"],
+                },
+                {
+                    "dimension": "convention",
+                    "requiredExtra": [],
+                    "requiredWhenDimension": ["claude_md_rule"],
+                    "extraFields": [],
+                },
+                {
+                    "dimension": "bug",
+                    "requiredExtra": [],
+                    "requiredWhenDimension": [],
+                    "extraFields": ["hidden_errors"],
+                },
+            ],
+        }
+
+    def test_canonical_required_field_is_yes(self):
+        self.assertEqual(gen.field_required_status("id", self.registry), "yes")
+
+    def test_required_extra_field_is_yes(self):
+        self.assertEqual(
+            gen.field_required_status("attack_vector", self.registry), "yes"
+        )
+
+    def test_required_when_dimension_field_is_conditional(self):
+        self.assertEqual(
+            gen.field_required_status("claude_md_rule", self.registry), "conditional"
+        )
+
+    def test_unlisted_field_is_no(self):
+        self.assertEqual(
+            gen.field_required_status("hidden_errors", self.registry), "no"
+        )
+
+
+class TestRewriteRequiredColumn(unittest.TestCase):
+    def setUp(self):
+        self.registry = {
+            "required": ["id"],
+            "canonicalFields": ["id", "claude_md_rule"],
+            "dimensions": [
+                {
+                    "dimension": "security",
+                    "requiredExtra": ["attack_vector"],
+                    "requiredWhenDimension": [],
+                    "extraFields": ["attack_vector"],
+                },
+                {
+                    "dimension": "convention",
+                    "requiredExtra": [],
+                    "requiredWhenDimension": ["claude_md_rule"],
+                    "extraFields": [],
+                },
+            ],
+        }
+
+    def test_flips_stale_canonical_cell(self):
+        text = "| `claude_md_rule` | string | no | some description |\n"
+        out = gen.rewrite_required_column(text, self.registry)
+        self.assertIn(
+            "| `claude_md_rule` | string | conditional | some description |", out
+        )
+
+    def test_flips_stale_perdim_cell(self):
+        text = "| `attack_vector` | string | security | no | how it's exploited |\n"
+        out = gen.rewrite_required_column(text, self.registry)
+        self.assertIn(
+            "| `attack_vector` | string | security | yes | how it's exploited |", out
+        )
+
+    def test_unknown_field_row_is_left_untouched(self):
+        text = "| `not_a_real_field` | string | yes | made up |\n"
+        out = gen.rewrite_required_column(text, self.registry)
+        self.assertEqual(out, text)
+
+    def test_non_table_lines_are_left_untouched(self):
+        text = "Some prose that isn't a table row at all.\n"
+        self.assertEqual(gen.rewrite_required_column(text, self.registry), text)
+
+    def test_preserves_trailing_newline_absence(self):
+        text = "| `claude_md_rule` | string | no | d |"
+        out = gen.rewrite_required_column(text, self.registry)
+        self.assertFalse(out.endswith("\n"))
+
+
+class TestCliAgainstRealRegistry(unittest.TestCase):
+    """Exercises apply_targets/main's write and --check paths against a throwaway copy."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        root = Path(self.tmp.name)
+        for rel in [
+            *gen.compute_targets(str(REPO)).keys(),
+            "workflows/src/registry.js",
+        ]:
+            src = REPO / rel
+            dst = root / rel
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+        self.root = root
+
+    def test_check_is_clean_on_a_freshly_regenerated_copy(self):
+        gen.apply_targets(str(self.root), check_only=False)
+        self.assertEqual(gen.apply_targets(str(self.root), check_only=True), [])
+
+    def test_write_mode_regenerates_a_hand_edited_sentence(self):
+        target = self.root / "agents" / "security-reviewer.md"
+        target.write_text(
+            target.read_text(encoding="utf-8").replace(
+                "required by the dispatch schema", "SOMETHING ELSE ENTIRELY"
+            ),
+            encoding="utf-8",
+        )
+        stale_before = gen.apply_targets(str(self.root), check_only=True)
+        self.assertIn("agents/security-reviewer.md", stale_before)
+        stale_after_write = gen.apply_targets(str(self.root), check_only=False)
+        self.assertIn("agents/security-reviewer.md", stale_after_write)
+        self.assertEqual(gen.apply_targets(str(self.root), check_only=True), [])
+
+    def test_main_check_mode_exits_nonzero_on_drift(self):
+        target = self.root / "agents" / "code-simplifier.md"
+        target.write_text(
+            target.read_text(encoding="utf-8").replace(
+                "behavior_preserved", "renamed_field"
+            ),
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO / "scripts" / "generate_contract_requirements.py"),
+                "--repo-root",
+                str(self.root),
+                "--check",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("stale generated contract requirements", result.stderr)
+
+    def test_main_write_mode_reports_regeneration_and_then_is_clean(self):
+        target = self.root / "agents" / "test-analyzer.md"
+        target.write_text(
+            target.read_text(encoding="utf-8").replace(
+                "all must always be present", "x"
+            ),
+            encoding="utf-8",
+        )
+        write_result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO / "scripts" / "generate_contract_requirements.py"),
+                "--repo-root",
+                str(self.root),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(write_result.returncode, 0)
+        self.assertIn("regenerated:", write_result.stdout)
+
+        check_result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO / "scripts" / "generate_contract_requirements.py"),
+                "--repo-root",
+                str(self.root),
+                "--check",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(check_result.returncode, 0)
+        self.assertIn("current", check_result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #238 (Wave 5, suites-only).

## What

`workflows/src/registry.js` was already the structural authority for `requiredExtra` and `requiredWhenDimension`; the English contract sentences restating them in `agents/*.md` were hand-written prose held honest by two pytest equality lockstep tests. This PR collapses that to the one-edit shape:

- New `scripts/generate_contract_requirements.py` (stdlib-only) renders those sentences as marker-fenced blocks in `agents/security-reviewer.md`, `cross-file-impact.md`, `test-analyzer.md`, `code-simplifier.md`, and `conventions-and-intent.md`, and rewrites the tri-state `Required` column cells in `skills/code-gauntlet/references/report-format.md`, all from a live import of the registry. Same protocol as `scripts/sync_agent_rules.py`: `--check` mode, freshness enforced by a pytest test that shells out with `--check`.
- First-run output is byte-identical to the prior hand-written prose (only the marker comment lines were added), so shipped agent-prompt wording is unchanged except one sentence: `test-analyzer.md`'s two-field wording generalizes from "without either ... both" to "missing any of them ... all" so the template is correct for any field count.
- The two equality lockstep tests are replaced by the freshness test **plus** a restored bidirectional guard (`test_contract_sentences_match_registry_in_both_directions`) that scans every agent file's anchor-phrase claims against the registry — adversarial review proved the freshness check alone cannot see a hand-typed over-claim in a file the generator never targets (e.g. `bug-detector.md`), which the deleted tests did catch.
- The registry itself, `workflows/`, and the bundle are untouched.

## Decisions of record

- A small `_CONDITIONAL_NOUNS` dict in the generator carries the English noun phrasing ("rule"/"spec text") the registry has no room to declare; a new `requiredWhenDimension` field absent from it fails loudly (KeyError), not silently.
- `splice()` fails closed on marker corruption: more than one generated block, or mismatched open/close marker counts, is a `SystemExit`, mutation-verified along with the freshness and bidirectional tests.
- The in-JSON-block placeholder OMIT texts and the worked examples remain hand-written, still guarded by the kept OMIT-marker lockstep tests; the generated paragraphs are the authoritative sentences per the issue's scope.
- Marker comments ship in agent prompts at ~2 short lines per file; carrying no issue numbers or incident text.

## Validation

- `pytest tests/ -q`: 1713 passed, 642 subtests.
- Scripts coverage 93.91% locally; floor ratcheted 92.7 → 92.9 in AGENTS.md and ci.yml per the >1.0 pp headroom policy (note: 93.91 is the local measurement; if this PR's CI reads materially lower, adjust the floor here per policy).
- `node --test workflows/test/*.test.js`: 890 pass; bundle byte-unchanged.
- `pre-commit run --all-files` green; `sync_agent_rules.py --check` and `generate_contract_requirements.py --check` clean.
- Mutation evidence: prose mutation, Required-cell flip, registry `requiredExtra` addition, deleted marker block, over-claim injection, and splice-corruption cases each drive the relevant check RED.
- Three-agent adversarial review (enforcement loss, generator robustness, repo conventions); all confirmed findings fixed in this PR, none deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbTRxvFWjQkZnEvSykrySi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure and agent-contract documentation only; the workflow registry and pipeline bundle are unchanged, with regression tests guarding generator drift.
> 
> **Overview**
> **Dispatch-required field prose in agent contracts is now generated from `workflows/src/registry.js`**, following the same pattern as `sync_agent_rules.py`: `scripts/generate_contract_requirements.py` writes marker-fenced blocks into five `agents/*.md` files and keeps the tri-state **Required** column in `report-format.md` aligned with the registry. CI freshness is enforced by pytest shelling out to `--check`.
> 
> The old hand-maintained lockstep equality tests are replaced by that freshness check **plus** a restored bidirectional scan so over-claims in agent files the generator does not touch still fail. Unit tests cover sentence rendering, splicing, and table rewrites. **Scripts coverage floor** moves **92.7 → 92.9** in `ci.yml` and `AGENTS.md`. Shipped prompt wording stays the same aside from the marker comments and a generalized two-field sentence in `test-analyzer.md` (“missing any of them … all”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0006452f7a6a41652da94184290fc4c0d55ee8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->