### PR TITLE
ci(js-lint): run the Biome gate from one pin file locally and in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,6 +26,7 @@ The PR title will be validated automatically.
 - [ ] Pipeline tests pass: `python -m pytest tests/ -q`
 - [ ] Bench self-tests pass: `python -m pytest bench/tests/ -q`
 - [ ] Workflow tests pass: `node --test workflows/test/*.test.js` (Node 24; the glob is required)
+- [ ] JS lint passes: `python3 workflows/test/tools/biome_check.py` (downloads the pinned Biome once)
 - [ ] Bundle rebuilt and byte-exact: `node workflows/build.js` then `git diff --exit-code workflows/pipeline.js`
 - [ ] Plugin manifests valid: `claude plugin validate .` (needs the Claude Code CLI; CI runs it regardless)
 - [ ] Parity fixtures regenerated with `workflows/test/tools/record_parity.py` if a deterministic transform changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,33 +93,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Download and verify Biome
-        env:
-          # Biome pin is manual — Dependabot cannot see a raw binary URL.
-          # To bump: identify the new release asset id, then:
-          #   gh api repos/biomejs/biome/releases/assets/<id> --jq .digest
-          # Update BIOME_VERSION, URL, and BIOME_SHA256 together. Do not add
-          # package.json / lockfile to get auto-bumps; that reopens #105.
-          BIOME_VERSION: "2.5.6"
-          BIOME_SHA256: "3cc9a0c3fa26ac26a89e8a3b203c010c9ae88e36f69a2679e79981f267ce9d57"
-        run: |
-          set -euo pipefail
-          url="https://github.com/biomejs/biome/releases/download/@biomejs/biome@${BIOME_VERSION}/biome-linux-x64"
-          out="${RUNNER_TEMP}/biome"
-          # --retry-all-errors: GitHub releases intermittently 503s (redded main
-          # 2026-08-12 on a docs-only merge); the sha256 check below still gates
-          # whatever the retry finally fetches.
-          curl -fsSL --retry 4 --retry-all-errors "$url" -o "$out"
-          echo "${BIOME_SHA256}  ${out}" | sha256sum -c -
-          chmod +x "$out"
-          echo "BIOME=${out}" >> "$GITHUB_ENV"
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
 
-      # cwd is workflows/ because --config-path from the repo root trips Biome 2.5.6's nested-root-configuration detection.
       - name: Lint workflows JS
-        working-directory: workflows
-        run: |
-          set -euo pipefail
-          "${BIOME}" check --error-on-warnings .
+        run: python3 workflows/test/tools/biome_check.py
 
   workflow-tests:
     name: Run Workflow JS Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ takes coordinated edits across N files, fix the shape rather than documenting th
 
 ## Tooling boundary (no npm in the tree)
 
-- No `package.json`, lockfile, or `node_modules` is tracked outside the vendored scorer under `bench/vendor/`.
+- No `package.json`, lockfile, or `node_modules` is tracked, except the vendored scorer's own
+  `bench/vendor/code-review-benchmark/uv.lock`.
 - The shipped pipeline runtime (`workflows/src`, `workflows/pipeline.js`) has zero
   dependencies — language globals plus the host-injected `agent`/`parallel`/
   `pipeline`/`args` only. No import survives into the bundle: `build.js` strips

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ takes coordinated edits across N files, fix the shape rather than documenting th
 
 ## Tooling boundary (no npm in the tree)
 
