### PR TITLE
feat(validate): structured reachability replaces the validator 65 cap (#115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         if: matrix.python-version == '3.12'
         run: |
           COVERAGE_FILE="$(mktemp -d)/.coverage" python -m pytest tests/ -q \
-            --cov=scripts --cov=.github --cov-fail-under=93.6
+            --cov=scripts --cov=.github --cov-fail-under=93.7
 
   js-lint:
     name: Run Workflow JS Lint
@@ -145,7 +145,7 @@ jobs:
             --test-coverage-include='workflows/src/*.js' \
             --test-coverage-include='workflows/build.js' \
             --test-coverage-lines=98.2 \
-            --test-coverage-branches=88.4 \
+            --test-coverage-branches=88.6 \
             --test-coverage-functions=97.6 \
             --test-reporter=spec --test-reporter-destination=stdout \
             --test-reporter=lcov --test-reporter-destination="$LCOV" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ repo tree (an in-tree data file trips the bench plugin-mutation guard):
 
 ```bash
 COVERAGE_FILE="$(mktemp -d)/.coverage" python -m pytest tests/ -q \
-  --cov=scripts --cov=.github --cov-fail-under=93.6
+  --cov=scripts --cov=.github --cov-fail-under=93.7
 
 COVERAGE_FILE="$(mktemp -d)/.coverage" python -m pytest bench/tests/ -q \
   --cov=bench --cov-fail-under=87.5
@@ -65,7 +65,7 @@ LCOV="$(mktemp -d)/js-coverage.lcov" && node --test --experimental-test-coverage
   --test-coverage-include='workflows/src/*.js' \
   --test-coverage-include='workflows/build.js' \
   --test-coverage-lines=98.2 \
-  --test-coverage-branches=88.4 \
+  --test-coverage-branches=88.6 \
   --test-coverage-functions=97.6 \
   --test-reporter=spec --test-reporter-destination=stdout \
   --test-reporter=lcov --test-reporter-destination="$LCOV" \
@@ -73,11 +73,11 @@ LCOV="$(mktemp -d)/js-coverage.lcov" && node --test --experimental-test-coverage
   && node workflows/test/tools/check_coverage_presence.mjs "$LCOV"
 ```
 
-Floors: Python 93.6 / 87.5 (scripts raised 2026-08-19 from the #219 PR CI measurement:
+Floors: Python 93.7 / 87.5 (scripts raised 2026-08-19 from the #219 PR CI measurement:
 93.37, then 2026-08-24 to 92.6 (#231: 93.54), to 92.7 (#236: 93.67), and 2026-08-25 to 92.9
 (#238: 93.84), and 2026-09-02 to 93.5 (#276 PR CI measurement: 94.52), and 2026-09-03 to 93.6 (#283 PR CI
-measurement: 94.62); bench raised 2026-08-19 from the #219 run:
-88.29); JS 98.2 / 88.4 / 97.6 (lines pinned
+measurement: 94.62), and 2026-09-04 to 93.7 (#285 PR CI measurement: 94.63); bench raised 2026-08-19 from the #219 run:
+88.29); JS 98.2 / 88.6 / 97.6 (lines pinned
 2026-08-03 from first green CI: 98.61; branches/functions raised 2026-08-18
 from the #62 PR measurement: 86.7/98.4, then 2026-08-26 to 98.1/86.3/97.5 from the #249 PR
 CI measurement: 99.01/87.25/98.48, then branches/functions 2026-08-27 to 86.5/97.6 from
@@ -86,7 +86,7 @@ the #255 PR CI measurement: 87.60, then branches 2026-08-31 to 87.0 from the #26
 measurement: 87.99, then lines/branches 2026-08-31 to 98.2/87.3 from the #271 PR CI
 measurement: 99.11/88.21, then branches 2026-09-02 to 88.3 from the #276 PR CI
 measurement: 89.39, then branches 2026-09-03 to 88.4 from the #283 PR CI measurement:
-89.48). Policy: a floor sits no more than 1.0 pp below the CI
+89.48, then branches 2026-09-04 to 88.6 from the #285 PR CI measurement: 89.57). Policy: a floor sits no more than 1.0 pp below the CI
 measurement for that gate; lower a floor only in the PR that causes the drop, with
 the reason in the body; raise when measured headroom exceeds 1.0 pp. A sudden
 multi-point JS drop usually means a deleted fixture group or an unloaded

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,20 +73,10 @@ LCOV="$(mktemp -d)/js-coverage.lcov" && node --test --experimental-test-coverage
   && node workflows/test/tools/check_coverage_presence.mjs "$LCOV"
 ```
 
-Floors: Python 93.7 / 87.5 (scripts raised 2026-08-19 from the #219 PR CI measurement:
-93.37, then 2026-08-24 to 92.6 (#231: 93.54), to 92.7 (#236: 93.67), and 2026-08-25 to 92.9
-(#238: 93.84), and 2026-09-02 to 93.5 (#276 PR CI measurement: 94.52), and 2026-09-03 to 93.6 (#283 PR CI
-measurement: 94.62), and 2026-09-04 to 93.7 (#285 PR CI measurement: 94.63); bench raised 2026-08-19 from the #219 run:
-88.29); JS 98.2 / 88.6 / 97.6 (lines pinned
-2026-08-03 from first green CI: 98.61; branches/functions raised 2026-08-18
-from the #62 PR measurement: 86.7/98.4, then 2026-08-26 to 98.1/86.3/97.5 from the #249 PR
-CI measurement: 99.01/87.25/98.48, then branches/functions 2026-08-27 to 86.5/97.6 from
-the #251 PR CI measurement: 99.02/87.47/98.51, then branches 2026-08-27 to 86.6 from
-the #255 PR CI measurement: 87.60, then branches 2026-08-31 to 87.0 from the #269 PR CI
-measurement: 87.99, then lines/branches 2026-08-31 to 98.2/87.3 from the #271 PR CI
-measurement: 99.11/88.21, then branches 2026-09-02 to 88.3 from the #276 PR CI
-measurement: 89.39, then branches 2026-09-03 to 88.4 from the #283 PR CI measurement:
-89.48, then branches 2026-09-04 to 88.6 from the #285 PR CI measurement: 89.57). Policy: a floor sits no more than 1.0 pp below the CI
+Floors: Python 93.7 / 87.5, JS 98.2 / 88.6 / 97.6. Each floor is pinned from a PR's CI
+measurement, most recently 2026-09-04 from #285 (scripts 94.63, JS branches 89.57); bench
+from #219 (88.29), JS lines from #271 (99.11), JS functions from #251 (98.51). The ratchet
+history is in git. Policy: a floor sits no more than 1.0 pp below the CI
 measurement for that gate; lower a floor only in the PR that causes the drop, with
 the reason in the body; raise when measured headroom exceeds 1.0 pp. A sudden
 multi-point JS drop usually means a deleted fixture group or an unloaded

--- a/agents/validator.md
+++ b/agents/validator.md
@@ -25,7 +25,12 @@ For each finding in your batch:
    - Is there documented intentional behavior that explains the pattern?
    - Are there other callers or entry points that make the assumption valid?
 
-3. **Assess reachability.** Ask: "Can you find a code path that actually triggers this today?" Trace from entry points (public APIs, event handlers, CLI entry points, scheduled jobs) to the flagged location. If the issue is only reachable under hypothetical future changes — a new caller is added, a config value changes, a new code path is introduced — **cap confidence at 65**. Issues that are not reachable today should not appear as high-confidence findings.
+3. **Assess reachability.** Ask: "Can you find a code path that actually triggers this today?" Trace from entry points (public APIs, event handlers, CLI entry points, scheduled jobs) to the flagged location. Return exactly one of these classifications:
+   - `current`: the described defect exists in the code as committed. This includes dead or unused code when the finding is about that code being dead or unused, a wrong type, a missing test, or a misleading comment — anything true of the tree today.
+   - `future_change_only`: the described failure can occur only after a change not in this PR, such as a new caller, changed configuration value, or new code path.
+   - `uncertain`: you could not determine which classification applies.
+
+   Reachability describes whether the claim is true of the tree today, not merely whether a function is called today. A finding about dead code is `current` when the dead-code claim is true.
 
 4. **Use your tools.** Pull surrounding context via Read, Grep, Glob, and LSP to check for defensive patterns, framework guarantees, or type protections. Prefer LSP `findReferences` to check whether a function has callers that trigger the claimed issue, `goToDefinition` to trace what a symbol actually resolves to, and `hover` to verify type claims. Fall back to Grep if LSP is unavailable. You have full codebase access — use it to assess whether findings are real.
 
@@ -40,8 +45,7 @@ Confidence Rubric (use these anchors):
  75  = probably real — no meaningful counter-evidence found
 100  = definitely real — issue is clearly present with no mitigating factors
 
-Note: If the only path to this issue requires a hypothetical future change (new
-caller, changed config, new code path), cap at 65 regardless of the anchor above.
+Reachability is reported separately from confidence; score confidence on the merits of the claim.
 ```
 
 ## What you receive
@@ -87,7 +91,8 @@ Return ONLY a JSON object with a `validations` array, one entry per finding you 
     {
       "finding_id": "<id>",
       "confidence": <0-100>,
-      "justification": "<one-sentence explanation of your assessment>"
+      "justification": "<one-sentence explanation of your assessment>",
+      "reachability": "<current|future_change_only|uncertain>"
     }
   ]
 }

--- a/scripts/apply_validations.py
+++ b/scripts/apply_validations.py
@@ -3,7 +3,8 @@
 apply_validations.py — Phase 5→6 bridge for code-gauntlet.
 
 Reads Phase 4 output (full findings with descriptions intact) from disk,
-applies validator confidence adjustments from a [{id, confidence}] JSON array,
+applies validator adjustments from a [{id, confidence, justification?,
+reachability?}] JSON array,
 and writes the updated findings back to disk.  Descriptions never leave disk —
 this eliminates the orchestrator description-compression that triggered the
 injection filter in the sentry benchmark.
@@ -176,6 +177,8 @@ def apply_validations(findings, validations):
     - Save original_confidence (always set, even when unchanged).
     - Update confidence to the validator's score.
     - Copy justification if present.
+    - Copy reachability when it is one of VALID_REACHABILITY (current,
+      future_change_only, uncertain); any other value is ignored.
 
     Findings without a matching validation pass through unchanged (but do NOT
     get original_confidence set — callers can detect un-validated findings by
@@ -268,7 +271,8 @@ def main():
     parser.add_argument(
         "validations_json",
         help=(
-            "Path to validator output JSON: [{id, confidence, justification?}, ...]."
+            "Path to validator output JSON: [{id, confidence, justification?, "
+            "reachability?}, ...]; reachability is current | future_change_only | uncertain."
         ),
     )
     parser.add_argument(

--- a/scripts/apply_validations.py
+++ b/scripts/apply_validations.py
@@ -33,7 +33,8 @@ Input — validations_json:
     [{
         "id":         "bug-1",        # required
         "confidence": 72,             # required
-        "justification": "..."        # optional — preserved on the finding
+        "justification": "...",       # optional — preserved on the finding
+        "reachability": "current|future_change_only|uncertain"  # optional — known values copied
     }, ...]
     or:
     {"validations": [...]}
@@ -60,6 +61,7 @@ Output JSON:
                                                            new == old)
         "validator_confidence": <score from validations_json>
         "validation_justification": <justification string, if present>
+        "reachability":              <known validator reachability value, if present>
 
 No external Python dependencies — stdlib only.
 """
@@ -72,6 +74,8 @@ from datetime import datetime, timezone
 
 sys.path.insert(0, os.path.dirname(__file__))
 from script_io import write_result
+
+VALID_REACHABILITY = frozenset(("current", "future_change_only", "uncertain"))
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -232,6 +236,10 @@ def apply_validations(findings, validations):
         justification = validation.get("justification")
         if justification:
             finding["validation_justification"] = justification
+
+        reachability = validation.get("reachability")
+        if isinstance(reachability, str) and reachability in VALID_REACHABILITY:
+            finding["reachability"] = reachability
 
         adjusted_count += 1
 

--- a/scripts/filter_findings.py
+++ b/scripts/filter_findings.py
@@ -46,6 +46,7 @@ Output JSON schema:
             "consensus_boosted":       N,   # confidence boosted for co-location (same file + 10-line bucket, any agent)
             "singleton_penalized":     N,   # singleton findings penalized -15 confidence (non-core dims)
             "dimension_routed":        N,   # findings routed to suggestion by dimension (BF-15a)
+            "reachability_demoted":    N,   # findings stamped by reachability demotion
             "cross_agent_consolidated": N,   # cross-agent findings stamped (never dropped) with consolidation_key
             "test_analyzer_promoted":  N,   # test-analyzer findings promoted to main report
             "tagged_main":             N,   # tagged for main report
@@ -72,6 +73,9 @@ Each filtered finding includes:
     # "suggested_fix_code" itself may be absent after filtering -- it is
     # deleted, not nulled, whenever suggested_fix_code_removed_by is present
     # (#63/D8, mirrors the suggestion contract above).
+    "original_severity": <severity before a reachability demotion, when changed>
+    "demoted_by": "reachability"  # present for future_change_only validator findings
+    "demotion_reason": "validator found no code path that reaches this issue without a future change"
 
 REVIEW.md parsing:
     Looks for a fenced code block or YAML-style section containing:
@@ -585,6 +589,40 @@ def apply_threshold_filter(findings, config):
         passed.append(finding)
 
     return passed, eliminated, contested_count
+
+
+# ---------------------------------------------------------------------------
+# Filter: validator reachability demotion
+# ---------------------------------------------------------------------------
+
+
+_REACHABILITY_DEMOTION_REASON = (
+    "validator found no code path that reaches this issue without a future change"
+)
+
+
+def apply_reachability_demotion(findings):
+    """Demote future-change-only findings to low severity without eliminating them.
+
+    Every matching finding receives the reachability stamps, including a finding
+    already at low severity. ``original_severity`` is recorded only when the
+    severity value changes.
+
+    Returns (findings, demoted_count); the input list and its findings are
+    mutated in place.
+    """
+    demoted_count = 0
+    for finding in findings:
+        if finding.get("reachability") != "future_change_only":
+            continue
+        if finding.get("severity") != "low":
+            if "severity" in finding:
+                finding["original_severity"] = finding["severity"]
+            finding["severity"] = "low"
+        finding["demoted_by"] = "reachability"
+        finding["demotion_reason"] = _REACHABILITY_DEMOTION_REASON
+        demoted_count += 1
+    return findings, demoted_count
 
 
 # ---------------------------------------------------------------------------
@@ -1988,13 +2026,16 @@ def tag_findings(findings):
     consolidation_key and one consolidation_primary, chosen by core-dimension,
     then confidence, then description length (see consolidate_cross_agent).
 
-    Step 2 — Dimension-based routing (BF-15a): Check the finding's dimension field
+    Step 2 — Reachability routing: a reachability-demoted finding always routes to
+    suggestion and receives ``routed_by="reachability"``.
+
+    Step 3 — Dimension-based routing (BF-15a): Check the finding's dimension field
     first. Dimensions like bug/security/cross_file_impact/intent always route to main.
     Dimensions like comment_accuracy always route to suggestion. Conditional dimensions
     (test_coverage, convention, type_design) route to suggestion unless functional-
     violation keywords are present.
 
-    Step 3 — Agent-based routing (fallback): If dimension routing returned None
+    Step 4 — Agent-based routing (fallback): If dimension routing returned None
     (unknown or missing dimension), fall back to agent-based rules:
 
       Agent routing:
@@ -2038,42 +2079,46 @@ def tag_findings(findings):
             else set()
         )
 
-        # Step 2: Try dimension-based routing first (BF-15a)
-        dim_route = _route_by_dimension(finding)
-        if dim_route is not None:
-            destination = dim_route
-            if dim_route == "suggestion":
-                finding["routed_by"] = "dimension"
+        # Step 2: Reachability demotion takes precedence over every other route.
+        if finding.get("demoted_by") == "reachability":
+            destination = "suggestion"
+            finding["routed_by"] = "reachability"
         else:
-            # Step 3: Fall back to agent-based routing
-            if agent in _MAIN_REPORT_AGENTS:
-                destination = "main"
-
-            elif agent == _CONVENTIONS_AGENT:
-                # Pass 3 (comment accuracy) -> suggestion; passes 1-2 -> main
-                if dimensions & _COMMENT_ACCURACY_DIMENSIONS:
-                    destination = "suggestion"
-                else:
+            # Step 3: Try dimension-based routing first (BF-15a)
+            dim_route = _route_by_dimension(finding)
+            if dim_route is not None:
+                destination = dim_route
+                if dim_route == "suggestion":
+                    finding["routed_by"] = "dimension"
+            else:
+                # Step 4: Fall back to agent-based routing
+                if agent in _MAIN_REPORT_AGENTS:
                     destination = "main"
 
-            elif agent in _SUGGESTION_AGENTS:
-                if agent == _AGENT_TEST_ANALYZER:
-                    # Promotion rule: functional correctness bugs -> main report
-                    if _is_test_correctness_finding(finding):
+                elif agent == _CONVENTIONS_AGENT:
+                    # Pass 3 (comment accuracy) -> suggestion; passes 1-2 -> main
+                    if dimensions & _COMMENT_ACCURACY_DIMENSIONS:
+                        destination = "suggestion"
+                    else:
                         destination = "main"
-                        finding["promoted_from"] = "test-analyzer"
-                        finding["promotion_reason"] = (
-                            "test-analyzer finding describes a functional correctness issue "
-                            "that exists today (not a missing-coverage gap)"
-                        )
+
+                elif agent in _SUGGESTION_AGENTS:
+                    if agent == _AGENT_TEST_ANALYZER:
+                        # Promotion rule: functional correctness bugs -> main report
+                        if _is_test_correctness_finding(finding):
+                            destination = "main"
+                            finding["promoted_from"] = "test-analyzer"
+                            finding["promotion_reason"] = (
+                                "test-analyzer finding describes a functional correctness issue "
+                                "that exists today (not a missing-coverage gap)"
+                            )
+                        else:
+                            destination = "suggestion"
                     else:
                         destination = "suggestion"
                 else:
-                    destination = "suggestion"
-
-            else:
-                # Unknown agent — conservative fallback: route to main
-                destination = "main"
+                    # Unknown agent — conservative fallback: route to main
+                    destination = "main"
 
         finding["report_destination"] = destination
         finding["report_tag"] = destination  # backward-compat alias
@@ -2279,17 +2324,20 @@ def main():
     # ------------------------------------------------------------------
     all_eliminated = []
 
-    # Step 1: threshold filter (with contestation)
+    # Step 1: reachability demotion (before threshold so the user's severity rule applies)
+    findings, _ = apply_reachability_demotion(findings)
+
+    # Step 2: threshold filter (with contestation)
     findings, elim_threshold, contested_count = apply_threshold_filter(findings, config)
     all_eliminated.extend(elim_threshold)
     passed_threshold = len(findings)
 
-    # Step 2: exclusion filter (before injection so explicit overrides take priority)
+    # Step 3: exclusion filter (before injection so explicit overrides take priority)
     findings, elim_exclusions = apply_exclusions(findings, exclusion_patterns)
     all_eliminated.extend(elim_exclusions)
     exclusions_removed = len(elim_exclusions)
 
-    # Step 3: injection filter
+    # Step 4: injection filter
     findings, elim_injection = apply_injection_filter(findings)
     all_eliminated.extend(elim_injection)
     injections_removed = len(elim_injection)
@@ -2306,11 +2354,11 @@ def main():
         1 for f in findings if f.get("suggested_fix_code_removed_by") == "injection"
     )
 
-    # Step 4: disagreement detection (returns active findings, suppressed, boosted_count)
+    # Step 5: disagreement detection (returns active findings, suppressed, boosted_count)
     findings, elim_suppressed, consensus_boosted = detect_disagreement(findings)
     all_eliminated.extend(elim_suppressed)
 
-    # Step 5: tag for output routing (also applies cross-agent consolidation)
+    # Step 6: tag for output routing (also applies cross-agent consolidation)
     findings, cross_agent_consolidated, tagged_main, tagged_suggestion = tag_findings(
         findings
     )
@@ -2322,6 +2370,9 @@ def main():
 
     # Count dimension-routed and singleton-penalized findings (BF-15)
     dimension_routed = sum(1 for f in findings if f.get("routed_by") == "dimension")
+    reachability_demoted = sum(
+        1 for f in findings + all_eliminated if f.get("demoted_by") == "reachability"
+    )
     singleton_penalized = sum(
         1 for f in findings + all_eliminated if f.get("singleton_penalty")
     )
@@ -2347,6 +2398,7 @@ def main():
             "consensus_boosted": consensus_boosted,
             "singleton_penalized": singleton_penalized,
             "dimension_routed": dimension_routed,
+            "reachability_demoted": reachability_demoted,
             "cross_agent_consolidated": cross_agent_consolidated,
             "test_analyzer_promoted": promoted_count,
             "tagged_main": tagged_main,

--- a/scripts/filter_findings.py
+++ b/scripts/filter_findings.py
@@ -2067,7 +2067,7 @@ def tag_findings(findings):
     # Step 1: Cross-agent consolidation (stamps, never drops -- #22 D1)
     findings, consolidated_count = consolidate_cross_agent(findings)
 
-    # Step 2 & 3: Dimension-based routing, then agent-based fallback
+    # Steps 2, 3 & 4: reachability routing, dimension-based routing, then agent-based fallback
     main_count = 0
     suggestion_count = 0
 
@@ -2320,7 +2320,7 @@ def main():
     exclusion_patterns = config.get("ignore", []) + load_exclusions(args.exclusions_md)
 
     # ------------------------------------------------------------------
-    # Pipeline: threshold -> exclusions -> injection -> disagreement -> tag
+    # Pipeline: reachability demotion -> threshold -> exclusions -> injection -> disagreement -> tag
     # ------------------------------------------------------------------
     all_eliminated = []
 

--- a/scripts/generate_contract_requirements.py
+++ b/scripts/generate_contract_requirements.py
@@ -387,7 +387,12 @@ _TEMPLATE_FIXTURE = {
         },
         {**_TEMPLATE_FINDING, "severity": "high"},
         {**_TEMPLATE_FINDING, "severity": "medium"},
-        {**_TEMPLATE_FINDING, "severity": "low", "report_tag": "suggestion"},
+        {
+            **_TEMPLATE_FINDING,
+            "severity": "low",
+            "report_tag": "suggestion",
+            "demoted_by": "reachability",
+        },
     ],
     "unverified": [
         {

--- a/skills/code-gauntlet/SKILL.md
+++ b/skills/code-gauntlet/SKILL.md
@@ -557,7 +557,7 @@ the post_review-ready wrapper (optionally fill its `review_body`, then pass the 
 legacy bare-array artifact still needs the hand-wrap with `review_body`/`owner`/`repo`/`pr_number`/`sha`
 (always set it). Never re-filter by tag, re-rank, or re-apply the cap yourself. Every finding in that
 payload is posted as a PR comment — suggestions are not a separate delivery destination. The `report_tag`
-is rendered as a Routing bullet; report findings remain grouped by severity
+is rendered as a Routing bullet; reachability-demoted findings are low-severity suggestions and are withheld by `main_only` but included by `all`. Report findings remain grouped by severity
 and, under `main_only`, whether the pipeline already withheld them from the payload. Read
 `references/phase8-delivery.md`, `references/report-format.md`, and `references/delivery-guide.md` for the
 templates and posting mechanics.

--- a/skills/code-gauntlet/references/report-format.md
+++ b/skills/code-gauntlet/references/report-format.md
@@ -174,6 +174,7 @@ Reviewed head `{head_sha_short}` at {generatedAt} by Code Gauntlet.
 - **Location:** `{finding.file}:{finding.line_start}`
 - **Dimension:** {finding.dimension}
 - **Routing:** improvement suggestion
+- **Reachability:** only under a future change (severity demoted to low)
 
 {finding.description}
 

--- a/skills/code-gauntlet/references/validation-pipeline.md
+++ b/skills/code-gauntlet/references/validation-pipeline.md
@@ -60,7 +60,7 @@ Before degrading, a slice gets **exactly one retry** (`VERIFY_ATTEMPTS_PER_SLICE
 
 Independent re-scoring by fresh Sonnet agents — **always Sonnet**. Discovery and validation sharing the same context produces correlated errors ~60% of the time; fresh agents assessing findings independently is what breaks that.
 
-The stage batches findings into `limits.validateBatch` chunks and dispatches one `validator` per batch through `parallel()`. Each validator attempts to **disprove** each finding and returns `[{ id, confidence, justification }]` (confidence 0–100). `applyValidations` merges the adjustments in place (id match, `[0,100]` clamp, `original_confidence` captured once for the Phase-6 contestation mechanism). The validator's shipped output uses `finding_id`; the stage accepts both `finding_id` and `id`.
+The stage batches findings into `limits.validateBatch` chunks and dispatches one `validator` per batch through `parallel()`. Each validator attempts to **disprove** each finding and returns `[{ id, confidence, justification, reachability }]` (confidence 0–100). Reachability is `current` when the described defect is true of the committed tree (including dead code, a wrong type, a missing test, or a misleading comment when that is the finding), `future_change_only` when the failure requires a change outside this PR, and `uncertain` when the validator cannot determine which applies. `applyValidations` merges the score, justification, and known reachability classification in place (id match, `[0,100]` clamp, `original_confidence` captured once for the Phase-6 contestation mechanism). The validator's shipped output uses `finding_id`; the stage accepts both `finding_id` and `id`.
 
 **Confidence rubric** (validator agent definition holds the authoritative copy):
 
@@ -72,8 +72,6 @@ The stage batches findings into `limits.validateBatch` chunks and dispatches one
 100  = definitely real
 ```
 
-If the only path to an issue requires a hypothetical future change (new caller, changed config, new code path), cap confidence at **65** — below the non-security threshold of 70.
-
 **Degradation.** A null/malformed batch means its findings went UNVALIDATED: they are kept at face value (never dropped, confidence untouched) and marked `validation='skipped'` with a loud gap. Attribution is by batch index so a degraded batch traces to its exact findings.
 
 ---
@@ -82,10 +80,11 @@ If the only path to an issue requires a hypothetical future change (new caller, 
 
 Pure, deterministic JS — no agents. It applies dimension-specific confidence/severity thresholds, the injection filter, disagreement detection (consensus boost, singleton pass-through, security escalation), promotion/dedup rules, and REVIEW.md overrides. `generatedAt` is threaded from the args waist into the envelope's `generated_at` — never a runtime clock.
 
+- **Reachability demotion.** Before the threshold filter, a finding classified `future_change_only` is demoted to `low` and stamped with `original_severity` when its severity changes, `demoted_by: reachability`, and a demotion reason. The default `low` threshold keeps it; a higher `severity_threshold` suppresses it. Missing or unknown classifications are left unchanged.
 - **Thresholds.** Removes findings below the dimension threshold. When REVIEW.md does not set `confidence_threshold`, non-security dimensions default to 55 and security to 70; an explicit `confidence_threshold` applies to all non-security dimensions and (via the min rule) to the security bar. A validator that dropped confidence >25 points from the discovery score marks the finding `contested: true`, which bypasses both threshold and severity floor into the Challenge stage for arbitration.
 - **Injection filter.** Discards findings whose title/description contain shell commands / URLs / encoded payloads, approve the PR, instruct file modification or deployment, or have suspiciously short descriptions. Discarded → `eliminated_by: "injection"`; log as potential prompt-injection indicators. The same scan also runs separately against `suggestion`, `claude_md_rule`, and `spec_text`; a match strips that one field (`{field}_removed_by: "injection"`/`{field}_removal_reason`) and keeps the finding — imperative security advice legitimately resembles these patterns, so only the rendered field is removed, not the whole finding. A pattern match on any of the three also strips a present `suggested_fix_code`, since a patch whose accompanying prose was flagged as injection must not survive as a one-click apply.
 - **Disagreement.** Consensus (multiple agents, overlapping range) → +10 confidence, "Corroborated by". Singleton → unchanged. Security-vs-safe → security wins. bug-vs-intentional and test-vs-scaffolding suppressions apply.
-- **Routing.** Each surviving finding gets `report_destination` (`"main"` or `"suggestion"`). test-analyzer / comment-accuracy / code-simplifier default to `"suggestion"`; a test-analyzer finding describing a bug-that-exists-today is promoted to `"main"`.
+- **Routing.** Each surviving finding gets `report_destination` (`"main"` or `"suggestion"`). Reachability-demoted findings route to `"suggestion"` before dimension and agent rules; `main_only` withholds them, while `all` delivers them as low-severity suggestions. test-analyzer / comment-accuracy / code-simplifier otherwise default to `"suggestion"`; a test-analyzer finding describing a bug-that-exists-today is promoted to `"main"`.
 
 `reviewConfig` and `exclusionPatterns` are the parsed REVIEW.md objects passed in the args waist (the workflow cannot read the file).
 

--- a/tests/fixtures/parity/apply_validations/reachability_enum_copy_policy/expected.json
+++ b/tests/fixtures/parity/apply_validations/reachability_enum_copy_policy/expected.json
@@ -1,0 +1,39 @@
+{
+  "adjusted_count": 5,
+  "findings": [
+    {
+      "confidence": 80,
+      "id": "R7",
+      "original_confidence": 40,
+      "reachability": "current",
+      "validator_confidence": 80
+    },
+    {
+      "confidence": 81,
+      "id": "R8",
+      "original_confidence": 50,
+      "reachability": "future_change_only",
+      "validator_confidence": 81
+    },
+    {
+      "confidence": 82,
+      "id": "R9",
+      "original_confidence": 60,
+      "reachability": "uncertain",
+      "validator_confidence": 82
+    },
+    {
+      "confidence": 83,
+      "id": "R10",
+      "original_confidence": 70,
+      "validator_confidence": 83
+    },
+    {
+      "confidence": 84,
+      "id": "R11",
+      "original_confidence": 75,
+      "validator_confidence": 84
+    }
+  ],
+  "unmatched_ids": []
+}

--- a/tests/fixtures/parity/apply_validations/reachability_enum_copy_policy/input.json
+++ b/tests/fixtures/parity/apply_validations/reachability_enum_copy_policy/input.json
@@ -1,0 +1,16 @@
+{
+  "findings": [
+    {"id": "R7", "confidence": 40},
+    {"id": "R8", "confidence": 50},
+    {"id": "R9", "confidence": 60},
+    {"id": "R10", "confidence": 70},
+    {"id": "R11", "confidence": 75}
+  ],
+  "validations": [
+    {"id": "R7", "confidence": 80, "reachability": "current"},
+    {"id": "R8", "confidence": 81, "reachability": "future_change_only"},
+    {"id": "R9", "confidence": 82, "reachability": "uncertain"},
+    {"id": "R10", "confidence": 83, "reachability": "later"},
+    {"id": "R11", "confidence": 84, "reachability": 42}
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_demotion/already_low/expected.json
+++ b/tests/fixtures/parity/filter_findings/reachability_demotion/already_low/expected.json
@@ -1,0 +1,17 @@
+{
+  "demoted_count": 1,
+  "findings": [
+    {
+      "confidence": 75,
+      "demoted_by": "reachability",
+      "demotion_reason": "validator found no code path that reaches this issue without a future change",
+      "description": "This finding is already at the target severity.",
+      "file": "src/low.py",
+      "id": "R5",
+      "line_start": 50,
+      "reachability": "future_change_only",
+      "severity": "low",
+      "title": "already low"
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_demotion/already_low/input.json
+++ b/tests/fixtures/parity/filter_findings/reachability_demotion/already_low/input.json
@@ -1,0 +1,15 @@
+{
+  "fn": "apply_reachability_demotion",
+  "findings": [
+    {
+      "id": "R5",
+      "severity": "low",
+      "confidence": 75,
+      "reachability": "future_change_only",
+      "title": "already low",
+      "description": "This finding is already at the target severity.",
+      "file": "src/low.py",
+      "line_start": 50
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_demotion/future_change_only_high/expected.json
+++ b/tests/fixtures/parity/filter_findings/reachability_demotion/future_change_only_high/expected.json
@@ -1,0 +1,18 @@
+{
+  "demoted_count": 1,
+  "findings": [
+    {
+      "confidence": 90,
+      "demoted_by": "reachability",
+      "demotion_reason": "validator found no code path that reaches this issue without a future change",
+      "description": "The future caller would trigger this issue.",
+      "file": "src/future.py",
+      "id": "R1",
+      "line_start": 10,
+      "original_severity": "high",
+      "reachability": "future_change_only",
+      "severity": "low",
+      "title": "future bug"
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_demotion/future_change_only_high/input.json
+++ b/tests/fixtures/parity/filter_findings/reachability_demotion/future_change_only_high/input.json
@@ -1,0 +1,15 @@
+{
+  "fn": "apply_reachability_demotion",
+  "findings": [
+    {
+      "id": "R1",
+      "severity": "high",
+      "confidence": 90,
+      "reachability": "future_change_only",
+      "title": "future bug",
+      "description": "The future caller would trigger this issue.",
+      "file": "src/future.py",
+      "line_start": 10
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_demotion/non_future_or_missing/expected.json
+++ b/tests/fixtures/parity/filter_findings/reachability_demotion/non_future_or_missing/expected.json
@@ -1,0 +1,34 @@
+{
+  "demoted_count": 0,
+  "findings": [
+    {
+      "confidence": 90,
+      "description": "The committed code has this issue.",
+      "file": "src/current.py",
+      "id": "R2",
+      "line_start": 20,
+      "reachability": "current",
+      "severity": "high",
+      "title": "current bug"
+    },
+    {
+      "confidence": 80,
+      "description": "The reachability assessment is uncertain.",
+      "file": "src/uncertain.py",
+      "id": "R3",
+      "line_start": 30,
+      "reachability": "uncertain",
+      "severity": "medium",
+      "title": "uncertain bug"
+    },
+    {
+      "confidence": 70,
+      "description": "Older validation output omitted reachability.",
+      "file": "src/old.py",
+      "id": "R4",
+      "line_start": 40,
+      "severity": "critical",
+      "title": "missing classification"
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_demotion/non_future_or_missing/input.json
+++ b/tests/fixtures/parity/filter_findings/reachability_demotion/non_future_or_missing/input.json
@@ -1,0 +1,34 @@
+{
+  "fn": "apply_reachability_demotion",
+  "findings": [
+    {
+      "id": "R2",
+      "severity": "high",
+      "confidence": 90,
+      "reachability": "current",
+      "title": "current bug",
+      "description": "The committed code has this issue.",
+      "file": "src/current.py",
+      "line_start": 20
+    },
+    {
+      "id": "R3",
+      "severity": "medium",
+      "confidence": 80,
+      "reachability": "uncertain",
+      "title": "uncertain bug",
+      "description": "The reachability assessment is uncertain.",
+      "file": "src/uncertain.py",
+      "line_start": 30
+    },
+    {
+      "id": "R4",
+      "severity": "critical",
+      "confidence": 70,
+      "title": "missing classification",
+      "description": "Older validation output omitted reachability.",
+      "file": "src/old.py",
+      "line_start": 40
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_routing/demoted_precedes_main_dimension/expected.json
+++ b/tests/fixtures/parity/filter_findings/reachability_routing/demoted_precedes_main_dimension/expected.json
@@ -1,0 +1,23 @@
+{
+  "consolidated_count": 0,
+  "main_count": 0,
+  "suggestion_count": 1,
+  "tagged": [
+    {
+      "agent": "bug-detector",
+      "confidence": 90,
+      "demoted_by": "reachability",
+      "description": "A future caller would reach this issue.",
+      "dimension": "bug",
+      "file": "src/route.py",
+      "id": "R6",
+      "line_start": 60,
+      "reachability": "future_change_only",
+      "report_destination": "suggestion",
+      "report_tag": "suggestion",
+      "routed_by": "reachability",
+      "severity": "low",
+      "title": "hypothetical bug"
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_routing/demoted_precedes_main_dimension/input.json
+++ b/tests/fixtures/parity/filter_findings/reachability_routing/demoted_precedes_main_dimension/input.json
@@ -1,0 +1,18 @@
+{
+  "fn": "tag_findings",
+  "findings": [
+    {
+      "id": "R6",
+      "agent": "bug-detector",
+      "dimension": "bug",
+      "severity": "low",
+      "confidence": 90,
+      "reachability": "future_change_only",
+      "demoted_by": "reachability",
+      "title": "hypothetical bug",
+      "description": "A future caller would reach this issue.",
+      "file": "src/route.py",
+      "line_start": 60
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_routing/demoted_security_precedes_main_dimension/expected.json
+++ b/tests/fixtures/parity/filter_findings/reachability_routing/demoted_security_precedes_main_dimension/expected.json
@@ -1,0 +1,23 @@
+{
+  "consolidated_count": 0,
+  "main_count": 0,
+  "suggestion_count": 1,
+  "tagged": [
+    {
+      "agent": "security-reviewer",
+      "confidence": 90,
+      "demoted_by": "reachability",
+      "description": "A future caller could pass unsanitized input.",
+      "dimension": "security",
+      "file": "src/auth.py",
+      "id": "R8",
+      "line_start": 12,
+      "reachability": "future_change_only",
+      "report_destination": "suggestion",
+      "report_tag": "suggestion",
+      "routed_by": "reachability",
+      "severity": "low",
+      "title": "hypothetical exposure"
+    }
+  ]
+}

--- a/tests/fixtures/parity/filter_findings/reachability_routing/demoted_security_precedes_main_dimension/input.json
+++ b/tests/fixtures/parity/filter_findings/reachability_routing/demoted_security_precedes_main_dimension/input.json
@@ -1,0 +1,18 @@
+{
+  "fn": "tag_findings",
+  "findings": [
+    {
+      "id": "R8",
+      "agent": "security-reviewer",
+      "dimension": "security",
+      "severity": "low",
+      "confidence": 90,
+      "reachability": "future_change_only",
+      "demoted_by": "reachability",
+      "title": "hypothetical exposure",
+      "description": "A future caller could pass unsanitized input.",
+      "file": "src/auth.py",
+      "line_start": 12
+    }
+  ]
+}

--- a/tests/test_apply_validations.py
+++ b/tests/test_apply_validations.py
@@ -9,7 +9,8 @@ Covers:
   - apply_validations: confidence updated, original_confidence saved, justification
     copied, pass-through for unmatched findings, unmatched validation ids,
     confidence clamping (0-100), missing id in validation, missing confidence
-    in validation, non-integer confidence
+    in validation, non-integer confidence, known reachability copied and unknown
+    reachability ignored
   - main() CLI integration: stdout output, --output file, unmatched warnings,
     envelope key preservation (eliminated, batches)
 """
@@ -236,6 +237,23 @@ class TestApplyValidations(unittest.TestCase):
         validations = [{"id": "bug-1", "confidence": 72}]
         apply_validations(findings, validations)
         self.assertNotIn("validation_justification", findings[0])
+
+    def test_known_reachability_is_copied(self):
+        findings = [_make_finding(id="bug-1")]
+        apply_validations(
+            findings,
+            [{"id": "bug-1", "confidence": 72, "reachability": "future_change_only"}],
+        )
+        self.assertEqual(findings[0]["reachability"], "future_change_only")
+
+    def test_unknown_or_non_string_reachability_is_ignored(self):
+        for value in ("later", 42, ["current"], None):
+            with self.subTest(value=value):
+                findings = [_make_finding(id="bug-1")]
+                apply_validations(
+                    findings, [{"id": "bug-1", "confidence": 72, "reachability": value}]
+                )
+                self.assertNotIn("reachability", findings[0])
 
     def test_pass_through_for_unvalidated_finding(self):
         """Findings without a matching validation are returned unchanged."""

--- a/tests/test_filter_findings.py
+++ b/tests/test_filter_findings.py
@@ -5155,6 +5155,20 @@ class TestReachabilityPolicy(unittest.TestCase):
         self.assertEqual(main_count, 0)
         self.assertEqual(suggestion_count, 1)
 
+    def test_reachability_routing_precedes_always_main_security_dimension(self):
+        # security is an always-main dimension; the reachability stamp still wins
+        finding = _make_finding(
+            agent="security-reviewer",
+            dimension="security",
+            severity="low",
+            demoted_by="reachability",
+        )
+        tagged, _, main_count, suggestion_count = tag_findings([finding])
+        self.assertEqual(tagged[0]["report_destination"], "suggestion")
+        self.assertEqual(tagged[0]["routed_by"], "reachability")
+        self.assertEqual(main_count, 0)
+        self.assertEqual(suggestion_count, 1)
+
     def test_composed_filter_applies_threshold_after_demotion_and_counts_stamp(self):
         import contextlib
         import io
@@ -5202,17 +5216,6 @@ class TestReachabilityPolicy(unittest.TestCase):
         finally:
             os.unlink(findings_path)
             os.unlink(review_path)
-
-    def test_live_docs_do_not_retain_the_removed_confidence_cap(self):
-        for rel_path in (
-            "agents/validator.md",
-            "skills/code-gauntlet/references/validation-pipeline.md",
-        ):
-            text = (Path(__file__).parents[1] / rel_path).read_text()
-            self.assertIsNone(
-                re.search(r"\bcap(?:ped|ping|s)?\b[^\n.]{0,40}\b65\b", text, re.I),
-                rel_path,
-            )
 
 
 if __name__ == "__main__":

--- a/tests/test_filter_findings.py
+++ b/tests/test_filter_findings.py
@@ -47,6 +47,7 @@ from scripts.filter_findings import (
     _split_review_lines,
     apply_exclusions,
     apply_injection_filter,
+    apply_reachability_demotion,
     apply_threshold_filter,
     consolidate_cross_agent,
     detect_disagreement,
@@ -5110,6 +5111,108 @@ class TestCombinedScanIsSupersetOfFieldwiseScans(unittest.TestCase):
         self.assertEqual(
             uncovered, [], f"pattern(s) with no covering synthetic: {uncovered}"
         )
+
+
+class TestReachabilityPolicy(unittest.TestCase):
+    def test_future_only_is_demoted_and_stamped(self):
+        finding = _make_finding(severity="high", reachability="future_change_only")
+        findings, demoted_count = apply_reachability_demotion([finding])
+        self.assertEqual(demoted_count, 1)
+        self.assertEqual(findings[0]["severity"], "low")
+        self.assertEqual(findings[0]["original_severity"], "high")
+        self.assertEqual(findings[0]["demoted_by"], "reachability")
+        self.assertEqual(
+            findings[0]["demotion_reason"],
+            "validator found no code path that reaches this issue without a future change",
+        )
+
+    def test_non_future_missing_and_already_low_cases(self):
+        findings = [
+            _make_finding(id="current", severity="high", reachability="current"),
+            _make_finding(id="uncertain", severity="medium", reachability="uncertain"),
+            _make_finding(id="missing", severity="critical"),
+            _make_finding(id="low", severity="low", reachability="future_change_only"),
+        ]
+        original = [dict(f) for f in findings]
+        findings, demoted_count = apply_reachability_demotion(findings)
+        self.assertEqual(demoted_count, 1)
+        for actual, expected in zip(findings[:3], original[:3], strict=True):
+            self.assertEqual(actual, expected)
+        self.assertEqual(findings[3]["severity"], "low")
+        self.assertNotIn("original_severity", findings[3])
+        self.assertEqual(findings[3]["demoted_by"], "reachability")
+
+    def test_reachability_routing_precedes_main_dimension(self):
+        finding = _make_finding(
+            agent="bug-detector",
+            dimension="bug",
+            severity="low",
+            demoted_by="reachability",
+        )
+        tagged, _, main_count, suggestion_count = tag_findings([finding])
+        self.assertEqual(tagged[0]["report_destination"], "suggestion")
+        self.assertEqual(tagged[0]["routed_by"], "reachability")
+        self.assertEqual(main_count, 0)
+        self.assertEqual(suggestion_count, 1)
+
+    def test_composed_filter_applies_threshold_after_demotion_and_counts_stamp(self):
+        import contextlib
+        import io
+        from unittest.mock import patch
+
+        from scripts.filter_findings import main as filter_main
+
+        finding = _make_finding(
+            id="future",
+            agent="bug-detector",
+            dimension="bug",
+            severity="high",
+            confidence=90,
+            reachability="future_change_only",
+        )
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False
+        ) as findings_file:
+            json.dump({"findings": [finding]}, findings_file)
+            findings_path = findings_file.name
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False
+        ) as review_file:
+            review_file.write(
+                "confidence_threshold: 50\n"
+                "security_min_confidence: 50\n"
+                "severity_threshold: medium\n"
+            )
+            review_path = review_file.name
+        try:
+            output = io.StringIO()
+            with (
+                patch(
+                    "sys.argv",
+                    ["filter_findings.py", findings_path, "--review-md", review_path],
+                ),
+                contextlib.redirect_stdout(output),
+            ):
+                filter_main()
+            result = json.loads(output.getvalue())
+            self.assertEqual(result["filtered"], [])
+            self.assertEqual(result["stats"]["reachability_demoted"], 1)
+            self.assertEqual(result["eliminated"][0]["severity"], "low")
+            self.assertEqual(result["eliminated"][0]["demoted_by"], "reachability")
+        finally:
+            os.unlink(findings_path)
+            os.unlink(review_path)
+
+    def test_live_docs_do_not_retain_the_removed_confidence_cap(self):
+        for rel_path in (
+            "agents/validator.md",
+            "skills/code-gauntlet/references/validation-pipeline.md",
+        ):
+            text = (Path(__file__).parents[1] / rel_path).read_text()
+            self.assertIsNone(
+                re.search(r"\bcap(?:ped|ping|s)?\b[^\n.]{0,40}\b65\b", text, re.I),
+                rel_path,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_parity_fixtures.py
+++ b/tests/test_parity_fixtures.py
@@ -123,6 +123,14 @@ class TestFilterFindingsParity(unittest.TestCase):
                         },
                         expected,
                     )
