### PR TITLE
fix(skills): ask the Task Board question at the Phase 8 gate and name TaskCreate as the only creation call (#207)

### DIFF
--- a/skills/code-gauntlet/SKILL.md
+++ b/skills/code-gauntlet/SKILL.md
@@ -593,9 +593,23 @@ Never decorate a machine-parsed block (`references/report-format.md`).
 >
 > Headless exception (`CODE_GAUNTLET_HEADLESS=1`): identical, and no `AskUserQuestion` is presented.
 
-> **MANDATORY GATE: Do not finish without presenting the single task-board question (Stage 2) in `references/phase8-delivery.md`.**
+> **MANDATORY GATE: Do not finish without presenting the single task-board question below (Stage 2 in references/phase8-delivery.md covers what happens after "Yes"). On "Yes" the only creation call is TaskCreate, one task per finding in the delivered payload; Phase 8 never creates issues, pull requests, or branches.**
 >
 > Headless exception (`CODE_GAUNTLET_HEADLESS=1`): the task board is skipped; do not present the offer.
+
+```
+AskUserQuestion(
+  questions: [{
+    question: "Create fix tasks on the task board from these findings?",
+    header: "Task Board",
+    multiSelect: false,
+    options: [
+      { label: "Yes — create tasks", description: "One FIX task per delivered finding via TaskCreate (FIX-bug-1, FIX-conv-2, ...)" },
+      { label: "No — done", description: "Finish the review without creating tasks" }
+    ]
+  }]
+)
+```
 
 ### Print methodology
 

--- a/skills/code-gauntlet/references/phase8-delivery.md
+++ b/skills/code-gauntlet/references/phase8-delivery.md
@@ -185,19 +185,7 @@ See `references/delivery-guide.md` for the findings JSON schema and validation d
 > Headless exception (`CODE_GAUNTLET_HEADLESS=1`): the task board is skipped — present no
 > `AskUserQuestion` and create no tasks. See `references/headless-mode.md`.
 
-```
-AskUserQuestion(
-  questions: [{
-    question: "Create fix tasks on the task board from these findings?",
-    header: "Task Board",
-    multiSelect: false,
-    options: [
-      { label: "Yes — create tasks", description: "One FIX task per delivered finding (F-01, F-02, ...)" },
-      { label: "No — done", description: "Finish the review without creating tasks" }
-    ]
-  }]
-)
-```
+The question itself is the block under the Phase 8 MANDATORY GATE in SKILL.md; it is asked there, verbatim.
 
 "Yes" creates a FIX task for every finding in the delivered set — the `artifactPaths.postReview` entries
 when the user chose "Post to PR", otherwise the same payload's entries as listed in the report. There is

--- a/tests/test_question_surface.py
+++ b/tests/test_question_surface.py
@@ -174,30 +174,21 @@ class TestQuestionSurface(unittest.TestCase):
                 self.assertEqual(matches[0]["path"], expected_path)
 
     def test_task_board_site_is_pinned_verbatim(self):
-        expected = (
-            "skills/code-gauntlet/SKILL.md",
-            "Create fix tasks on the task board from these findings?",
-            "Task Board",
-            "false",
-            [
+        expected = {
+            "path": "skills/code-gauntlet/SKILL.md",
+            "question": "Create fix tasks on the task board from these findings?",
+            "header": "Task Board",
+            "multiSelect": "false",
+            "options": [
                 (
                     "Yes — create tasks",
                     "One FIX task per delivered finding via TaskCreate (FIX-bug-1, FIX-conv-2, ...)",
                 ),
                 ("No — done", "Finish the review without creating tasks"),
             ],
-        )
+        }
         task_board = next(site for site in sites() if site["header"] == "Task Board")
-        self.assertEqual(
-            (
-                task_board["path"],
-                task_board["question"],
-                task_board["header"],
-                task_board["multiSelect"],
-                task_board["options"],
-            ),
-            expected,
-        )
+        self.assertEqual(task_board, expected)
 
     def test_task_board_gate_states_the_action_boundary(self):
         # The gate paragraph is what the orchestrator reads when it asks; the

--- a/tests/test_question_surface.py
+++ b/tests/test_question_surface.py
@@ -199,6 +199,31 @@ class TestQuestionSurface(unittest.TestCase):
             expected,
         )
 
+    def test_task_board_gate_states_the_action_boundary(self):
+        # The gate paragraph is what the orchestrator reads when it asks; the
+        # boundary it states (TaskCreate only, never an outward-facing artifact)
+        # is the mechanism issue #207 pins, so a rewrite that drops it goes red.
+        skill = (SKILLS / "code-gauntlet" / "SKILL.md").read_text(encoding="utf-8")
+        gate = next(
+            line
+            for line in skill.splitlines()
+            if "MANDATORY GATE" in line and "task-board question" in line
+        )
+        self.assertIn("the only creation call is TaskCreate", gate)
+        self.assertIn("never creates issues, pull requests, or branches", gate)
+
+    def test_task_board_block_sits_at_its_gate(self):
+        # Point of use: the verbatim block follows its gate and precedes the next
+        # section, so the model meets the question where the gate fires.
+        skill = (SKILLS / "code-gauntlet" / "SKILL.md").read_text(encoding="utf-8")
+        gate = skill.index("task-board question below")
+        block = skill.index(
+            'question: "Create fix tasks on the task board from these findings?"'
+        )
+        next_section = skill.index("### Print methodology")
+        self.assertLess(gate, block)
+        self.assertLess(block, next_section)
+
     def test_every_site_conforms_to_the_schema(self):
         offenders = {}
         for s in sites():

--- a/tests/test_question_surface.py
+++ b/tests/test_question_surface.py
@@ -22,6 +22,11 @@ SKILLS = REPO / "skills"
 # that changes the surface, with the reason in the body.
 EXPECTED_QUESTION_SITES = 9
 
+PINNED_SITES = {
+    "Task Board": "skills/code-gauntlet/SKILL.md",
+    "Delivery": "skills/code-gauntlet/references/phase8-delivery.md",
+}
+
 MAX_HEADER_CHARS = 12
 MIN_OPTIONS = 2
 MAX_OPTIONS = 4
@@ -158,6 +163,40 @@ class TestQuestionSurface(unittest.TestCase):
             EXPECTED_QUESTION_SITES,
             "question surface changed: "
             + ", ".join(f"{s['path']}:{s['header']}" for s in found),
+        )
+
+    def test_phase8_sites_live_where_pinned(self):
+        found = sites()
+        for header, expected_path in PINNED_SITES.items():
+            matches = [site for site in found if site["header"] == header]
+            with self.subTest(header=header):
+                self.assertEqual(len(matches), 1, f"expected one {header} site")
+                self.assertEqual(matches[0]["path"], expected_path)
+
+    def test_task_board_site_is_pinned_verbatim(self):
+        expected = (
+            "skills/code-gauntlet/SKILL.md",
+            "Create fix tasks on the task board from these findings?",
+            "Task Board",
+            "false",
+            [
+                (
+                    "Yes — create tasks",
+                    "One FIX task per delivered finding via TaskCreate (FIX-bug-1, FIX-conv-2, ...)",
+                ),
+                ("No — done", "Finish the review without creating tasks"),
+            ],
+        )
+        task_board = next(site for site in sites() if site["header"] == "Task Board")
+        self.assertEqual(
+            (
+                task_board["path"],
+                task_board["question"],
+                task_board["header"],
+                task_board["multiSelect"],
+                task_board["options"],
+            ),
+            expected,
         )
 
     def test_every_site_conforms_to_the_schema(self):