-- No `package.json`, lockfile, or `node_modules` is tracked in the repository.
+- No `package.json`, lockfile, or `node_modules` is tracked outside the vendored scorer under `bench/vendor/`.
 - The shipped pipeline runtime (`workflows/src`, `workflows/pipeline.js`) has zero
   dependencies — language globals plus the host-injected `agent`/`parallel`/
   `pipeline`/`args` only. No import survives into the bundle: `build.js` strips

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,9 @@ python -m pytest bench/tests/ -q
 # JS workflow tests (Node 24)
 node --test workflows/test/*.test.js
 
+# Run the Biome JS lint gate locally (downloads the pinned binary once, verifies its checksum)
+python3 workflows/test/tools/biome_check.py
+
 # Rebuild the generated workflow bundle after editing workflows/src/
 node workflows/build.js
 
@@ -157,6 +160,7 @@ Before submitting a PR, run:
 python -m pytest tests/ -q
 python -m pytest bench/tests/ -q
 node --test workflows/test/*.test.js
+python3 workflows/test/tools/biome_check.py
 node workflows/build.js && git diff --exit-code workflows/pipeline.js
 claude plugin validate .
 pre-commit run --all-files
@@ -166,6 +170,7 @@ This will:
 
 - Execute the pytest suite for pipeline scripts and the bench harness
 - Execute the Node workflow test suite (stage contracts, parity replay, and the bundler's collision guard)
+- Execute the shared Biome JS lint gate with its pinned binary
 - Confirm the committed bundle is byte-identical to a fresh build
 - Validate the plugin and marketplace manifests
 - Check YAML and TOML syntax
@@ -179,8 +184,7 @@ This will:
 no extra dependency. CI installs a pinned version (`.github/workflows/validate.yml`) and runs it on every pull
 request, so a local run is a fast pre-check, not the enforcement. Skip it only if you do not have the CLI.
 
-Two required checks have no local command and are **CI-only**: `Run Workflow JS Lint` (Biome, downloaded and
-checksum-pinned in `.github/workflows/ci.yml`) and `lint-pr-title` (needs the PR title). Everything else in the
+One required check has no local command and is **CI-only**: `lint-pr-title` (needs the PR title). Everything else in the
 merge gate is reproducible from the block above.
 
 Live bench smoke and paired measurements are **not** contributor gates — see
@@ -231,8 +235,8 @@ If a change is breaking, include `!` (e.g., `feat!: change findings JSON schema`
 
 - Ensure all checks pass (pre-commit and the test suite) before requesting review. The checklist in
   `.github/pull_request_template.md` enumerates every CI-enforced gate a contributor can run locally; tick the
-  ones that apply and say why for any you skipped. The two CI-only checks named under
-  [Testing](#testing) have no local command and are not on the checklist.
+  ones that apply and say why for any you skipped. The CI-only check named under
+  [Testing](#testing) has no local command and is not on the checklist.
 - **Merges to `main` require the always-on CI check-runs to be green** (lint, pytest
   matrix, workflow JS tests, bench self-tests, plugin validate, PR title lint). Those
   contexts are frozen in `REQUIRED_PR_CHECK_CONTEXTS` in

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -197,7 +197,10 @@ CODEX_CAP_BYTES = 32_768
 # before editing src/ why the bundle has no full-line comments or blank lines and why a
 # rebuild can fail on size. The mechanism is code, but the rule an author needs before
 # editing src/ is read only after the failure; nothing else in the tree tells them.
-AGENTS_SET_BUDGET_BYTES = 21_992
+# Raised 21_992 -> 22_345 (2026-09-05, #158/#176): authors need the shared Biome runner,
+# operational pin location, and vendored-scorer tooling boundary before editing; code
+# cannot carry these cross-surface contributor rules.
+AGENTS_SET_BUDGET_BYTES = 22_345
 CLAUDE_MD_MAX_BYTES = 856
 
 # Root CLAUDE.md is a pointer, not a document. The line cap is a shape bound and keeps its

--- a/tests/test_agent_instruction_layout.py
+++ b/tests/test_agent_instruction_layout.py
@@ -200,7 +200,9 @@ CODEX_CAP_BYTES = 32_768
 # Raised 21_992 -> 22_345 (2026-09-05, #158/#176): authors need the shared Biome runner,
 # operational pin location, and vendored-scorer tooling boundary before editing; code
 # cannot carry these cross-surface contributor rules.
-AGENTS_SET_BUDGET_BYTES = 22_345
+# Raised 22_345 -> 22_349 (2026-09-06, #295 review): the tooling-boundary bullet now names the
+# one exempt lockfile exactly, matching the guard test; a broader phrase misstated the rule.
+AGENTS_SET_BUDGET_BYTES = 22_349
 CLAUDE_MD_MAX_BYTES = 856
 
 # Root CLAUDE.md is a pointer, not a document. The line cap is a shape bound and keeps its

--- a/tests/test_biome_check.py
+++ b/tests/test_biome_check.py
@@ -139,6 +139,13 @@ class TestBiomeCheck(unittest.TestCase):
 
             self.assertEqual(code, 0)
             self.assertEqual(len(fetched), 1)
+            self.assertEqual(
+                fetched,
+                [
+                    f"https://github.com/biomejs/biome/releases/download/"
+                    f"@biomejs/biome@{TEST_VERSION}/{asset}"
+                ],
+            )
             self.assertEqual(final.read_bytes(), expected_data)
             self.assertEqual(stat.S_IMODE(final.stat().st_mode), 0o755)
             self.assertFalse(final.with_name(f"{asset}.part").exists())
@@ -200,6 +207,11 @@ class TestBiomeCheck(unittest.TestCase):
             cache = Path(directory) / "cache"
             pin_path.write_text(json.dumps(pin), encoding="utf-8")
             calls: list[tuple[list[str], Path]] = []
+            fetched: list[str] = []
+
+            def fetch(url: str) -> bytes:
+                fetched.append(url)
+                return data
 
             def record_run(argv: list[str], cwd: Path) -> int:
                 calls.append((argv, cwd))
@@ -208,11 +220,18 @@ class TestBiomeCheck(unittest.TestCase):
             with patch.object(biome_check, "PIN_FILE", pin_path):
                 code = main(
                     ["--asset", asset, "--cache-dir", str(cache)],
-                    fetch=lambda url: data,
+                    fetch=fetch,
                     run=record_run,
                 )
             final = cache.resolve() / TEST_VERSION / asset
             self.assertEqual(code, 0)
+            self.assertEqual(
+                fetched,
+                [
+                    f"https://github.com/biomejs/biome/releases/download/"
+                    f"@biomejs/biome@{TEST_VERSION}/{asset}"
+                ],
+            )
             self.assertEqual(final.read_bytes(), data)
             self.assertEqual(stat.S_IMODE(final.stat().st_mode), 0o755)
             self.assertEqual(
@@ -422,6 +441,22 @@ class TestBiomeCheck(unittest.TestCase):
             self.assertEqual(code, 0)
             self.assertTrue((cache / TEST_VERSION / asset).is_file())
             self.assertFalse((xdg / "code-gauntlet" / "biome").exists())
+
+            flag_cache = Path(directory) / "flag-cache"
+            env_cache = Path(directory) / "flag-env-cache"
+            with patch.object(biome_check, "PIN_FILE", pin_path):
+                code = main(
+                    ["--asset", asset, "--cache-dir", str(flag_cache)],
+                    fetch=lambda _url: data,
+                    run=lambda _argv, _cwd: 0,
+                    environ={
+                        "CODE_GAUNTLET_BIOME_CACHE": str(env_cache),
+                        "XDG_CACHE_HOME": str(xdg),
+                    },
+                )
+            self.assertEqual(code, 0)
+            self.assertTrue((flag_cache / TEST_VERSION / asset).is_file())
+            self.assertFalse((env_cache / TEST_VERSION / asset).exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_biome_check.py
+++ b/tests/test_biome_check.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import hashlib
+import http.client
 import io
 import json
 import os
+import socket
 import stat
 import tempfile
 import unittest
 import urllib.error
 from contextlib import redirect_stderr
+from email.message import Message
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from workflows.test.tools import biome_check
@@ -104,6 +108,39 @@ class TestBiomeCheck(unittest.TestCase):
             self.assertIn(f"expected {checksums[asset]}", error.getvalue())
             self.assertIn("actual", error.getvalue())
             self.assertFalse(final.exists())
+            self.assertFalse(final.with_name(f"{asset}.part").exists())
+
+    @unittest.skipUnless(os.name != "nt", "mode bits are POSIX-only")
+    def test_mismatched_cache_is_refreshed_and_installed_executable(self) -> None:
+        asset = "biome-test"
+        old_data = b"stale cached binary"
+        expected_data = b"refreshed binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(expected_data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            cache = Path(directory) / "cache"
+            final = cache.resolve() / TEST_VERSION / asset
+            final.parent.mkdir(parents=True)
+            final.write_bytes(old_data)
+            final.chmod(0o644)
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            fetched: list[str] = []
+
+            def fetch(url: str) -> bytes:
+                fetched.append(url)
+                return expected_data
+
+            with patch.object(biome_check, "PIN_FILE", pin_path):
+                code = main(
+                    ["--asset", asset, "--cache-dir", str(cache)],
+                    fetch=fetch,
+                    run=lambda _argv, _cwd: 0,
+                )
+
+            self.assertEqual(code, 0)
+            self.assertEqual(len(fetched), 1)
+            self.assertEqual(final.read_bytes(), expected_data)
+            self.assertEqual(stat.S_IMODE(final.stat().st_mode), 0o755)
             self.assertFalse(final.with_name(f"{asset}.part").exists())
 
     @unittest.skipUnless(os.name != "nt", "mode bits are POSIX-only")
@@ -252,6 +289,100 @@ class TestBiomeCheck(unittest.TestCase):
                 )
             self.assertEqual(code, 1)
             self.assertEqual(failed_calls, 5)
+
+    def test_retry_recovers_from_non_url_errors(self) -> None:
+        failures = (
+            socket.timeout("timed out"),  # noqa: UP041 - named regression case
+            urllib.error.HTTPError(
+                "https://example.test/biome", 503, "unavailable", Message(), None
+            ),
+            http.client.IncompleteRead(b"partial"),
+        )
+        asset = "biome-test"
+        data = b"retry-all-errors binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            for index, failure in enumerate(failures):
+                calls = 0
+
+                def flaky_fetch(_url: str, failure: Exception = failure) -> bytes:
+                    nonlocal calls
+                    calls += 1
+                    if calls == 1:
+                        raise failure
+                    return data
+
+                with (
+                    self.subTest(error=type(failure).__name__),
+                    patch.object(biome_check, "PIN_FILE", pin_path),
+                    patch.object(biome_check.time, "sleep") as sleep,
+                ):
+                    code = main(
+                        [
+                            "--asset",
+                            asset,
+                            "--cache-dir",
+                            str(Path(directory) / f"cache-{index}"),
+                        ],
+                        fetch=flaky_fetch,
+                        run=lambda _argv, _cwd: 0,
+                    )
+
+                self.assertEqual(code, 0)
+                self.assertEqual(calls, 2)
+                sleep.assert_called_once_with(1)
+
+    def test_fetch_url_builds_the_pinned_request(self) -> None:
+        url = "https://example.test/biome"
+        data = b"downloaded over urllib"
+        with patch.object(biome_check.urllib.request, "urlopen") as urlopen:
+            response = urlopen.return_value.__enter__.return_value
+            response.read.return_value = data
+
+            result = biome_check._fetch_url(url)
+
+        self.assertEqual(result, data)
+        urlopen.assert_called_once()
+        request = urlopen.call_args.args[0]
+        self.assertIsInstance(request, biome_check.urllib.request.Request)
+        self.assertEqual(request.full_url, url)
+        self.assertEqual(request.get_header("User-agent"), biome_check.USER_AGENT)
+        self.assertEqual(urlopen.call_args.kwargs["timeout"], 30)
+
+    def test_main_wires_the_default_process_adapter(self) -> None:
+        asset = "biome-test"
+        data = b"pre-verified binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            cache = Path(directory) / "cache"
+            final = cache.resolve() / TEST_VERSION / asset
+            final.parent.mkdir(parents=True)
+            final.write_bytes(data)
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+
+            with (
+                patch.object(biome_check, "PIN_FILE", pin_path),
+                patch.object(
+                    biome_check.subprocess,
+                    "run",
+                    return_value=SimpleNamespace(returncode=17),
+                ) as subprocess_run,
+            ):
+                code = main(
+                    ["--asset", asset, "--cache-dir", str(cache)],
+                    fetch=lambda _url: (_ for _ in ()).throw(
+                        AssertionError("pre-verified cache downloaded")
+                    ),
+                )
+
+            self.assertEqual(code, 17)
+            subprocess_run.assert_called_once_with(
+                [str(final), "check", "--error-on-warnings", "."],
+                cwd=biome_check.WORKFLOWS_DIR,
+            )
 
     def test_invalid_asset_override_is_usage_error(self) -> None:
         data = b"asset error"

--- a/tests/test_biome_check.py
+++ b/tests/test_biome_check.py
@@ -458,6 +458,28 @@ class TestBiomeCheck(unittest.TestCase):
             self.assertTrue((flag_cache / TEST_VERSION / asset).is_file())
             self.assertFalse((env_cache / TEST_VERSION / asset).exists())
 
+    def test_bare_home_fallback_uses_dot_cache(self) -> None:
+        asset = "biome-test"
+        data = b"home binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            home = Path(directory) / "home"
+            home.mkdir()
+            with patch.object(biome_check, "PIN_FILE", pin_path):
+                code = main(
+                    ["--asset", asset],
+                    fetch=lambda _url: data,
+                    run=lambda _argv, _cwd: 0,
+                    environ={"HOME": str(home)},
+                )
+            self.assertEqual(code, 0)
+            expected = (
+                home / ".cache" / "code-gauntlet" / "biome" / TEST_VERSION / asset
+            )
+            self.assertTrue(expected.is_file())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_biome_check.py
+++ b/tests/test_biome_check.py
@@ -1,0 +1,297 @@
+"""Tests for the contributor-local Biome runner."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import stat
+import tempfile
+import unittest
+import urllib.error
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import patch
+
+from workflows.test.tools import biome_check
+from workflows.test.tools.biome_check import (
+    PinError,
+    UnsupportedPlatformError,
+    build_command,
+    load_pin,
+    main,
+    resolve_asset,
+)
+
+ASSET_ROWS = (
+    ("Darwin", "arm64", "biome-darwin-arm64"),
+    ("Darwin", "x86_64", "biome-darwin-x64"),
+    ("Linux", "x86_64", "biome-linux-x64"),
+    ("Linux", "amd64", "biome-linux-x64"),
+    ("Linux", "aarch64", "biome-linux-arm64"),
+    ("Linux", "arm64", "biome-linux-arm64"),
+    ("Windows", "AMD64", "biome-win32-x64.exe"),
+    ("Windows", "x86_64", "biome-win32-x64.exe"),
+    ("Windows", "ARM64", "biome-win32-arm64.exe"),
+    ("Windows", "aarch64", "biome-win32-arm64.exe"),
+)
+
+
+def _pin_data(version: str, asset: str, digest: str) -> dict[str, object]:
+    return {"version": version, "sha256": {asset: digest}}
+
+
+TEST_VERSION = "1.2.3"
+
+
+class TestBiomeCheck(unittest.TestCase):
+    def test_resolve_asset_table_and_unsupported_pair(self) -> None:
+        for system, machine, expected in ASSET_ROWS:
+            with self.subTest(system=system, machine=machine):
+                self.assertEqual(resolve_asset(system, machine), expected)
+        with self.assertRaises(UnsupportedPlatformError) as raised:
+            resolve_asset("Plan9", "sparc")
+        for asset in biome_check.ASSET_NAMES:
+            self.assertIn(asset, str(raised.exception))
+
+    def test_load_pin_rejects_invalid_shapes_and_values(self) -> None:
+        cases: tuple[tuple[object, str], ...] = (
+            ([], "pin file must be an object"),
+            ({"sha256": {"asset": "a" * 64}}, "version"),
+            (_pin_data("1.2", "asset", "a" * 64), "version"),
+            (_pin_data(TEST_VERSION, "asset", "g" * 64), "asset"),
+            (_pin_data(TEST_VERSION, "asset", "a" * 63), "asset"),
+            ({"version": TEST_VERSION}, "sha256"),
+            ({"version": TEST_VERSION, "sha256": {}}, "sha256"),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "pin.json"
+            for value, message in cases:
+                with self.subTest(value=value):
+                    path.write_text(json.dumps(value), encoding="utf-8")
+                    with self.assertRaisesRegex(PinError, message):
+                        load_pin(path)
+
+    def test_build_command_puts_extra_args_after_the_workflow_path(self) -> None:
+        self.assertEqual(
+            build_command("/tmp/biome binary", ["--verbose"]),
+            ["/tmp/biome binary", "check", "--error-on-warnings", ".", "--verbose"],
+        )
+
+    def test_checksum_mismatch_leaves_no_final_or_part_file(self) -> None:
+        expected_bytes = b"the expected binary"
+        asset = "biome-test"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(expected_bytes).hexdigest())
+        checksums = pin["sha256"]
+        assert isinstance(checksums, dict)
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            cache = Path(directory) / "cache with spaces"
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            error = io.StringIO()
+            with (
+                redirect_stderr(error),
+                patch.object(biome_check, "PIN_FILE", pin_path),
+            ):
+                code = main(
+                    ["--asset", asset, "--cache-dir", str(cache)],
+                    fetch=lambda _url: b"wrong bytes",
+                    run=lambda _argv, _cwd: 0,
+                )
+            final = cache.resolve() / TEST_VERSION / asset
+            self.assertEqual(code, 1)
+            self.assertIn(f"expected {checksums[asset]}", error.getvalue())
+            self.assertIn("actual", error.getvalue())
+            self.assertFalse(final.exists())
+            self.assertFalse(final.with_name(f"{asset}.part").exists())
+
+    @unittest.skipUnless(os.name != "nt", "mode bits are POSIX-only")
+    def test_cache_hit_skips_fetch_restores_mode_and_runs_expected_command(
+        self,
+    ) -> None:
+        asset = "biome-test"
+        data = b"cached binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            cache = Path(directory) / "cache with spaces"
+            final = cache.resolve() / TEST_VERSION / asset
+            final.parent.mkdir(parents=True)
+            final.write_bytes(data)
+            final.chmod(0o644)
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            calls: list[tuple[list[str], Path]] = []
+
+            def run(argv: list[str], cwd: Path) -> int:
+                calls.append((argv, cwd))
+                return 0
+
+            with patch.object(biome_check, "PIN_FILE", pin_path):
+                code = main(
+                    ["--asset", asset, "--cache-dir", str(cache), "--", "--verbose"],
+                    fetch=lambda _url: (_ for _ in ()).throw(
+                        AssertionError("cache hit downloaded")
+                    ),
+                    run=run,
+                )
+            self.assertEqual(code, 0)
+            self.assertEqual(stat.S_IMODE(final.stat().st_mode), 0o755)
+            self.assertEqual(
+                calls,
+                [
+                    (
+                        [
+                            str(final),
+                            "check",
+                            "--error-on-warnings",
+                            ".",
+                            "--verbose",
+                        ],
+                        biome_check.WORKFLOWS_DIR,
+                    )
+                ],
+            )
+
+    @unittest.skipUnless(os.name != "nt", "mode bits are POSIX-only")
+    def test_download_verifies_and_installs_executable(self) -> None:
+        asset = "biome-test"
+        data = b"downloaded binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            cache = Path(directory) / "cache"
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            calls: list[tuple[list[str], Path]] = []
+
+            def record_run(argv: list[str], cwd: Path) -> int:
+                calls.append((argv, cwd))
+                return 0
+
+            with patch.object(biome_check, "PIN_FILE", pin_path):
+                code = main(
+                    ["--asset", asset, "--cache-dir", str(cache)],
+                    fetch=lambda url: data,
+                    run=record_run,
+                )
+            final = cache.resolve() / TEST_VERSION / asset
+            self.assertEqual(code, 0)
+            self.assertEqual(final.read_bytes(), data)
+            self.assertEqual(stat.S_IMODE(final.stat().st_mode), 0o755)
+            self.assertEqual(
+                calls[0],
+                (
+                    [str(final), "check", "--error-on-warnings", "."],
+                    biome_check.WORKFLOWS_DIR,
+                ),
+            )
+
+    def test_biome_return_code_is_propagated(self) -> None:
+        asset = "biome-test"
+        data = b"return code binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            with patch.object(biome_check, "PIN_FILE", pin_path):
+                self.assertEqual(
+                    main(
+                        ["--asset", asset, "--cache-dir", directory],
+                        fetch=lambda _url: data,
+                        run=lambda _argv, _cwd: 17,
+                    ),
+                    17,
+                )
+
+    def test_retry_four_failures_then_success_and_five_failures(self) -> None:
+        asset = "biome-test"
+        data = b"retry binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            successful_calls = 0
+
+            def flaky_fetch(_url: str) -> bytes:
+                nonlocal successful_calls
+                successful_calls += 1
+                if successful_calls < 5:
+                    raise urllib.error.URLError("temporary failure")
+                return data
+
+            with (
+                patch.object(biome_check, "PIN_FILE", pin_path),
+                patch.object(biome_check.time, "sleep") as sleep,
+            ):
+                code = main(
+                    ["--asset", asset, "--cache-dir", str(Path(directory) / "one")],
+                    fetch=flaky_fetch,
+                    run=lambda _argv, _cwd: 0,
+                )
+            self.assertEqual(code, 0)
+            self.assertEqual(successful_calls, 5)
+            self.assertEqual(
+                [call.args[0] for call in sleep.call_args_list], [1, 2, 4, 8]
+            )
+
+            failed_calls = 0
+
+            def failing_fetch(_url: str) -> bytes:
+                nonlocal failed_calls
+                failed_calls += 1
+                raise urllib.error.URLError("permanent failure")
+
+            with (
+                patch.object(biome_check, "PIN_FILE", pin_path),
+                patch.object(biome_check.time, "sleep"),
+            ):
+                code = main(
+                    ["--asset", asset, "--cache-dir", str(Path(directory) / "two")],
+                    fetch=failing_fetch,
+                    run=lambda _argv, _cwd: 0,
+                )
+            self.assertEqual(code, 1)
+            self.assertEqual(failed_calls, 5)
+
+    def test_invalid_asset_override_is_usage_error(self) -> None:
+        data = b"asset error"
+        pin = _pin_data(TEST_VERSION, "biome-test", hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            with patch.object(biome_check, "PIN_FILE", pin_path):
+                self.assertEqual(
+                    main(
+                        ["--asset", "missing", "--cache-dir", directory],
+                        fetch=lambda _url: data,
+                        run=lambda _argv, _cwd: 0,
+                    ),
+                    2,
+                )
+
+    def test_cache_environment_precedes_xdg_default(self) -> None:
+        asset = "biome-test"
+        data = b"environment binary"
+        pin = _pin_data(TEST_VERSION, asset, hashlib.sha256(data).hexdigest())
+        with tempfile.TemporaryDirectory() as directory:
+            pin_path = Path(directory) / "pin.json"
+            pin_path.write_text(json.dumps(pin), encoding="utf-8")
+            cache = Path(directory) / "configured-cache"
+            xdg = Path(directory) / "xdg-cache"
+            with patch.object(biome_check, "PIN_FILE", pin_path):
+                code = main(
+                    ["--asset", asset],
+                    fetch=lambda _url: data,
+                    run=lambda _argv, _cwd: 0,
+                    environ={
+                        "CODE_GAUNTLET_BIOME_CACHE": str(cache),
+                        "XDG_CACHE_HOME": str(xdg),
+                    },
+                )
+            self.assertEqual(code, 0)
+            self.assertTrue((cache / TEST_VERSION / asset).is_file())
+            self.assertFalse((xdg / "code-gauntlet" / "biome").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_contribution_surface.py
+++ b/tests/test_contribution_surface.py
@@ -34,6 +34,16 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parents[1]
 FORMS = REPO / ".github" / "ISSUE_TEMPLATE"
 LABELS_DIFF = REPO / ".github" / "labels_diff.py"
+BIOME_ASSETS = {
+    "biome-darwin-arm64",
+    "biome-darwin-x64",
+    "biome-linux-arm64",
+    "biome-linux-arm64-musl",
+    "biome-linux-x64",
+    "biome-linux-x64-musl",
+    "biome-win32-arm64.exe",
+    "biome-win32-x64.exe",
+}
 
 ADVISORY_URL = (
     "https://github.com/liatrio-labs/claude-code-gauntlet/security/advisories/new"
@@ -776,6 +786,7 @@ class TestContributingDocs(unittest.TestCase):
         for command in (
             "python -m pytest tests/ -q",
             "node --test workflows/test/*.test.js",
+            "python3 workflows/test/tools/biome_check.py",
             "pre-commit run --all-files",
             "node workflows/build.js",
         ):
@@ -796,6 +807,7 @@ class TestContributingDocs(unittest.TestCase):
         text = _read(".github/pull_request_template.md")
         for gate in (
             "node --test workflows/test/*.test.js",
+            "python3 workflows/test/tools/biome_check.py",
             "node workflows/build.js",
             "workflows/test/tools/record_parity.py",
         ):
@@ -916,6 +928,45 @@ class TestContributingDocs(unittest.TestCase):
         )
 
 
+class TestBiomeLintSurface(unittest.TestCase):
+    def test_pin_file_has_all_known_assets_and_valid_digests(self) -> None:
+        pin = json.loads(_read("workflows/biome-pin.json"))
+        self.assertIsInstance(pin, dict)
+        self.assertRegex(pin["version"], r"^\d+\.\d+\.\d+$")
+        self.assertEqual(set(pin["sha256"]), BIOME_ASSETS)
+        for asset, digest in pin["sha256"].items():
+            with self.subTest(asset=asset):
+                self.assertIn(asset, BIOME_ASSETS)
+                self.assertRegex(digest, r"^[0-9a-f]{64}$")
+
+    def test_ci_js_lint_uses_runner_without_another_biome_pin(self) -> None:
+        ci = _read(".github/workflows/ci.yml")
+        js_lint = ci.split("  js-lint:\n", 1)[1].split("\n  workflow-tests:", 1)[0]
+        self.assertIn("python3 workflows/test/tools/biome_check.py", js_lint)
+        for forbidden in (
+            "BIOME_VERSION",
+            "BIOME_SHA256",
+            "sha256sum",
+            "releases/download/@biomejs",
+        ):
+            with self.subTest(forbidden=forbidden):
+                self.assertNotIn(forbidden, ci)
+
+    def test_operational_biome_version_lives_only_in_pin_file(self) -> None:
+        version = json.loads(_read("workflows/biome-pin.json"))["version"]
+        paths = (
+            ".github/workflows/ci.yml",
+            "workflows/AGENTS.md",
+            "workflows/CLAUDE.md",
+            "CONTRIBUTING.md",
+            "README.md",
+            ".github/pull_request_template.md",
+        )
+        for path in paths:
+            with self.subTest(path=path):
+                self.assertNotIn(version, _read(path))
+
+
 # Required PR check-run names for ruleset 16049246 (protect-default-branch).
 # Any new always-on PR gate must update THIS tuple and the live ruleset in the
 # same change (see #108 / #102 / #105). GitHub matches check-run names, not
@@ -943,7 +994,7 @@ LOCAL_COMMAND_FOR_REQUIRED_CHECK = {
     "Run Tests (3.10)": "python -m pytest tests/ -q",
     "Run Tests (3.11)": "python -m pytest tests/ -q",
     "Run Tests (3.12)": "python -m pytest tests/ -q",
-    "Run Workflow JS Lint": None,  # Biome is a checksum-pinned CI download.
+    "Run Workflow JS Lint": "python3 workflows/test/tools/biome_check.py",
     "Run Workflow JS Tests": "node --test workflows/test/*.test.js",
     "Run Bench Self-Tests (3.11)": "python -m pytest bench/tests/ -q",
     "Run Bench Self-Tests (3.12)": "python -m pytest bench/tests/ -q",

--- a/tests/test_contribution_surface.py
+++ b/tests/test_contribution_surface.py
@@ -797,6 +797,30 @@ class TestContributingDocs(unittest.TestCase):
         )
         self.assertIn("workflows/test/tools/record_parity.py", text)
 
+    def test_contributing_places_biome_command_in_each_relevant_bash_block(self):
+        text = _read("CONTRIBUTING.md")
+        command = "python3 workflows/test/tools/biome_check.py"
+        sections = (
+            (
+                "### Common Commands",
+                "## The v3 workflow pipeline (JS)",
+            ),
+            (
+                "## Testing",
+                "## Branching and Commit Conventions",
+            ),
+        )
+        for heading, next_heading in sections:
+            with self.subTest(heading=heading):
+                section = text.split(f"{heading}\n", 1)[1].split(
+                    f"\n{next_heading}\n", 1
+                )
+                blocks = re.findall(
+                    r"```bash\n(?P<block>.*?)```", section[0], re.DOTALL
+                )
+                self.assertEqual(len(blocks), 1)
+                self.assertIn(command, blocks[0])
+
     def test_contributing_describes_the_v3_js_pipeline_areas(self):
         text = _read("CONTRIBUTING.md")
         self.assertIn("workflows/src/", text)

--- a/tests/test_tooling_boundary.py
+++ b/tests/test_tooling_boundary.py
@@ -59,12 +59,28 @@ class TestToolingBoundary(unittest.TestCase):
             "x/y/node_modules/z.js",
             "bun.lockb",
             EXEMPT_PATH,
+            "bench/vendor/other/package.json",
+            "bench/vendor/code-review-benchmark/package-lock.json",
+            "docs/Pipfile.lock",
             "docs/uv.lock",
         ]
         self.assertEqual(
             violations(paths),
-            ["a/package.json", "x/y/node_modules/z.js", "bun.lockb", "docs/uv.lock"],
+            [
+                "a/package.json",
+                "x/y/node_modules/z.js",
+                "bun.lockb",
+                "bench/vendor/other/package.json",
+                "bench/vendor/code-review-benchmark/package-lock.json",
+                "docs/Pipfile.lock",
+                "docs/uv.lock",
+            ],
         )
+
+    def test_every_forbidden_basename_is_detected(self) -> None:
+        forbidden_paths = [f"dir/{name}" for name in FORBIDDEN_BASENAMES]
+        paths = [*forbidden_paths, "nested/node_modules/package.json"]
+        self.assertEqual(violations(paths), paths)
 
     def test_uv_lock_is_ignored_for_local_ci_tooling(self) -> None:
         result = subprocess.run(

--- a/tests/test_tooling_boundary.py
+++ b/tests/test_tooling_boundary.py
@@ -1,0 +1,59 @@
+"""Structural guard for the repository tooling boundary (#176).
+
+The tooling boundary in AGENTS.md was convention-only before this test. The
+vendored scorer's own ``bench/vendor/code-review-benchmark/uv.lock`` is the one
+exact exemption, documented at bench/vendor/VENDORED.md:85-87; that vendored
+third-party tree is exempt from the stdlib rule and runs under uv against its
+own lockfile.
+"""
+
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+FORBIDDEN_BASENAMES = (
+    "package.json",
+    "package-lock.json",
+    "npm-shrinkwrap.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "bun.lock",
+    "bun.lockb",
+    "uv.lock",
+    "poetry.lock",
+    "Pipfile",
+    "Pipfile.lock",
+)
+EXEMPT_PATH = "bench/vendor/code-review-benchmark/uv.lock"
+
+
+class TestToolingBoundary(unittest.TestCase):
+    def test_tracked_tooling_files_stay_outside_the_vendored_scorer(self) -> None:
+        result = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=REPO,
+            check=True,
+            capture_output=True,
+        )
+        paths = [path for path in result.stdout.decode().split("\0") if path]
+        violations = []
+        for path in paths:
+            if path == EXEMPT_PATH:
+                continue
+            parts = Path(path).parts
+            if Path(path).name in FORBIDDEN_BASENAMES or "node_modules" in parts:
+                violations.append(path)
+        self.assertEqual(violations, [])
+        self.assertEqual(paths.count(EXEMPT_PATH), 1)
+
+    def test_uv_lock_is_ignored_for_local_ci_tooling(self) -> None:
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", "--", "uv.lock"],
+            cwd=REPO,
+        )
+        self.assertEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tooling_boundary.py
+++ b/tests/test_tooling_boundary.py
@@ -35,8 +35,8 @@ def violations(paths: Iterable[str]) -> list[str]:
     for path in paths:
         if path == EXEMPT_PATH:
             continue
-        path_parts = Path(path).parts
-        if Path(path).name in FORBIDDEN_BASENAMES or "node_modules" in path_parts:
+        candidate = Path(path)
+        if candidate.name in FORBIDDEN_BASENAMES or "node_modules" in candidate.parts:
             offenders.append(path)
     return offenders
 

--- a/tests/test_tooling_boundary.py
+++ b/tests/test_tooling_boundary.py
@@ -78,6 +78,24 @@ class TestToolingBoundary(unittest.TestCase):
         )
 
     def test_every_forbidden_basename_is_detected(self) -> None:
+        # Hand-typed pin: a fixture derived from the tuple under test would stay green
+        # if the tuple lost an entry, so the tuple is first checked against this literal.
+        self.assertEqual(
+            set(FORBIDDEN_BASENAMES),
+            {
+                "package.json",
+                "package-lock.json",
+                "npm-shrinkwrap.json",
+                "yarn.lock",
+                "pnpm-lock.yaml",
+                "bun.lock",
+                "bun.lockb",
+                "uv.lock",
+                "poetry.lock",
+                "Pipfile",
+                "Pipfile.lock",
+            },
+        )
         forbidden_paths = [f"dir/{name}" for name in FORBIDDEN_BASENAMES]
         paths = [*forbidden_paths, "nested/node_modules/package.json"]
         self.assertEqual(violations(paths), paths)

--- a/tests/test_tooling_boundary.py
+++ b/tests/test_tooling_boundary.py
@@ -9,6 +9,7 @@ own lockfile.
 
 import subprocess
 import unittest
+from collections.abc import Iterable
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[1]
@@ -28,6 +29,18 @@ FORBIDDEN_BASENAMES = (
 EXEMPT_PATH = "bench/vendor/code-review-benchmark/uv.lock"
 
 
+def violations(paths: Iterable[str]) -> list[str]:
+    """Return tracked paths that cross the local tooling boundary."""
+    offenders = []
+    for path in paths:
+        if path == EXEMPT_PATH:
+            continue
+        path_parts = Path(path).parts
+        if Path(path).name in FORBIDDEN_BASENAMES or "node_modules" in path_parts:
+            offenders.append(path)
+    return offenders
+
+
 class TestToolingBoundary(unittest.TestCase):
     def test_tracked_tooling_files_stay_outside_the_vendored_scorer(self) -> None:
         result = subprocess.run(
@@ -37,15 +50,21 @@ class TestToolingBoundary(unittest.TestCase):
             capture_output=True,
         )
         paths = [path for path in result.stdout.decode().split("\0") if path]
-        violations = []
-        for path in paths:
-            if path == EXEMPT_PATH:
-                continue
-            parts = Path(path).parts
-            if Path(path).name in FORBIDDEN_BASENAMES or "node_modules" in parts:
-                violations.append(path)
-        self.assertEqual(violations, [])
+        self.assertEqual(violations(paths), [])
         self.assertEqual(paths.count(EXEMPT_PATH), 1)
+
+    def test_violations_identifies_forbidden_synthetic_paths(self) -> None:
+        paths = [
+            "a/package.json",
+            "x/y/node_modules/z.js",
+            "bun.lockb",
+            EXEMPT_PATH,
+            "docs/uv.lock",
+        ]
+        self.assertEqual(
+            violations(paths),
+            ["a/package.json", "x/y/node_modules/z.js", "bun.lockb", "docs/uv.lock"],
+        )
 
     def test_uv_lock_is_ignored_for_local_ci_tooling(self) -> None:
         result = subprocess.run(

--- a/workflows/AGENTS.md
+++ b/workflows/AGENTS.md
@@ -17,14 +17,15 @@ The v3 review pipeline. `pipeline.js` is invoked by the skill through the `Workf
 - **No wall-clock.** Timestamps arrive through the args waist (`generatedAt`); environment values
   are read by the skill and passed in `policy`.
 
-## JS lint (CI)
+## JS lint
 
-CI job `js-lint` runs Biome 2.5.6 against this directory via `workflows/biome.json`
-(lint-only). Formatter is **off**: default `lineWidth: 80` would wrap long
-`import … from` lines and break `build.js`'s single-line import `strip()` regex,
-failing `tests/test_bundle_fresh.py`. `noRestrictedGlobals` applies to `src/`
-only; `test/**` and `build.js` override it (they legitimately use `process` /
-`console`).
+CI and contributors run the same `python3 workflows/test/tools/biome_check.py`; the operational
+version and per-asset SHA-256 pins live only in `biome-pin.json`.
+To bump, regenerate every row with one command: `gh api repos/biomejs/biome/releases/tags/@biomejs/biome@<new> --jq '.assets[] | {name, digest}'`; update every entry in `biome-pin.json` together and never add package.json / a lockfile for auto-bumps (that reopens #105).
+Formatter is **off**: default `lineWidth: 80` would wrap long `import … from` lines and break
+`build.js`'s single-line import `strip()` regex, failing `tests/test_bundle_fresh.py`.
+`noRestrictedGlobals` applies to `src/` only; `test/**` and `build.js` override it (they
+legitimately use `process` / `console`).
 
 Deferred rules (measured 2026-07-30, HEAD `ebf399d`) — hit counts are why they
 stay off so a later re-evaluation need not re-derive them:

--- a/workflows/AGENTS.md
+++ b/workflows/AGENTS.md
@@ -21,7 +21,7 @@ The v3 review pipeline. `pipeline.js` is invoked by the skill through the `Workf
 
 CI and contributors run the same `python3 workflows/test/tools/biome_check.py`; the operational
 version and per-asset SHA-256 pins live only in `biome-pin.json`.
-To bump, regenerate every row with one command: `gh api repos/biomejs/biome/releases/tags/@biomejs/biome@<new> --jq '.assets[] | {name, digest}'`; update every entry in `biome-pin.json` together and never add package.json / a lockfile for auto-bumps (that reopens #105).
+To bump, regenerate every row with one command: `gh api repos/biomejs/biome/releases/tags/@biomejs/biome@<new> --jq '.assets[] | {name, digest}'`; update every entry in `biome-pin.json` together and never add a package manifest for auto-bumps.
 Formatter is **off**: default `lineWidth: 80` would wrap long `import … from` lines and break
 `build.js`'s single-line import `strip()` regex, failing `tests/test_bundle_fresh.py`.
 `noRestrictedGlobals` applies to `src/` only; `test/**` and `build.js` override it (they

--- a/workflows/CLAUDE.md
+++ b/workflows/CLAUDE.md
@@ -25,7 +25,7 @@ The v3 review pipeline. `pipeline.js` is invoked by the skill through the `Workf
 
 CI and contributors run the same `python3 workflows/test/tools/biome_check.py`; the operational
 version and per-asset SHA-256 pins live only in `biome-pin.json`.
-To bump, regenerate every row with one command: `gh api repos/biomejs/biome/releases/tags/@biomejs/biome@<new> --jq '.assets[] | {name, digest}'`; update every entry in `biome-pin.json` together and never add package.json / a lockfile for auto-bumps (that reopens #105).
+To bump, regenerate every row with one command: `gh api repos/biomejs/biome/releases/tags/@biomejs/biome@<new> --jq '.assets[] | {name, digest}'`; update every entry in `biome-pin.json` together and never add a package manifest for auto-bumps.
 Formatter is **off**: default `lineWidth: 80` would wrap long `import … from` lines and break
 `build.js`'s single-line import `strip()` regex, failing `tests/test_bundle_fresh.py`.
 `noRestrictedGlobals` applies to `src/` only; `test/**` and `build.js` override it (they

--- a/workflows/CLAUDE.md
+++ b/workflows/CLAUDE.md
@@ -21,14 +21,15 @@ The v3 review pipeline. `pipeline.js` is invoked by the skill through the `Workf
 - **No wall-clock.** Timestamps arrive through the args waist (`generatedAt`); environment values
   are read by the skill and passed in `policy`.
 
-## JS lint (CI)
+## JS lint
 
-CI job `js-lint` runs Biome 2.5.6 against this directory via `workflows/biome.json`
-(lint-only). Formatter is **off**: default `lineWidth: 80` would wrap long
-`import … from` lines and break `build.js`'s single-line import `strip()` regex,
-failing `tests/test_bundle_fresh.py`. `noRestrictedGlobals` applies to `src/`
-only; `test/**` and `build.js` override it (they legitimately use `process` /
-`console`).
+CI and contributors run the same `python3 workflows/test/tools/biome_check.py`; the operational
+version and per-asset SHA-256 pins live only in `biome-pin.json`.
+To bump, regenerate every row with one command: `gh api repos/biomejs/biome/releases/tags/@biomejs/biome@<new> --jq '.assets[] | {name, digest}'`; update every entry in `biome-pin.json` together and never add package.json / a lockfile for auto-bumps (that reopens #105).
+Formatter is **off**: default `lineWidth: 80` would wrap long `import … from` lines and break
+`build.js`'s single-line import `strip()` regex, failing `tests/test_bundle_fresh.py`.
+`noRestrictedGlobals` applies to `src/` only; `test/**` and `build.js` override it (they
+legitimately use `process` / `console`).
 
 Deferred rules (measured 2026-07-30, HEAD `ebf399d`) — hit counts are why they
 stay off so a later re-evaluation need not re-derive them:

--- a/workflows/biome-pin.json
+++ b/workflows/biome-pin.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.5.6",
+  "sha256": {
+    "biome-darwin-arm64": "5dba813a5ee1bd2749b9f3ee020e1f42d3fbd8fda7ed1d5d4df23fdb87e76579",
+    "biome-darwin-x64": "02f773b007e5ebe6b40f35e8999bd9c24eaa8dd5231dcab610bc1a17ef17b1b6",
+    "biome-linux-arm64": "be5850727c7ef88516bf0495d345b50bf0e3507c361e912bf24f7329930ea22c",
+    "biome-linux-arm64-musl": "35f069cdb2977bcc47fb9e9d71f3e07784dd280772cb9fca23c24c9c228ac7f1",
+    "biome-linux-x64": "3cc9a0c3fa26ac26a89e8a3b203c010c9ae88e36f69a2679e79981f267ce9d57",
+    "biome-linux-x64-musl": "108f8d177e963fafb684f9b9c96361bc4e137450a97f5b19139d80203ce7d966",
+    "biome-win32-arm64.exe": "2796c61fd757fe2ef760d645b4047746aa40ad543cd712672e6558ce4ff60b88",
+    "biome-win32-x64.exe": "47b7c8f59181870782dbeb26bfa45a51229a277ffd458f5cf852dc96dfd3999c"
+  }
+}

--- a/workflows/test/tools/biome_check.py
+++ b/workflows/test/tools/biome_check.py
@@ -202,6 +202,8 @@ def _ensure_binary(
             _set_executable(destination)
             return destination, True
     except OSError:
+        # An unreadable cache probe is treated like a miss: fall through to a
+        # fresh, verified download rather than trusting a file we could not hash.
         pass
 
     destination.unlink(missing_ok=True)
@@ -270,10 +272,7 @@ def main(
     except BiomeUsageError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    except BiomeCheckError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
-    except OSError as exc:
+    except (BiomeCheckError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/workflows/test/tools/biome_check.py
+++ b/workflows/test/tools/biome_check.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Run the local twin of CI's ``Run Workflow JS Lint`` gate.
+
+CI runs this same file. It reads the version and per-asset SHA-256 values from
+``workflows/biome-pin.json``, stores verified binaries in the user cache, and
+downloads a missing or mismatched asset from the Biome release. ``biome check``
+must run with cwd = <repo>/workflows because ``--config-path`` from the repo
+root trips Biome's nested-root-configuration detection. The Windows and musl
+assets are pinned for users but have no CI runner and are unexercised there.
+
+The final download name is replaced atomically from ``<asset>.part``. On
+Windows, replacing an in-use binary raises ``PermissionError``; close Biome
+before retrying. The runner is Python 3.10-compatible and stdlib-only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS_DIR = REPO_ROOT / "workflows"
+PIN_FILE = WORKFLOWS_DIR / "biome-pin.json"
+ASSET_NAMES = (
+    "biome-darwin-arm64",
+    "biome-darwin-x64",
+    "biome-linux-arm64",
+    "biome-linux-arm64-musl",
+    "biome-linux-x64",
+    "biome-linux-x64-musl",
+    "biome-win32-arm64.exe",
+    "biome-win32-x64.exe",
+)
+VERSION_PATTERN = r"^\d+\.\d+\.\d+$"
+HEX_PATTERN = r"^[0-9a-f]{64}$"
+RELEASE_URL = "https://github.com/biomejs/biome/releases/download/@biomejs/biome@{version}/{asset}"
+USER_AGENT = "code-gauntlet-biome-check"
+MAX_FETCH_ATTEMPTS = 5
+
+
+class BiomeCheckError(Exception):
+    """Base class for runner errors."""
+
+
+class BiomeUsageError(ValueError, BiomeCheckError):
+    """An unsupported platform, invalid pin, or invalid asset selection."""
+
+
+class PinError(BiomeUsageError):
+    """The pin file is missing or has an invalid shape or value."""
+
+
+class UnsupportedPlatformError(BiomeUsageError):
+    """The host platform has no default asset mapping."""
+
+
+class DownloadError(BiomeCheckError):
+    """The release asset could not be downloaded after all retries."""
+
+
+class ChecksumError(BiomeCheckError):
+    """The downloaded release asset did not match its pin."""
+
+
+@dataclass(frozen=True)
+class Pin:
+    version: str
+    sha256: dict[str, str]
+
+
+Fetch = Callable[[str], bytes]
+ProcessRunner = Callable[[list[str], Path], int]
+
+
+def resolve_asset(system: str, machine: str) -> str:
+    """Resolve a platform pair to a release asset, or raise a typed error."""
+    mappings = {
+        ("Darwin", "arm64"): "biome-darwin-arm64",
+        ("Darwin", "x86_64"): "biome-darwin-x64",
+        ("Linux", "x86_64"): "biome-linux-x64",
+        ("Linux", "amd64"): "biome-linux-x64",
+        ("Linux", "aarch64"): "biome-linux-arm64",
+        ("Linux", "arm64"): "biome-linux-arm64",
+        ("Windows", "AMD64"): "biome-win32-x64.exe",
+        ("Windows", "x86_64"): "biome-win32-x64.exe",
+        ("Windows", "ARM64"): "biome-win32-arm64.exe",
+        ("Windows", "aarch64"): "biome-win32-arm64.exe",
+    }
+    try:
+        return mappings[(system, machine)]
+    except KeyError as exc:
+        names = ", ".join(ASSET_NAMES)
+        raise UnsupportedPlatformError(
+            f"unsupported platform {system}/{machine}; pin file assets: {names}"
+        ) from exc
+
+
+def load_pin(path: str | os.PathLike[str]) -> Pin:
+    """Read and validate a Biome pin file."""
+    pin_path = Path(path)
+    try:
+        with pin_path.open(encoding="utf-8") as handle:
+            raw = json.load(handle)
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise PinError(f"could not read pin file {pin_path}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise PinError("pin file must be an object")
+    if "version" not in raw:
+        raise PinError("pin file is missing key 'version'")
+    version = raw["version"]
+    if not isinstance(version, str) or not re.fullmatch(VERSION_PATTERN, version):
+        raise PinError("pin key 'version' must match major.minor.patch")
+    if "sha256" not in raw:
+        raise PinError("pin file is missing key 'sha256'")
+    checksums = raw["sha256"]
+    if not isinstance(checksums, dict) or not checksums:
+        raise PinError("pin key 'sha256' must be a non-empty object")
+
+    validated: dict[str, str] = {}
+    for asset, digest in checksums.items():
+        if not isinstance(asset, str):
+            raise PinError("pin key 'sha256' contains a non-string asset key")
+        if not isinstance(digest, str) or not re.fullmatch(HEX_PATTERN, digest):
+            raise PinError(f"pin key '{asset}' must be 64 lowercase hex characters")
+        validated[asset] = digest
+    return Pin(version=version, sha256=validated)
+
+
+def build_command(binary: str | os.PathLike[str], extra: list[str]) -> list[str]:
+    """Build the Biome invocation with caller arguments appended."""
+    return [os.fspath(binary), "check", "--error-on-warnings", ".", *extra]
+
+
+def _fetch_url(url: str) -> bytes:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return cast(bytes, response.read())
+
+
+def _fetch_with_retries(fetch: Fetch, url: str) -> bytes:
+    last_error: Exception | None = None
+    for attempt in range(MAX_FETCH_ATTEMPTS):
+        try:
+            return fetch(url)
+        except Exception as exc:  # noqa: BLE001 - --retry-all-errors semantics
+            last_error = exc
+            if attempt + 1 < MAX_FETCH_ATTEMPTS:
+                time.sleep(2**attempt)
+    assert last_error is not None
+    raise DownloadError(
+        f"download failed after {MAX_FETCH_ATTEMPTS} attempts: {last_error}"
+    ) from last_error
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _set_executable(path: Path) -> None:
+    if os.name != "nt":
+        path.chmod(0o755)
+
+
+def _cache_root(cache_dir: str | None, environ: Mapping[str, str]) -> Path:
+    configured = (
+        cache_dir if cache_dir is not None else environ.get("CODE_GAUNTLET_BIOME_CACHE")
+    )
+    if configured is not None:
+        return Path(configured).expanduser().resolve()
+    base = environ.get("XDG_CACHE_HOME")
+    if not base:
+        home = environ.get("HOME") or str(Path.home())
+        base = os.path.join(home, ".cache")
+    return (Path(base).expanduser() / "code-gauntlet" / "biome").resolve()
+
+
+def _ensure_binary(
+    pin: Pin, asset: str, cache_root: Path, fetch: Fetch
+) -> tuple[Path, bool]:
+    expected = pin.sha256[asset]
+    destination = cache_root / pin.version / asset
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        if destination.is_file() and _sha256(destination) == expected:
+            _set_executable(destination)
+            return destination, True
+    except OSError:
+        pass
+
+    destination.unlink(missing_ok=True)
+    part = destination.with_name(f"{asset}.part")
+    try:
+        data = _fetch_with_retries(
+            fetch, RELEASE_URL.format(version=pin.version, asset=asset)
+        )
+        if not isinstance(data, bytes):
+            raise DownloadError("fetcher returned non-bytes data")
+        part.write_bytes(data)
+        actual = _sha256(part)
+        if actual != expected:
+            raise ChecksumError(
+                f"checksum mismatch for {asset}: expected {expected}, actual {actual}"
+            )
+        os.replace(part, destination)
+        _set_executable(destination)
+        return destination, False
+    finally:
+        part.unlink(missing_ok=True)
+
+
+def _run_process(command: list[str], cwd: Path) -> int:
+    return subprocess.run(command, cwd=cwd).returncode
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--asset", help="override the platform asset, for musl users")
+    parser.add_argument("--cache-dir", help="override the Biome cache directory")
+    parser.add_argument("extra", nargs=argparse.REMAINDER)
+    return parser
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    fetch: Fetch | None = None,
+    run: ProcessRunner | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> int:
+    """Download if needed, then run Biome and return its exit code."""
+    args = _parser().parse_args(argv)
+    env = os.environ if environ is None else environ
+    try:
+        pin = load_pin(PIN_FILE)
+        asset = (
+            args.asset
+            if args.asset is not None
+            else resolve_asset(platform.system(), platform.machine())
+        )
+        if asset not in pin.sha256:
+            raise BiomeUsageError(f"asset '{asset}' is not present in pin key 'sha256'")
+        cache_root = _cache_root(args.cache_dir, env)
+        fetcher = _fetch_url if fetch is None else fetch
+        binary, cached = _ensure_binary(pin, asset, cache_root, fetcher)
+        if cached:
+            print(f"Using cached Biome binary: {binary}", file=sys.stderr)
+        else:
+            print(f"Downloaded and verified Biome binary: {binary}", file=sys.stderr)
+        extra = args.extra[1:] if args.extra[:1] == ["--"] else args.extra
+        command = build_command(binary, extra)
+        runner = _run_process if run is None else run
+        return runner(command, WORKFLOWS_DIR)
+    except BiomeUsageError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except BiomeCheckError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why?

Closes #158, #176 (Wave 2 of #101).

`Run Workflow JS Lint` is a required merge check, but a contributor could only discover a Biome failure by pushing: the pinned version and checksum lived in `ci.yml` and nothing in the tree could reproduce the job. Separately, the AGENTS.md tooling boundary (no manifest or lockfile tracked) was convention only; `uv.lock` was git-ignored by PR #274 but nothing enforced the rule, and the boundary sentence was already false on main (`bench/vendor/code-review-benchmark/uv.lock` is tracked).

## What Changed?

- **One operational pin.** `workflows/biome-pin.json` holds the Biome version and the SHA-256 of every release asset (all eight rows copied from one `gh api` call, never hand-typed). It is the only place the version or a checksum appears in CI or current instructions; a test reads the version from the pin file and asserts it appears in none of `ci.yml`, `workflows/AGENTS.md`, `workflows/CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, or the PR template.
- **One runner for CI and contributors.** `python3 workflows/test/tools/biome_check.py` (stdlib only, mypy and ruff clean, Python 3.10) resolves the host asset, verifies a cached binary on every run (and restores its executable bit), downloads with one attempt plus four retries on any error, verifies before installing atomically from `<asset>.part`, and runs `biome check --error-on-warnings .` from `workflows/`. CI's `js-lint` job now runs that same file, so the two paths cannot drift. `--asset` overrides for musl users; Windows and musl rows are pinned but have no CI runner.
- **Contract.** `LOCAL_COMMAND_FOR_REQUIRED_CHECK` maps the check to the command; CONTRIBUTING (both fenced blocks), the PR template, and `workflows/AGENTS.md` (bump procedure, no version literal) follow; `lint-pr-title` is the only remaining CI-only check.
- **Tooling boundary as a mechanism.** `tests/test_tooling_boundary.py` fails if any of eleven manifest or lockfile basenames, or a `node_modules` segment, is tracked outside the one exact vendored exemption, or if `uv.lock` stops being git-ignored. The root AGENTS.md bullet now states that exemption. `AGENTS_SET_BUDGET_BYTES` raised 21,992 to 22,345 with the justification in the ratchet history.

## Additional Notes

- Validated live on macOS arm64: first run downloaded and verified `biome-darwin-arm64` in 5 s and exited 0; a planted `workflows/src/_lint_probe.js` with an undeclared name produced `Found 1 error` and a non-zero exit; the second run used the cache in 0.09 s. CI's `Run Workflow JS Lint` passed on ubuntu through the same runner.
- Built by a Codex luna implementer from a plan red-teamed by one Claude opus agent and one Codex sol pass. Three Codex luna review rounds (mutation ledger and spec conformance lenses in isolated worktrees): 30 mutations run, every production-behaviour mutation red at the final commit; the survivors they found (cache refresh, retry-all-errors, the urllib and subprocess adapters, the boundary predicate, the release URL, the exact vendored exemption, every forbidden basename, both CONTRIBUTING blocks, cache precedence) each gained a red-verified test in-PR. Exact digest identity in the pin test is deliberately not asserted: it is unverifiable offline, and CI (linux-x64) plus the maintainer's machine (darwin-arm64) verify the two exercised digests on every run.
- Scripts coverage at the final commit: 94.78% (floor 93.8, headroom under 1.0 pp, no ratchet).

- [x] Pipeline tests pass: `python -m pytest tests/ -q`
- [x] Bench self-tests pass: `python -m pytest bench/tests/ -q`
- [x] Workflow tests pass: `node --test workflows/test/*.test.js`
- [x] JS lint passes: `python3 workflows/test/tools/biome_check.py`
- [x] Bundle rebuilt and byte-exact: `node workflows/build.js` then `git diff --exit-code workflows/pipeline.js`
- [ ] Plugin manifests valid: `claude plugin validate .` (CI runs it)
- [x] Parity fixtures: no deterministic transform changed
- [x] Linters/hooks pass: `pre-commit run --all-files`
- [x] Docs, skill references, and agent contracts updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDMiJiiohYeKM4tzKwxHfG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect contributor/CI tooling and documentation guards only; workflow runtime and review pipeline behavior are unchanged.
> 
> **Overview**
> **Workflow JS lint** is no longer CI-only: contributors run the same gate as `Run Workflow JS Lint` via `python3 workflows/test/tools/biome_check.py`, which reads **`workflows/biome-pin.json`** (version plus SHA-256 for all eight release assets), downloads or refreshes a verified cached binary, and runs `biome check --error-on-warnings .` from `workflows/`. The **`js-lint`** job drops its inline curl/checksum shell and invokes that script instead, so local and CI paths cannot drift.
> 
> Contributor docs and checklists (**CONTRIBUTING**, PR template, **`workflows/AGENTS.md`**) document the command and bump procedure; **`LOCAL_COMMAND_FOR_REQUIRED_CHECK`** now maps the required check to it, leaving **`lint-pr-title`** as the only CI-only merge gate. **`tests/test_biome_check.py`** and **`TestBiomeLintSurface`** lock pin shape, CI wiring, and “version literal only in the pin file”; **`tests/test_tooling_boundary.py`** enforces the no-manifest/lockfile rule (single vendored **`uv.lock`** exemption), with a matching **AGENTS.md** wording fix and a small **AGENTS** byte-budget ratchet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26820fe8a0dd71fc63b3f66bb658b86568ca7db6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->