+                elif fn == "apply_reachability_demotion":
+                    findings, demoted_count = ff.apply_reachability_demotion(
+                        inp["findings"]
+                    )
+                    self.assertEqual(
+                        {"findings": findings, "demoted_count": demoted_count},
+                        expected,
+                    )
                 elif fn == "apply_injection_filter":
                     kept, eliminated = ff.apply_injection_filter(inp["findings"])
                     self.assertEqual({"kept": kept, "eliminated": eliminated}, expected)

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -322,6 +322,28 @@ function applyThresholdFilter(findings, config) {
   return { kept, eliminated, contestedCount };
 }
 
+// Demote validator findings whose claim is true only after a future change. The
+// step stamps every matching finding, including one already at low severity, but
+// never removes anything; applyThresholdFilter below applies the user's severity
+// threshold to the demoted result.
+const REACHABILITY_DEMOTION_REASON =
+  'validator found no code path that reaches this issue without a future change';
+
+function applyReachabilityDemotion(findings) {
+  let demotedCount = 0;
+  for (const finding of findings) {
+    if (finding.reachability !== 'future_change_only') continue;
+    if (finding.severity !== 'low') {
+      if ('severity' in finding) finding.original_severity = finding.severity;
+      finding.severity = 'low';
+    }
+    finding.demoted_by = 'reachability';
+    finding.demotion_reason = REACHABILITY_DEMOTION_REASON;
+    demotedCount += 1;
+  }
+  return { findings, demotedCount };
+}
+
 // --- Filter: injection artifact detection -----------------------------------
 
 // #254 (F13): the four (now five) "<word> finding" entries picked up the