### PR DESCRIPTION
## Why?

Closes #207 (Wave 5 of #101).

In a live run the orchestrator replaced the canonical Phase 8 task-board question with "Want me to create GitHub issues from the report's leftover items?" (header "Task board", options "No, skip it" / "Yes, file issues"). Both the mechanism (GitHub issues instead of task-board FIX tasks through TaskCreate) and the target set (leftovers instead of every delivered finding) drifted. The verbatim block lived only in `references/phase8-delivery.md`, and `SKILL.md` carried a one-line gate that pointed at it. `tests/test_question_surface.py` pinned the site count, schema, and uniqueness of the nine question sites but not where a site lives or what its options say. The Yes option also described a task-id shape (`F-01`) that exists nowhere in the product; delivered ids look like `bug-1` and `conv-2`, and the task template emits `FIX-bug-1`.

## What Changed?

- **The Stage 2 question is single-sourced at its point of use.** The `AskUserQuestion` block moves from the reference into `SKILL.md` directly under the Phase 8 MANDATORY GATE, as a top-level fence (a fence nested inside the `>` gate quote is invisible to the question-surface extractor, which would have silently dropped the site count to eight). The reference keeps the post-"Yes" flow and points back at the block.
- **The gate states the action boundary.** On "Yes" the only creation call is TaskCreate, one task per finding in the delivered payload; Phase 8 never creates issues, pull requests, or branches. The Yes option names the mechanism and the real id shape: "One FIX task per delivered finding via TaskCreate (FIX-bug-1, FIX-conv-2, ...)".
- **Four pins in `tests/test_question_surface.py`.** The Task Board site must live in `SKILL.md` and the Delivery site in the reference; the Task Board tuple (question, header, multiSelect, ordered options) is hand-typed in the test and compared whole; the gate paragraph must carry the boundary clauses; the block must sit between its gate and the next section. Each was verified red under its rewrite (block moved back, `via TaskCreate` dropped, block inside the quote, site count set to eight, an option label paraphrased, the old duplicate restored, the boundary clause removed, the block moved below the next section). Site count stays at nine.

