### PR TITLE
fix(ci): pin GitPython 3.1.59 in the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install python-semantic-release
-        run: pip install python-semantic-release==10.6.1
+        # GitPython is pinned because 3.1.60 (2026-08-25) removed
+        # Actor.name_email_regex, which python-semantic-release 10.6.1 reads
+        # (#245). Bump both together after verifying compatibility.
+        run: pip install python-semantic-release==10.6.1 gitpython==3.1.59
 
       - name: Semantic Release
         id: release


### PR DESCRIPTION
Closes #245.

GitPython 3.1.60 (published 2026-08-25T18:33 UTC — between the last green `Semantic Release` run at 16:52 and the first failure at 19:26) removed `Actor.name_email_regex`, which the pinned `python-semantic-release==10.6.1` reads. Every release run on main since then fails with that AttributeError, so the #239 and #240 merges have no cut release.

Reproduced locally in a clean venv: `10.6.1` + GitPython `3.1.60` fails with the exact CI error; `+ gitpython==3.1.59` succeeds and `semantic-release version --print` computes `3.20.1` from the accumulated commits. No newer `python-semantic-release` exists (10.6.1 is latest), so pinning the transitive dependency is the only available direction; the comment in the workflow says to bump both together.

Merging this PR triggers the release job itself, which is the live validation — it should cut v3.20.1 with the accumulated #239/#240/this commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YbTRxvFWjQkZnEvSykrySi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin for the release workflow; no application runtime or security-sensitive logic changes.
> 
> **Overview**
> **Unblocks semantic release on `main`** by pinning **GitPython `3.1.59`** next to the existing **`python-semantic-release==10.6.1`** install in `.github/workflows/release.yml`.
> 
> GitPython **3.1.60** dropped `Actor.name_email_regex`, which **10.6.1** still uses, so unpinned installs were breaking the **Semantic Release** step. A short workflow comment documents the pin and says to bump **both** packages together after compatibility is verified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 769cc339f283f3b3d1f7d497f11de3e7454329a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->