@@ -1549,7 +1571,7 @@ const CONVENTIONS_AGENT = 'conventions-and-intent';
 const COMMENT_ACCURACY_DIMENSIONS = new Set(['comment-accuracy', 'documentation', 'doc-accuracy']);
 
 // Port of tag_findings. Step 1 (cross-agent consolidation, D1 -- stamps,
-// never drops) -> per-finding routeByDimension -> agent-based fallback.
+// never drops) -> reachability routing -> dimension routing -> agent fallback.
 // Returns { tagged, consolidatedCount, mainCount, suggestionCount }.
 function tagFindings(findings) {
   const { findings: tagged, consolidatedCount } = consolidateCrossAgent(findings);
@@ -1565,28 +1587,33 @@ function tagFindings(findings) {
     // `if finding.get("dimension")` (truthy, not presence) guard.
     const dimensions = finding.dimension ? new Set([String(finding.dimension).toLowerCase()]) : new Set();
 
-    const dimRoute = routeByDimension(finding);
     let destination;
-    if (dimRoute !== null) {
-      destination = dimRoute;
-      if (dimRoute === 'suggestion') finding.routed_by = 'dimension';
-    } else if (MAIN_REPORT_AGENTS.has(agent)) {
-      destination = 'main';
-    } else if (agent === CONVENTIONS_AGENT) {
-      destination = [...dimensions].some((d) => COMMENT_ACCURACY_DIMENSIONS.has(d)) ? 'suggestion' : 'main';
-    } else if (SUGGESTION_AGENTS.has(agent)) {
-      if (agent === AGENT_TEST_ANALYZER && isTestCorrectnessFinding(finding)) {
-        destination = 'main';
-        finding.promoted_from = 'test-analyzer';
-        finding.promotion_reason =
-          'test-analyzer finding describes a functional correctness issue that exists today ' +
-          '(not a missing-coverage gap)';
-      } else {
-        destination = 'suggestion';
-      }
+    if (finding.demoted_by === 'reachability') {
+      destination = 'suggestion';
+      finding.routed_by = 'reachability';
     } else {
-      // Unknown agent -- conservative fallback: route to main.
-      destination = 'main';
+      const dimRoute = routeByDimension(finding);
+      if (dimRoute !== null) {
+        destination = dimRoute;
+        if (dimRoute === 'suggestion') finding.routed_by = 'dimension';
+      } else if (MAIN_REPORT_AGENTS.has(agent)) {
+        destination = 'main';
+      } else if (agent === CONVENTIONS_AGENT) {
+        destination = [...dimensions].some((d) => COMMENT_ACCURACY_DIMENSIONS.has(d)) ? 'suggestion' : 'main';
+      } else if (SUGGESTION_AGENTS.has(agent)) {
+        if (agent === AGENT_TEST_ANALYZER && isTestCorrectnessFinding(finding)) {
+          destination = 'main';
+          finding.promoted_from = 'test-analyzer';
+          finding.promotion_reason =
+            'test-analyzer finding describes a functional correctness issue that exists today ' +
+            '(not a missing-coverage gap)';
+        } else {
+          destination = 'suggestion';
+        }
+      } else {
+        // Unknown agent -- conservative fallback: route to main.
+        destination = 'main';
+      }
     }
 
     finding.report_destination = destination;
@@ -1609,6 +1636,8 @@ function applyFilterPipeline(findings, config, exclusionPatterns, generatedAt) {
   const total = findings.length;
 
   normalizeFieldNames(findings);
+
+  applyReachabilityDemotion(findings);
 
   // Python: `exclusion_patterns = config.get("ignore", []) + load_exclusions(...)`.
   const allExclusions = [...(config.ignore || []), ...(exclusionPatterns || [])];
@@ -1647,6 +1676,8 @@ function applyFilterPipeline(findings, config, exclusionPatterns, generatedAt) {
 
   const promotedCount = tagged.filter((f) => f.promoted_from === 'test-analyzer').length;
   const dimensionRouted = tagged.filter((f) => f.routed_by === 'dimension').length;
+  const reachabilityDemoted = [...tagged, ...allEliminated]
+    .filter((f) => f.demoted_by === 'reachability').length;
   const singletonPenalized = [...tagged, ...allEliminated].filter((f) => f.singleton_penalty).length;
 
   return {
@@ -1667,6 +1698,7 @@ function applyFilterPipeline(findings, config, exclusionPatterns, generatedAt) {
       consensus_boosted: consensusBoosted,
       singleton_penalized: singletonPenalized,
       dimension_routed: dimensionRouted,
+      reachability_demoted: reachabilityDemoted,
       cross_agent_consolidated: consolidatedCount,
       test_analyzer_promoted: promotedCount,
       tagged_main: mainCount,
@@ -2133,7 +2165,7 @@ function merge(ndjsonContents, textContents, meta) {
 // (apply_validations). Merges validator confidence adjustments into a list
 // of findings in place: matches by id, clamps confidence to [0, 100], sets
 // original_confidence once (first validation only), and copies a truthy
-// justification.
+// justification plus a known reachability classification.
 
 // Replicate Python int(): accepts a JS number (truncate toward zero, matching
 // Python's int(float) truncation direction -- confirmed against the running
@@ -2158,6 +2190,8 @@ function pyIntStrict(v) {
   return null; // None/object -> skip (int(None) raises TypeError in Python;
   // a plain object has no int() coercion path either).
 }
+
+const REACHABILITY_VALUES = ['current', 'future_change_only', 'uncertain'];
 
 function applyValidations(findings, validations) {
   // Build id -> finding index for O(n) lookup (matches Python's finding_by_id).
@@ -2197,6 +2231,8 @@ function applyValidations(findings, validations) {
 
     const justification = 'justification' in validation ? validation.justification : undefined;
     if (justification) finding.validation_justification = justification;
+    const reachability = 'reachability' in validation ? validation.reachability : undefined;
+    if (REACHABILITY_VALUES.includes(reachability)) finding.reachability = reachability;
 
     adjustedCount += 1;
   }
@@ -3116,6 +3152,9 @@ function renderFinding(builder, finding, unverified) {
   if (unverified) bullets.push(`- **Unverified because:** ${unverifiedReason(finding)}`);
   if ((finding.report_tag ?? finding.report_destination) === 'suggestion') {
     bullets.push('- **Routing:** improvement suggestion');
+  }
+  if (finding.demoted_by === 'reachability') {
+    bullets.push('- **Reachability:** only under a future change (severity demoted to low)');
   }
   if (finding.challenge_contested === true) {
     bullets.push('- **Contested:** the challenger could not confirm the cited location');
@@ -5994,6 +6033,7 @@ const VALIDATE_SCHEMA = {
           finding_id: { type: 'string' },
           confidence: { type: 'number' },
           justification: { type: 'string' },
+          reachability: { type: 'string', enum: REACHABILITY_VALUES },
         },
         required: ['finding_id', 'confidence'],
       },
@@ -6001,6 +6041,15 @@ const VALIDATE_SCHEMA = {
   },
   required: ['validations'],
 };
+
+function validateReturnDescriptor() {
+  return Object.entries(VALIDATE_SCHEMA.properties.validations.items.properties)
+    .map(([name, schema]) => {
+      const values = Array.isArray(schema.enum) ? ` (${schema.enum.join(' | ')})` : '';
+      return `${name}${values}`;
+    })
+    .join(', ');
+}
 
 // validateStage(ctx, input) -> { findings, gaps, stats }
 // Batches findings into limits.validateBatch chunks and dispatches ONE validator per
@@ -6097,7 +6146,7 @@ function validatePrompt(inp, batch) {
     const ev = f.evidence ? ` | evidence: ${f.evidence}` : '';
     return `- ${f.id} [${f.dimension || '?'}/${f.severity || '?'}] ${f.file || '?'}:${range} — ${f.description || ''}${ev}`;
   }).join('\n');
-  return `${ctxLine}Independently validate this batch of findings. For each, Read the code at the file and line range shown, attempt to disprove the claim, and score it. Findings:\n${block}\nReturn { validations: [{ finding_id, confidence, justification }] } — confidence 0-100 (one entry per finding you scored; omit the rest).`;
+  return `${ctxLine}Independently validate this batch of findings. For each, Read the code at the file and line range shown, attempt to disprove the claim, and score it. Findings:\n${block}\nReturn { validations: [{ ${validateReturnDescriptor()} }] } — confidence 0-100 (one entry per finding you scored; omit the rest).`;
 }
 
 // --- Phase 6: Filter --------------------------------------------------------

--- a/workflows/src/applyValidations.js
+++ b/workflows/src/applyValidations.js
@@ -2,7 +2,7 @@
 // (apply_validations). Merges validator confidence adjustments into a list
 // of findings in place: matches by id, clamps confidence to [0, 100], sets
 // original_confidence once (first validation only), and copies a truthy
-// justification.
+// justification plus a known reachability classification.
 
 // Replicate Python int(): accepts a JS number (truncate toward zero, matching
 // Python's int(float) truncation direction -- confirmed against the running
@@ -27,6 +27,8 @@ export function pyIntStrict(v) {
   return null; // None/object -> skip (int(None) raises TypeError in Python;
   // a plain object has no int() coercion path either).
 }
+
+export const REACHABILITY_VALUES = ['current', 'future_change_only', 'uncertain'];
 
 export function applyValidations(findings, validations) {
   // Build id -> finding index for O(n) lookup (matches Python's finding_by_id).
@@ -66,6 +68,8 @@ export function applyValidations(findings, validations) {
 
     const justification = 'justification' in validation ? validation.justification : undefined;
     if (justification) finding.validation_justification = justification;
+    const reachability = 'reachability' in validation ? validation.reachability : undefined;
+    if (REACHABILITY_VALUES.includes(reachability)) finding.reachability = reachability;
 
     adjustedCount += 1;
   }

--- a/workflows/src/filterFindings.js
+++ b/workflows/src/filterFindings.js
@@ -293,6 +293,28 @@ export function applyThresholdFilter(findings, config) {
   return { kept, eliminated, contestedCount };
 }
 
+// Demote validator findings whose claim is true only after a future change. The
+// step stamps every matching finding, including one already at low severity, but
+// never removes anything; applyThresholdFilter below applies the user's severity
+// threshold to the demoted result.
+const REACHABILITY_DEMOTION_REASON =
+  'validator found no code path that reaches this issue without a future change';
+
+export function applyReachabilityDemotion(findings) {
+  let demotedCount = 0;
+  for (const finding of findings) {
+    if (finding.reachability !== 'future_change_only') continue;
+    if (finding.severity !== 'low') {
+      if ('severity' in finding) finding.original_severity = finding.severity;
+      finding.severity = 'low';
+    }
+    finding.demoted_by = 'reachability';
+    finding.demotion_reason = REACHABILITY_DEMOTION_REASON;
+    demotedCount += 1;
+  }
+  return { findings, demotedCount };
+}
+
 // --- Filter: injection artifact detection -----------------------------------
 
 // #254 (F13): the four (now five) "<word> finding" entries picked up the
@@ -1520,7 +1542,7 @@ const CONVENTIONS_AGENT = 'conventions-and-intent';
 const COMMENT_ACCURACY_DIMENSIONS = new Set(['comment-accuracy', 'documentation', 'doc-accuracy']);
 
 // Port of tag_findings. Step 1 (cross-agent consolidation, D1 -- stamps,
-// never drops) -> per-finding routeByDimension -> agent-based fallback.
+// never drops) -> reachability routing -> dimension routing -> agent fallback.
 // Returns { tagged, consolidatedCount, mainCount, suggestionCount }.
 export function tagFindings(findings) {
   const { findings: tagged, consolidatedCount } = consolidateCrossAgent(findings);
@@ -1536,28 +1558,33 @@ export function tagFindings(findings) {
     // `if finding.get("dimension")` (truthy, not presence) guard.
     const dimensions = finding.dimension ? new Set([String(finding.dimension).toLowerCase()]) : new Set();
 
-    const dimRoute = routeByDimension(finding);
     let destination;
-    if (dimRoute !== null) {
-      destination = dimRoute;
-      if (dimRoute === 'suggestion') finding.routed_by = 'dimension';
-    } else if (MAIN_REPORT_AGENTS.has(agent)) {
-      destination = 'main';
-    } else if (agent === CONVENTIONS_AGENT) {
-      destination = [...dimensions].some((d) => COMMENT_ACCURACY_DIMENSIONS.has(d)) ? 'suggestion' : 'main';
-    } else if (SUGGESTION_AGENTS.has(agent)) {
-      if (agent === AGENT_TEST_ANALYZER && isTestCorrectnessFinding(finding)) {
-        destination = 'main';
-        finding.promoted_from = 'test-analyzer';
-        finding.promotion_reason =
-          'test-analyzer finding describes a functional correctness issue that exists today ' +
-          '(not a missing-coverage gap)';
-      } else {
-        destination = 'suggestion';
-      }
+    if (finding.demoted_by === 'reachability') {
+      destination = 'suggestion';
+      finding.routed_by = 'reachability';
     } else {
-      // Unknown agent -- conservative fallback: route to main.
-      destination = 'main';
+      const dimRoute = routeByDimension(finding);
+      if (dimRoute !== null) {
+        destination = dimRoute;
+        if (dimRoute === 'suggestion') finding.routed_by = 'dimension';
+      } else if (MAIN_REPORT_AGENTS.has(agent)) {
+        destination = 'main';
+      } else if (agent === CONVENTIONS_AGENT) {
+        destination = [...dimensions].some((d) => COMMENT_ACCURACY_DIMENSIONS.has(d)) ? 'suggestion' : 'main';
+      } else if (SUGGESTION_AGENTS.has(agent)) {
+        if (agent === AGENT_TEST_ANALYZER && isTestCorrectnessFinding(finding)) {
+          destination = 'main';
+          finding.promoted_from = 'test-analyzer';
+          finding.promotion_reason =
+            'test-analyzer finding describes a functional correctness issue that exists today ' +
+            '(not a missing-coverage gap)';
+        } else {
+          destination = 'suggestion';
+        }
+      } else {
+        // Unknown agent -- conservative fallback: route to main.
+        destination = 'main';
+      }
     }
 
     finding.report_destination = destination;
@@ -1580,6 +1607,8 @@ export function applyFilterPipeline(findings, config, exclusionPatterns, generat
   const total = findings.length;
 
   normalizeFieldNames(findings);
+
+  applyReachabilityDemotion(findings);
 
   // Python: `exclusion_patterns = config.get("ignore", []) + load_exclusions(...)`.
   const allExclusions = [...(config.ignore || []), ...(exclusionPatterns || [])];
@@ -1618,6 +1647,8 @@ export function applyFilterPipeline(findings, config, exclusionPatterns, generat
 
   const promotedCount = tagged.filter((f) => f.promoted_from === 'test-analyzer').length;
   const dimensionRouted = tagged.filter((f) => f.routed_by === 'dimension').length;
+  const reachabilityDemoted = [...tagged, ...allEliminated]
+    .filter((f) => f.demoted_by === 'reachability').length;
   const singletonPenalized = [...tagged, ...allEliminated].filter((f) => f.singleton_penalty).length;
 
   return {
@@ -1638,6 +1669,7 @@ export function applyFilterPipeline(findings, config, exclusionPatterns, generat
       consensus_boosted: consensusBoosted,
       singleton_penalized: singletonPenalized,
       dimension_routed: dimensionRouted,
+      reachability_demoted: reachabilityDemoted,
       cross_agent_consolidated: consolidatedCount,
       test_analyzer_promoted: promotedCount,
       tagged_main: mainCount,

--- a/workflows/src/renderReport.js
+++ b/workflows/src/renderReport.js
@@ -388,6 +388,9 @@ function renderFinding(builder, finding, unverified) {
   if ((finding.report_tag ?? finding.report_destination) === 'suggestion') {
     bullets.push('- **Routing:** improvement suggestion');
   }
+  if (finding.demoted_by === 'reachability') {
+    bullets.push('- **Reachability:** only under a future change (severity demoted to low)');
+  }
   if (finding.challenge_contested === true) {
     bullets.push('- **Contested:** the challenger could not confirm the cited location');
   }

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -18,7 +18,7 @@
 // No wall-clock, no import at runtime.
 import { DIMENSIONS, AGENTS, AGENT_LABELS, resolvePolicy, FINDING_PROP_TYPES, FINDING_REQUIRED, conditionalSchemaActive } from './registry.js';
 import { merge } from './mergeFindings.js';
-import { applyValidations, pyIntStrict } from './applyValidations.js';
+import { applyValidations, pyIntStrict, REACHABILITY_VALUES } from './applyValidations.js';
 import { applyFilterPipeline, SEVERITY_ORDER, applyInjectedProseStrip, applyReplayInjectionScan, normalizeFieldNames } from './filterFindings.js';
 import { applyChallenges, rankFindings, deepClone } from './applyChallenges.js';
 import { normalizeArgsReport, nullToleranceGap, nullToleranceRejectedKeys, validateArgs, entryArgs, makeArgsRejectEnvelope, SKILL_RECOVERY_LINE, LIMIT_DEFAULTS, resolveReviewConfig, computeLightEligible } from './args.js';
@@ -1743,6 +1743,7 @@ const VALIDATE_SCHEMA = {
           finding_id: { type: 'string' },
           confidence: { type: 'number' },
           justification: { type: 'string' },
+          reachability: { type: 'string', enum: REACHABILITY_VALUES },
         },
         required: ['finding_id', 'confidence'],
       },
@@ -1750,6 +1751,15 @@ const VALIDATE_SCHEMA = {
   },
   required: ['validations'],
 };
+
+function validateReturnDescriptor() {
+  return Object.entries(VALIDATE_SCHEMA.properties.validations.items.properties)
+    .map(([name, schema]) => {
+      const values = Array.isArray(schema.enum) ? ` (${schema.enum.join(' | ')})` : '';
+      return `${name}${values}`;
+    })
+    .join(', ');
+}
 
 // validateStage(ctx, input) -> { findings, gaps, stats }
 // Batches findings into limits.validateBatch chunks and dispatches ONE validator per
@@ -1846,7 +1856,7 @@ function validatePrompt(inp, batch) {
     const ev = f.evidence ? ` | evidence: ${f.evidence}` : '';
     return `- ${f.id} [${f.dimension || '?'}/${f.severity || '?'}] ${f.file || '?'}:${range} — ${f.description || ''}${ev}`;
   }).join('\n');
-  return `${ctxLine}Independently validate this batch of findings. For each, Read the code at the file and line range shown, attempt to disprove the claim, and score it. Findings:\n${block}\nReturn { validations: [{ finding_id, confidence, justification }] } — confidence 0-100 (one entry per finding you scored; omit the rest).`;
+  return `${ctxLine}Independently validate this batch of findings. For each, Read the code at the file and line range shown, attempt to disprove the claim, and score it. Findings:\n${block}\nReturn { validations: [{ ${validateReturnDescriptor()} }] } — confidence 0-100 (one entry per finding you scored; omit the rest).`;
 }
 
 // --- Phase 6: Filter --------------------------------------------------------

--- a/workflows/test/filter_unit.test.js
+++ b/workflows/test/filter_unit.test.js
@@ -554,6 +554,19 @@ test('tagFindings routes reachability-demoted findings to suggestions before dim
   assert.equal(suggestionCount, 1);
 });
 
+test('tagFindings: reachability precedence also overrides the always-main security dimension', () => {
+  const finding = {
+    id: 'R8', agent: 'security-reviewer', dimension: 'security', severity: 'low', confidence: 90,
+    title: 'future-only exposure', description: 'a future caller could pass unsanitized input',
+    demoted_by: 'reachability',
+  };
+  const { tagged, mainCount, suggestionCount } = tagFindings([finding]);
+  assert.equal(tagged[0].report_destination, 'suggestion');
+  assert.equal(tagged[0].routed_by, 'reachability');
+  assert.equal(mainCount, 0);
+  assert.equal(suggestionCount, 1);
+});
+
 // Beyond the brief's pinned determinism check: a small end-to-end smoke test
 // that exercises every applyFilterPipeline stage in composition (threshold ->
 // exclusions -> injection -> disagreement -> tag), since no golden-fixture

--- a/workflows/test/filter_unit.test.js
+++ b/workflows/test/filter_unit.test.js
@@ -10,6 +10,7 @@ import {
   WS_TRIM_RE,
   applyFilterPipeline,
   applyThresholdFilter,
+  applyReachabilityDemotion,
   applyInjectionFilter,
   applyExclusions,
   applyInjectedProseStrip,
@@ -498,6 +499,59 @@ test('applyFilterPipeline stamps generated_at from the injected value, never a w
   const cfg = { confidence_threshold: 70, security_min_confidence: 70, severity_threshold: 'low' };
   const out = applyFilterPipeline([], cfg, [], '2026-07-18T00:00:00Z');
   assert.equal(out.generated_at, '2026-07-18T00:00:00Z');
+});
+
+test('applyReachabilityDemotion stamps future-only findings and preserves already-low severity', () => {
+  const findings = [
+    { id: 'R1', severity: 'high', reachability: 'future_change_only' },
+    { id: 'R2', severity: 'low', reachability: 'future_change_only' },
+    { id: 'R3', severity: 'high', reachability: 'current' },
+    { id: 'R4', severity: 'medium', reachability: 'uncertain' },
+    { id: 'R5', severity: 'critical' },
+  ];
+  const { findings: demoted, demotedCount } = applyReachabilityDemotion(findings);
+  assert.equal(demotedCount, 2);
+  assert.equal(demoted[0].severity, 'low');
+  assert.equal(demoted[0].original_severity, 'high');
+  assert.equal(demoted[0].demoted_by, 'reachability');
+  assert.equal(demoted[0].demotion_reason, 'validator found no code path that reaches this issue without a future change');
+  assert.equal(demoted[1].severity, 'low');
+  assert.equal(demoted[1].original_severity, undefined);
+  assert.equal(demoted[1].demoted_by, 'reachability');
+  assert.equal(demoted[2].severity, 'high');
+  assert.equal(demoted[3].severity, 'medium');
+  assert.equal(demoted[4].severity, 'critical');
+  assert.equal(demoted[2].demoted_by, undefined);
+});
+
+test('reachability demotion runs before severity threshold and is counted in composed stats', () => {
+  const finding = {
+    id: 'R6', agent: 'bug-detector', dimension: 'bug', file: 'r.py', line_start: 1,
+    severity: 'high', confidence: 90, reachability: 'future_change_only',
+    title: 'future-only issue', description: 'a future caller would trigger this issue',
+  };
+  const out = applyFilterPipeline([finding], {
+    confidence_threshold: 50, security_min_confidence: 50, severity_threshold: 'medium', ignore: [],
+  }, [], '2026-07-18T00:00:00Z');
+  assert.equal(out.filtered.length, 0);
+  assert.equal(out.eliminated.length, 1);
+  assert.equal(out.eliminated[0].severity, 'low');
+  assert.equal(out.eliminated[0].demoted_by, 'reachability');
+  assert.equal(out.stats.reachability_demoted, 1);
+});
+
+test('tagFindings routes reachability-demoted findings to suggestions before dimensions', () => {
+  const finding = {
+    id: 'R7', agent: 'bug-detector', dimension: 'bug', severity: 'low', confidence: 90,
+    title: 'future-only issue', description: 'a future caller would trigger this issue',
+    demoted_by: 'reachability',
+  };
+  const { tagged, mainCount, suggestionCount } = tagFindings([finding]);
+  assert.equal(tagged[0].report_destination, 'suggestion');
+  assert.equal(tagged[0].report_tag, 'suggestion');
+  assert.equal(tagged[0].routed_by, 'reachability');
+  assert.equal(mainCount, 0);
+  assert.equal(suggestionCount, 1);
 });
 
 // Beyond the brief's pinned determinism check: a small end-to-end smoke test

--- a/workflows/test/parity.test.js
+++ b/workflows/test/parity.test.js
@@ -10,6 +10,7 @@ import {
   normalizeFieldNames,
   parseReviewMd,
   applyThresholdFilter,
+  applyReachabilityDemotion,
   applyInjectionFilter,
   applyReplayInjectionScan,
   loadExclusions,
@@ -255,6 +256,11 @@ for (const c of loadCases('filter_findings')) {
       assert.deepEqual(idsOf(kept), idsOf(c.expected.kept));
       assert.deepEqual(idsOf(eliminated), idsOf(c.expected.eliminated));
       assert.equal(contestedCount, c.expected.contested_count);
+      return;
+    }
+    if (fn === 'apply_reachability_demotion') {
+      const { findings, demotedCount } = applyReachabilityDemotion(c.input.findings);
+      assert.deepEqual({ findings, demoted_count: demotedCount }, c.expected);
       return;
     }
     if (fn === 'apply_injection_filter') {

--- a/workflows/test/render_report.test.js
+++ b/workflows/test/render_report.test.js
@@ -147,6 +147,13 @@ test('T-ROUTE: severity wins over suggestion routing', () => {
   assert.ok(!report.includes('## Improvement Suggestions'));
 });
 
+test('T-REACHABILITY: demoted findings render the reachability explanation only when stamped', () => {
+  const demoted = rendered({ findings: [finding('R', { demoted_by: 'reachability', report_tag: 'suggestion' })] });
+  assert.ok(demoted.includes('- **Reachability:** only under a future change (severity demoted to low)'));
+  const ordinary = rendered({ findings: [finding('R')] });
+  assert.ok(!ordinary.includes('- **Reachability:**'));
+});
+
 test('T-STRIP: the renderer excludes report-excluded fields without mutating its caller', () => {
   const source = finding('S', {
     suggested_fix_code: 'SECRET_PATCH',

--- a/workflows/test/stages_vfc.test.js
+++ b/workflows/test/stages_vfc.test.js
@@ -97,6 +97,25 @@ test('validate accepts the .md-shaped validator output (finding_id -> id)', asyn
   assert.equal(out.stats.adjusted, 1);
 });
 
+test('validate copies a known reachability classification from validator output', async () => {
+  const findings = [vFinding('F1')];
+  const ctx = validateCtx({ byBatch: () => [{ finding_id: 'F1', confidence: 80, reachability: 'future_change_only' }] });
+  const out = await validateStage(ctx, { findings, limits: { validateBatch: 10 }, policy: {} });
+  assert.equal(out.findings[0].reachability, 'future_change_only');
+});
+
+test('validate schema and prompt descriptor derive reachability property and enum', async () => {
+  const ctx = validateCtx();
+  await validateStage(ctx, { findings: [vFinding('F1')], limits: { validateBatch: 10 }, policy: {} });
+  const item = ctx.calls[0].schema.properties.validations.items;
+  assert.deepEqual(item.properties.reachability.enum, ['current', 'future_change_only', 'uncertain']);
+  assert.ok(!item.required.includes('reachability'));
+  const prompt = ctx.calls[0].prompt;
+  for (const name of Object.keys(item.properties)) assert.ok(prompt.includes(name), `${name} missing from prompt`);
+  for (const value of item.properties.reachability.enum) assert.ok(prompt.includes(value), `${value} missing from prompt`);
+  assert.ok(prompt.includes('Return { validations: [{ finding_id, confidence, justification, reachability (current | future_change_only | uncertain) }] }'));
+});
+
 test('validate: empty finding set dispatches nothing', async () => {
   const ctx = validateCtx();
   const out = await validateStage(ctx, { findings: [], limits: { validateBatch: 10 }, policy: {} });

--- a/workflows/test/tools/record_parity.py
+++ b/workflows/test/tools/record_parity.py
@@ -87,6 +87,9 @@ def _filter_findings(inp):
             "eliminated": eliminated,
             "contested_count": contested_count,
         }
+    if fn == "apply_reachability_demotion":
+        findings, demoted_count = ff.apply_reachability_demotion(inp["findings"])
+        return {"findings": findings, "demoted_count": demoted_count}
     if fn == "apply_injection_filter":
         kept, eliminated = ff.apply_injection_filter(inp["findings"])
         return {"kept": kept, "eliminated": eliminated}


### PR DESCRIPTION
Replaces the validator's prose rule "cap confidence at 65 for hypothetical findings" with a structured `reachability` classification and a code-owned demotion step in the Filter stage. The cap was written when both thresholds were 70; since the non-security bar moved to 55, a 65-capped hypothetical survived non-security filtering at whatever severity discovery gave it and died only on security. Validators also applied the cap inconsistently (measured 55 and 60). The number is gone from every live contract; confidence is scored on the merits and reachability is reported as its own field.

## Mechanism

- The validator returns `reachability` on each validation item: `current` (the claim is true of the committed tree, dead code included when dead code is the claim), `future_change_only` (the failure needs a new caller, config value or code path not in this PR), or `uncertain`. Optional in `VALIDATE_SCHEMA` so an omitted field can never degrade a whole batch; the prompt's return line is derived from the schema.
- Both apply-validations twins copy the value only when it is one of the three strings.
- Both filter twins run `applyReachabilityDemotion` / `apply_reachability_demotion` first: a `future_change_only` finding is set to `severity: low` (with `original_severity`, `demoted_by: reachability`, `demotion_reason`). Nothing is eliminated. Because the step precedes the threshold step, a REVIEW.md `severity_threshold` above `low` suppresses these findings by the user's own rule.
- Routing sends demoted findings to `suggestion` (`routed_by: reachability`) ahead of dimension and agent routing, so `main_only` deliveries withhold them. Stats gain `reachability_demoted`. The report renders a Reachability bullet on demoted findings.
- Registry, checkpoint gate, challenge and contestation are untouched. `reachability` is validator metadata like `validation_justification`, not a discovery field.

## Why demotion, not elimination

Measured from `checkpoint-all` artifacts of the five most recent bench runs (validator justification regex, then read by hand). Four findings were genuinely future-only:

| run | pr | id | sev | discovery | validator | final | challenge | outcome |
|---|---|---|---|---|---|---|---|---|
| mini-20260818 | discourse-graphite-10 | type-2 | low | 68 | 55 | 65 | 80 | delivered |
| mini-20260818 | sentry-93824 | type-1 | high | 85 | 60 | 45 | 82 | delivered, adjudicated valid_extra |
| smoke-20260812 | cal.com-22345 | type-1 | low | 46 | 55 | 40 | 20 | challenge removed |
| smoke-20260816 | cal.com-22345 | bug-1 | low | 50 | 55 | 65 | 20 | challenge removed |

Elimination would have removed one valid-extra and one unadjudicated finding and no adjudicated noise. The sentry `simplify-1` dead-code finding (validator 75, challenge 92, "no callers anywhere") shows a literal "reachable today" boolean would misclassify a present defect, hence the three-value enum with dead code defined as `current`. The sentry type-1 row also shows the old cap delivering a hypothetical as HIGH; under this PR it is LOW and suggestion-routed.

Red-teamed by one Claude opus and one Codex sol pass. Both rejected the first draft (eliminate at Filter, keyed to the contestation drop that deleting the cap removes). Opus proposed routing hypotheticals to Challenge unconditionally; declined because every filter survivor already reaches Challenge, which arbitrated all four cases above.

## Paired mini watch items

Recall, noise and valid_extra against the e8b3af7 baseline; `stats.reachability_demoted` per PR; the sentry#93824 type-1 class should appear as LOW suggestion, not HIGH.

## Not in scope

Closing `VALIDATE_SCHEMA` (`additionalProperties`); the challenge cap's overflow behavior; `docs/v3-residue-audit-2026-07.md` stays as a dated record (its R-021 row cites `validation-pipeline.md:72`; the cap sentence sat at line 75 before this PR removed it).

Gates: CI green on e282efc (16 checks, CodeQL python still queued at ready time). Local: pytest 1977 passed, bench 554 passed, Node 1223 pass, parity goldens fresh, generators current, bundle byte-identical, pre-commit clean. Coverage from the #285 CI run: scripts 94.63, bench 88.29, JS 98.71 / 89.57 / 97.72; floors ratcheted to 93.7 and JS branches 88.6 (headroom over 1.0 pp). Review: two Codex luna lenses (mutation ledger, 11 mutations all red; spec conformance D1-D9) with zero blocker or major, one docstring minor fixed in 58ea8ab.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4ZcxgaK8oBKLdcFnuGs2n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches validator output shape and filter routing/demotion in both Python and bundled JS pipeline twins; behavior is heavily fixture-tested but changes what reviewers see for hypothetical findings.
> 
> **Overview**
> Replaces the validator’s informal **65 confidence cap** for hypothetical issues with an explicit **`reachability`** field (`current`, `future_change_only`, `uncertain`). Confidence is scored on merit; reachability is merged in **apply_validations** (Python and JS twins) and drives filter behavior.
> 
> **Filter stage:** `future_change_only` findings are **demoted to low severity** (with stamps like `demoted_by: reachability`), run **before** threshold filtering, **routed to suggestions** ahead of dimension/agent rules, and surfaced in reports with a Reachability bullet. Stats add `reachability_demoted`.
> 
> **Contracts and docs** update `agents/validator.md`, validation pipeline references, validate-stage schema/prompt (optional `reachability` in JSON schema), and delivery/report formatting. CI coverage floors ratchet to **93.7** (Python scripts) and **88.6** (JS branches); `AGENTS.md` shortens the floor history text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e282efcf6c69450b1015a74276d997ac8d4c5fd4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->