## Additional Notes

- **Residual, stated plainly.** No runtime hook can pin what the host model asks. In the drifted run the Delivery question fired verbatim from the same reference file, so the file was in context and the model paraphrased anyway. This change removes the pointer indirection and puts the mechanism and the target set into the bytes the model reads when it asks; it does not prove the cause is fixed. `SKILL.md` is loader-injected, so the block's position past the single-Read window measured in `complete-read-contract.md` does not apply to it.
- **Split out.** Rendering the post-"Yes" FIX-task payload in code (toolchain detection, sibling selection, field mapping) is filed as #296; the design red-team found six open contract questions there that do not belong in this change.
- **Dropped on review.** Banning issue-creation vocabulary in `FORBIDDEN_PATTERNS` was rejected: the phrases have never been in the tree, so the guard could not go red.
- Suites only; no recall or noise surface is touched (the delivered set is fixed upstream in `stages.js`).

- [x] Pipeline tests pass: `python -m pytest tests/ -q` (2041 passed)
- [x] Bench self-tests pass: `python -m pytest bench/tests/ -q` (untouched; CI runs them)
- [x] Workflow tests pass: `node --test workflows/test/*.test.js`
- [ ] JS lint passes: `python3 workflows/test/tools/biome_check.py` (no JS touched; CI runs it)
- [x] Bundle rebuilt and byte-exact: no `workflows/src` change
- [ ] Plugin manifests valid: `claude plugin validate .` (CI runs it)
- [x] Parity fixtures: no deterministic transform changed
- [x] Linters/hooks pass: `pre-commit run --all-files`
- [x] Docs, skill references, and agent contracts updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCG69NaAxwcGxpgRZhLyoi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only contract pins for interactive delivery UX; no pipeline, posting, or runtime workflow code changes.
> 
> **Overview**
> **Phase 8 Task Board prompt is now single-sourced where the orchestrator actually finishes the run.** The verbatim `AskUserQuestion` block moves from `references/phase8-delivery.md` into `SKILL.md` immediately under a strengthened MANDATORY GATE (as a top-level fence, not inside the gate quote, so the question-surface extractor still counts nine sites). The reference keeps Stage 2 behavior after “Yes” and only points back to that block.
> 
> **The gate documents the creation boundary:** accepting tasks means **TaskCreate only**—one FIX task per delivered finding—with explicit language that Phase 8 must not create GitHub issues, PRs, or branches. The “Yes” option text now names `TaskCreate` and realistic id shapes (`FIX-bug-1`, `FIX-conv-2`, …) instead of `F-01`.
> 
> **`tests/test_question_surface.py` adds regression pins:** Task Board must live in `SKILL.md` and Delivery in the phase-8 reference; the Task Board tuple (question, header, options) is asserted verbatim; the gate must contain the TaskCreate/boundary clauses; and the question block must sit between the gate and `### Print methodology`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 963a7057e8a7b2ed36610548809634942be0cf48. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->