### PR TITLE
fix(args): tolerate a JSON null pr_comment_cap receipt and generate receipt examples (#303)

### DIFF
--- a/scripts/generate_contract_requirements.py
+++ b/scripts/generate_contract_requirements.py
@@ -72,7 +72,7 @@ IDENTITY_FENCES = {
     # D9's chat convention names the mark in prose. A hand-authored fourth copy would
     # break the one-edit property (a registry edit + a generator run + a hand edit
     # nothing turns red on), so it is generated like the rest.
-    "skills/code-gauntlet/SKILL.md": ["chat_identity"],
+    "skills/code-gauntlet/SKILL.md": ["chat_identity", "config_receipt"],
 }
 
 # English phrasing for fields that carry a dimension-conditional requirement. Not derivable
@@ -87,8 +87,7 @@ _CONDITIONAL_NOUNS = {
 def load_registry(repo_root=REPO_ROOT):
     """The live schema declaration, imported from the ESM source (mirrors the test helper)."""
     node_src = (
-        "const t = v => typeof v === 'string' ? v : v.type;"
-        "import('./workflows/src/registry.js').then(m => console.log(JSON.stringify({"
+        "Promise.all([import('./workflows/src/registry.js'), import('./workflows/src/args.js')]).then(([m, a]) => console.log(JSON.stringify({"
         "  required: m.FINDING_REQUIRED,"
         "  canonicalFields: Object.keys(m.FINDING_PROP_TYPES),"
         "  dimensions: m.DIMENSIONS.map(d => ({"
@@ -103,6 +102,7 @@ def load_registry(repo_root=REPO_ROOT):
         "  ruleSourceLabels: m.RULE_SOURCE_LABELS,"
         "  ruleSourceLabelFallback: m.RULE_SOURCE_LABEL_FALLBACK,"
         "  agents: m.AGENTS,"
+        "  knobs: a.KNOB_REGISTRY.map(d => ({ key: d.key, modes: d.modes, example: d.example })),"
         "})))"
     )
     out = subprocess.run(
@@ -622,6 +622,32 @@ def identity_body(rel_path, symbol, identity, repo_root=REPO_ROOT):
                 + "carries no other"
             ),
             "emoji, except severity emoji when listing findings.",
+        ]
+    if symbol == "config_receipt":
+
+        def receipt(mode):
+            rendered = {}
+            for knob in identity["knobs"]:
+                if mode not in knob["modes"]:
+                    continue
+                value, source = knob["example"][mode]
+                rendered[knob["key"]] = {"value": value, "source": source}
+            return json.dumps(rendered, indent=4, ensure_ascii=False).splitlines()
+
+        return [
+            'Every `configEcho` value is the printed token as a string; an unset interactive cap is the string `"null"`, and a JSON null there is accepted, spelled `"null"`, and disclosed as a gap; `limits.deliveryCap` carries the typed null.',
+            "",
+            "**Interactive receipt:**",
+            "",
+            "```json",
+            *receipt("interactive"),
+            "```",
+            "",
+            "**Headless receipt:**",
+            "",
+            "```json",
+            *receipt("headless"),
+            "```",
         ]
     if symbol == "inline_legend":
         return [

--- a/skills/code-gauntlet/SKILL.md
+++ b/skills/code-gauntlet/SKILL.md
@@ -372,7 +372,7 @@ Assemble the args waist (see `references/phase2-triage.md` for the full field li
   riskTable: [ ...{ path, risk } per changed file, from Phase 2e... ],  // REQUIRED, path set === changedFiles
   scopeAnswer: "light" | "full",  // ONLY when the 2e trivial-scope gate asked; omit otherwise
   policy: { tier, subagentModel, provider, gateway },
-  configEcho: { key: { value, source } },  // REQUIRED; exact resolved knob receipt, in registry order when rendered
+  configEcho: { key: { value: "<printed token, a string>", source } },  // REQUIRED; see the generated config receipt below
   pluginRoot,  // REQUIRED absolute plugin root; script paths must stay under {pluginRoot}/scripts/
   reviewScope: { requested: "incremental" | "full", kind: "incremental" | "full", since: string | null,
                  commits: integer | null, detector: null | { previously_reviewed, sha_resolvable,
@@ -417,6 +417,76 @@ Assemble the args waist (see `references/phase2-triage.md` for the full field li
   }
 }
 ```
+
+<!-- generated-from-registry-identity:config_receipt — do not edit; run scripts/generate_contract_requirements.py -->
+Every `configEcho` value is the printed token as a string; an unset interactive cap is the string `"null"`, and a JSON null there is accepted, spelled `"null"`, and disclosed as a gap; `limits.deliveryCap` carries the typed null.
+
+**Interactive receipt:**
+
+```json
+{
+    "model_tier": {
+        "value": "optimized",
+        "source": "fixed"
+    },
+    "pr_comment_cap": {
+        "value": "null",
+        "source": "default"
+    },
+    "delivery_tier": {
+        "value": "all",
+        "source": "default"
+    },
+    "review_md": {
+        "value": "absent",
+        "source": "discovery"
+    }
+}
+```
+
+**Headless receipt:**
+
+```json
+{
+    "model_tier": {
+        "value": "optimized",
+        "source": "default"
+    },
+    "delivery": {
+        "value": "markdown",
+        "source": "default"
+    },
+    "post_mode": {
+        "value": "dry-run",
+        "source": "default"
+    },
+    "pr_comment_cap": {
+        "value": "6",
+        "source": "default"
+    },
+    "delivery_tier": {
+        "value": "all",
+        "source": "default"
+    },
+    "draft_policy": {
+        "value": "review",
+        "source": "default"
+    },
+    "reviewed_policy": {
+        "value": "full",
+        "source": "default"
+    },
+    "pr_not_found_policy": {
+        "value": "error",
+        "source": "default"
+    },
+    "trivial_scope": {
+        "value": "full",
+        "source": "default"
+    }
+}
+```
+<!-- /generated-from-registry-identity:config_receipt -->
 
 `mode` is `"headless"` under `CODE_GAUNTLET_HEADLESS=1`, else `"interactive"`. Never call `new Date()` inside the workflow — `generatedAt` is the only clock.
 

--- a/skills/code-gauntlet/references/phase1-preflight.md
+++ b/skills/code-gauntlet/references/phase1-preflight.md
@@ -202,8 +202,10 @@ Resolved config:
   review_md=absent (discovery)
 ```
 
-`source ∈ env|default|fixed|discovery`. A headless run prints `Headless config:` instead and never this
-block; the two are mutually exclusive and both satisfy the Phase 2 gate.
+`source ∈ env|default|fixed|discovery`. Each `value` is the printed token as a string; an unset
+interactive cap is `"null"`, while `limits.deliveryCap` remains the typed `null`. A headless run
+prints `Headless config:` instead and never this block; the two are mutually exclusive and both
+satisfy the Phase 2 gate.
 
 ---
 

--- a/skills/code-gauntlet/references/phase2-triage.md
+++ b/skills/code-gauntlet/references/phase2-triage.md
@@ -361,7 +361,7 @@ Assemble the args waist the workflow consumes. It is a single JSON object passed
 | `changedFiles` | the changed-file array, by value (Summarize bucketing; the workflow has no disk access) |
 | `changedLines` | total changed line count, by value (Summarize bucketing threshold) |
 | `riskTable` | the Phase 2e per-file risk classification, by value, as `[{ path, risk }]` — `path` set must equal `changedFiles` exactly (missing or extra paths fail loud; see Phase 2e's risk-level table for the `risk` contract) |
-| `configEcho` | the required keyed receipt `{ key: { value, source } }` for every mode-specific knob; values and sources must satisfy the headless/interactive contract and mirror the resolved decisions |
+| `configEcho` | the required keyed receipt `{ key: { value, source } }` for every mode-specific knob; each `value` is the printed token as a string, and values and sources must satisfy the headless/interactive contract and mirror the resolved decisions |
 | `pluginRoot` | the required absolute POSIX path to this plugin; `persist.assembleScriptPath` and `verify.scriptPath`, when present, must start with `{pluginRoot}/scripts/` |
 | `reviewScope` | `{ requested, kind, since, commits, detector }`, copied from the prior-review state; `detector` is `null` for local/branch targets, otherwise copy `previously_reviewed`, `sha_resolvable`, `head_advanced`, `sha_is_ancestor`, `incremental_safe`, and `error` (the first detector error or `null`) verbatim. `kind=incremental` requires `requested=incremental` and `detector.incremental_safe=true`; an incremental request that becomes full retains the detector so the renderer can derive the fallback reason |
 | `policy` | `{ tier, subagentModel, provider, gateway }` — see below |

--- a/tests/test_boundary_parity.py
+++ b/tests/test_boundary_parity.py
@@ -525,8 +525,8 @@ class TestReportMethodologyRuntimeParity(unittest.TestCase):
         else:
             echo = {
                 "model_tier": {"value": "optimized", "source": "fixed"},
-                "delivery_tier": {"value": "all", "source": "default"},
                 "pr_comment_cap": {"value": "null", "source": "default"},
+                "delivery_tier": {"value": "all", "source": "default"},
                 "review_md": {"value": "absent", "source": "discovery"},
             }
             expected = {

--- a/tests/test_docs_registry.py
+++ b/tests/test_docs_registry.py
@@ -14,10 +14,13 @@ Scope: git-tracked files only (``git ls-files``), so gitignored local artifacts
 never fail the suite.
 """
 
+import json
 import re
 import subprocess
 import unittest
 from pathlib import Path
+
+from scripts import generate_contract_requirements as contract_generator
 
 REPO = Path(__file__).resolve().parents[1]
 
@@ -126,6 +129,38 @@ def _individually_classified_rows_section():
 
 
 class TestDocsRegistry(unittest.TestCase):
+    def test_generated_config_receipt_matches_registry_examples(self):
+        """The generated receipt examples stay pinned to each registry row's examples."""
+        registry = contract_generator.load_registry(str(REPO))
+        expected = {}
+        for mode in ("interactive", "headless"):
+            expected[mode] = {}
+            for knob in registry["knobs"]:
+                if mode not in knob["modes"]:
+                    continue
+                value, source = knob["example"][mode]
+                expected[mode][knob["key"]] = {"value": value, "source": source}
+
+        path = REPO / "skills" / "code-gauntlet" / "SKILL.md"
+        text = path.read_text()
+        open_marker, close_marker = contract_generator.identity_marker_lines(
+            "config_receipt", "skills/code-gauntlet/SKILL.md"
+        )
+        start = text.index(open_marker) + len(open_marker)
+        end = text.index(close_marker, start)
+        body = text[start:end]
+        for mode, label in (("interactive", "Interactive"), ("headless", "Headless")):
+            match = re.search(
+                rf"\*\*{label} receipt:\*\*\n\n```json\n(.*?)\n```",
+                body,
+                re.DOTALL,
+            )
+            self.assertIsNotNone(match, f"missing {mode} config receipt fence")
+            actual = json.loads(match.group(1))
+            self.assertEqual(
+                actual, expected[mode], f"{mode} receipt drifted from KNOB_REGISTRY"
+            )
+
     def test_config_receipt_examples_follow_registry_order(self):
         """Every skill example must render knobs in the source registry's mode order."""
         args_source = (REPO / "workflows" / "src" / "args.js").read_text()

--- a/tests/test_generate_contract_requirements.py
+++ b/tests/test_generate_contract_requirements.py
@@ -311,6 +311,67 @@ class TestIdentityFenceGuards(unittest.TestCase):
             "self_inconsistency": "SI",
         },
         "ruleSourceLabelFallback": "RF",
+        "knobs": [
+            {
+                "key": "model_tier",
+                "modes": ["headless", "interactive"],
+                "example": {
+                    "headless": ["optimized", "default"],
+                    "interactive": ["optimized", "fixed"],
+                },
+            },
+            {
+                "key": "delivery",
+                "modes": ["headless"],
+                "example": {"headless": ["markdown", "default"]},
+            },
+            {
+                "key": "post_mode",
+                "modes": ["headless"],
+                "example": {"headless": ["dry-run", "default"]},
+            },
+            {
+                "key": "pr_comment_cap",
+                "modes": ["headless", "interactive"],
+                "example": {
+                    "headless": ["6", "default"],
+                    "interactive": ["null", "default"],
+                },
+            },
+            {
+                "key": "delivery_tier",
+                "modes": ["headless", "interactive"],
+                "example": {
+                    "headless": ["all", "default"],
+                    "interactive": ["all", "default"],
+                },
+            },
+            {
+                "key": "draft_policy",
+                "modes": ["headless"],
+                "example": {"headless": ["review", "default"]},
+            },
+            {
+                "key": "reviewed_policy",
+                "modes": ["headless"],
+                "example": {"headless": ["full", "default"]},
+            },
+            {
+                "key": "pr_not_found_policy",
+                "modes": ["headless"],
+                "example": {"headless": ["error", "default"]},
+            },
+            {
+                "key": "trivial_scope",
+                "modes": ["headless"],
+                "example": {"headless": ["full", "default"]},
+            },
+            {
+                "key": "review_md",
+                "modes": ["interactive"],
+                "example": {"interactive": ["absent", "discovery"]},
+            },
+        ],
     }
 
     # Every declared fence body, hand-typed against the placeholder IDENTITY above.
@@ -440,6 +501,75 @@ class TestIdentityFenceGuards(unittest.TestCase):
             "The final delivery summary opens with `MARK NAME` on its first line and "
             "carries no other\n"
             "emoji, except severity emoji when listing findings."
+        ),
+        ("skills/code-gauntlet/SKILL.md", "config_receipt"): (
+            'Every `configEcho` value is the printed token as a string; an unset interactive cap is the string `"null"`, and a JSON null there is accepted, spelled `"null"`, and disclosed as a gap; `limits.deliveryCap` carries the typed null.\n'
+            "\n"
+            "**Interactive receipt:**\n"
+            "\n"
+            "```json\n"
+            "{\n"
+            '    "model_tier": {\n'
+            '        "value": "optimized",\n'
+            '        "source": "fixed"\n'
+            "    },\n"
+            '    "pr_comment_cap": {\n'
+            '        "value": "null",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "delivery_tier": {\n'
+            '        "value": "all",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "review_md": {\n'
+            '        "value": "absent",\n'
+            '        "source": "discovery"\n'
+            "    }\n"
+            "}\n"
+            "```\n"
+            "\n"
+            "**Headless receipt:**\n"
+            "\n"
+            "```json\n"
+            "{\n"
+            '    "model_tier": {\n'
+            '        "value": "optimized",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "delivery": {\n'
+            '        "value": "markdown",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "post_mode": {\n'
+            '        "value": "dry-run",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "pr_comment_cap": {\n'
+            '        "value": "6",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "delivery_tier": {\n'
+            '        "value": "all",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "draft_policy": {\n'
+            '        "value": "review",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "reviewed_policy": {\n'
+            '        "value": "full",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "pr_not_found_policy": {\n'
+            '        "value": "error",\n'
+            '        "source": "default"\n'
+            "    },\n"
+            '    "trivial_scope": {\n'
+            '        "value": "full",\n'
+            '        "source": "default"\n'
+            "    }\n"
+            "}\n"
+            "```"
         ),
     }
 

--- a/tests/test_generate_contract_requirements.py
+++ b/tests/test_generate_contract_requirements.py
@@ -313,63 +313,17 @@ class TestIdentityFenceGuards(unittest.TestCase):
         "ruleSourceLabelFallback": "RF",
         "knobs": [
             {
-                "key": "model_tier",
+                "key": "alpha",
                 "modes": ["headless", "interactive"],
                 "example": {
-                    "headless": ["optimized", "default"],
-                    "interactive": ["optimized", "fixed"],
-                },
-            },
-            {
-                "key": "delivery",
-                "modes": ["headless"],
-                "example": {"headless": ["markdown", "default"]},
-            },
-            {
-                "key": "post_mode",
-                "modes": ["headless"],
-                "example": {"headless": ["dry-run", "default"]},
-            },
-            {
-                "key": "pr_comment_cap",
-                "modes": ["headless", "interactive"],
-                "example": {
-                    "headless": ["6", "default"],
+                    "headless": ["h-alpha", "env"],
                     "interactive": ["null", "default"],
                 },
             },
             {
-                "key": "delivery_tier",
-                "modes": ["headless", "interactive"],
-                "example": {
-                    "headless": ["all", "default"],
-                    "interactive": ["all", "default"],
-                },
-            },
-            {
-                "key": "draft_policy",
+                "key": "beta",
                 "modes": ["headless"],
-                "example": {"headless": ["review", "default"]},
-            },
-            {
-                "key": "reviewed_policy",
-                "modes": ["headless"],
-                "example": {"headless": ["full", "default"]},
-            },
-            {
-                "key": "pr_not_found_policy",
-                "modes": ["headless"],
-                "example": {"headless": ["error", "default"]},
-            },
-            {
-                "key": "trivial_scope",
-                "modes": ["headless"],
-                "example": {"headless": ["full", "default"]},
-            },
-            {
-                "key": "review_md",
-                "modes": ["interactive"],
-                "example": {"interactive": ["absent", "discovery"]},
+                "example": {"headless": ["h-beta", "default"]},
             },
         ],
     }
@@ -509,21 +463,9 @@ class TestIdentityFenceGuards(unittest.TestCase):
             "\n"
             "```json\n"
             "{\n"
-            '    "model_tier": {\n'
-            '        "value": "optimized",\n'
-            '        "source": "fixed"\n'
-            "    },\n"
-            '    "pr_comment_cap": {\n'
+            '    "alpha": {\n'
             '        "value": "null",\n'
             '        "source": "default"\n'
-            "    },\n"
-            '    "delivery_tier": {\n'
-            '        "value": "all",\n'
-            '        "source": "default"\n'
-            "    },\n"
-            '    "review_md": {\n'
-            '        "value": "absent",\n'
-            '        "source": "discovery"\n'
             "    }\n"
             "}\n"
             "```\n"
@@ -532,40 +474,12 @@ class TestIdentityFenceGuards(unittest.TestCase):
             "\n"
             "```json\n"
             "{\n"
-            '    "model_tier": {\n'
-            '        "value": "optimized",\n'
-            '        "source": "default"\n'
+            '    "alpha": {\n'
+            '        "value": "h-alpha",\n'
+            '        "source": "env"\n'
             "    },\n"
-            '    "delivery": {\n'
-            '        "value": "markdown",\n'
-            '        "source": "default"\n'
-            "    },\n"
-            '    "post_mode": {\n'
-            '        "value": "dry-run",\n'
-            '        "source": "default"\n'
-            "    },\n"
-            '    "pr_comment_cap": {\n'
-            '        "value": "6",\n'
-            '        "source": "default"\n'
-            "    },\n"
-            '    "delivery_tier": {\n'
-            '        "value": "all",\n'
-            '        "source": "default"\n'
-            "    },\n"
-            '    "draft_policy": {\n'
-            '        "value": "review",\n'
-            '        "source": "default"\n'
-            "    },\n"
-            '    "reviewed_policy": {\n'
-            '        "value": "full",\n'
-            '        "source": "default"\n'
-            "    },\n"
-            '    "pr_not_found_policy": {\n'
-            '        "value": "error",\n'
-            '        "source": "default"\n'
-            "    },\n"
-            '    "trivial_scope": {\n'
-            '        "value": "full",\n'
+            '    "beta": {\n'
+            '        "value": "h-beta",\n'
             '        "source": "default"\n'
             "    }\n"
             "}\n"

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -2234,16 +2234,16 @@ const digits = (value) => typeof value === 'string' && /^\d+$/.test(value);
 const positiveDigits = (value) => digits(value) && !/^0+$/.test(value);
 const safeReceiptValue = (value) => typeof value === 'string' && !CONTROL_RE.test(value) && !value.includes('`');
 const KNOB_REGISTRY = [
-  { key: 'model_tier', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['fixed'] }, valueRule: (value) => value === 'optimized' },
-  { key: 'delivery', modes: ['headless'], allowedSources: { headless: ['env', 'review_md', 'default'] }, valueRule: deliveryValue },
-  { key: 'post_mode', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['dry-run', 'live'].includes(value) },
-  { key: 'pr_comment_cap', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['env', 'default'] }, valueRule: (value, mode) => mode === 'headless' ? positiveDigits(value) : (value === 'null' || digits(value)) },
-  { key: 'delivery_tier', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['env', 'default'] }, valueRule: (value) => DELIVERY_TIERS.includes(value) },
-  { key: 'draft_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['review', 'skip'].includes(value) },
-  { key: 'reviewed_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['incremental', 'full', 'skip'].includes(value) },
-  { key: 'pr_not_found_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['local', 'error'].includes(value) },
-  { key: 'trivial_scope', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => SCOPE_ANSWERS.includes(value) },
-  { key: 'review_md', modes: ['interactive'], allowedSources: { interactive: ['discovery'] }, valueRule: (value) => ['present', 'absent'].includes(value) },
+  { key: 'model_tier', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['fixed'] }, valueRule: (value) => value === 'optimized', example: { headless: ['optimized', 'default'], interactive: ['optimized', 'fixed'] } },
+  { key: 'delivery', modes: ['headless'], allowedSources: { headless: ['env', 'review_md', 'default'] }, valueRule: deliveryValue, example: { headless: ['markdown', 'default'] } },
+  { key: 'post_mode', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['dry-run', 'live'].includes(value), example: { headless: ['dry-run', 'default'] } },
+  { key: 'pr_comment_cap', modes: ['headless', 'interactive'], nullReceipt: ['interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['env', 'default'] }, valueRule: (value, mode) => mode === 'headless' ? positiveDigits(value) : (value === 'null' || digits(value)), example: { headless: ['6', 'default'], interactive: ['null', 'default'] } },
+  { key: 'delivery_tier', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['env', 'default'] }, valueRule: (value) => DELIVERY_TIERS.includes(value), example: { headless: ['all', 'default'], interactive: ['all', 'default'] } },
+  { key: 'draft_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['review', 'skip'].includes(value), example: { headless: ['review', 'default'] } },
+  { key: 'reviewed_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['incremental', 'full', 'skip'].includes(value), example: { headless: ['full', 'default'] } },
+  { key: 'pr_not_found_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['local', 'error'].includes(value), example: { headless: ['error', 'default'] } },
+  { key: 'trivial_scope', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => SCOPE_ANSWERS.includes(value), example: { headless: ['full', 'default'] } },
+  { key: 'review_md', modes: ['interactive'], allowedSources: { interactive: ['discovery'] }, valueRule: (value) => ['present', 'absent'].includes(value), example: { interactive: ['absent', 'discovery'] } },
 ];
 const REVIEW_MD_PATH_CONTROL_RE = /[\u0000-\u001F\u007F]/;
 function validatePathSegments(value, label, { separateSlashErrors = false, requireBasename = false } = {}) {
@@ -2296,6 +2296,9 @@ function nullToleranceGap(key) {
   const why = NULL_TOLERANCE_CONSEQUENCE[key] || 'the run proceeds as if the field had not been supplied';
   return `null_arg: args.${key} arrived as a literal null and was treated as ABSENT — ${why}. Omit ${key} entirely (or stamp a well-formed value); do not stamp null.`;
 }
+function nullRespellGap(key) {
+  return `null_receipt: args.${key} arrived as a literal null and was spelled as the printed token "null"; the receipt and the configuration are unchanged; stamp the string "null".`;
+}
 function nullToleranceRejectedKeys(cleanArgs, dropped) {
   if (!Array.isArray(dropped) || dropped.length === 0) return [];
   const baseline = validateArgs(cleanArgs).errors.length;
@@ -2320,8 +2323,9 @@ function withNullAt(args, key) {
   return out;
 }
 function stripNullOptionalsReport(args) {
-  if (!args || typeof args !== 'object' || Array.isArray(args)) return { args, dropped: [] };
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return { args, dropped: [], respelled: [] };
   const dropped = [];
+  const respelled = [];
   const out = { ...args };
   for (const k of NULLABLE_TOP_LEVEL) {
     if (out[k] === null) { delete out[k]; dropped.push(k); }
@@ -2350,7 +2354,19 @@ function stripNullOptionalsReport(args) {
     }
     out.limits = limits;
   }
-  return { args: out, dropped };
+  if (isPlainObject(out.configEcho) && typeof out.mode === 'string') {
+    const configEcho = { ...out.configEcho };
+    for (const descriptor of KNOB_REGISTRY) {
+      if (!descriptor.nullReceipt || !descriptor.nullReceipt.includes(out.mode)) continue;
+      const entry = configEcho[descriptor.key];
+      if (isPlainObject(entry) && entry.value === null) {
+        configEcho[descriptor.key] = { ...entry, value: 'null' };
+        respelled.push(`configEcho.${descriptor.key}.value`);
+      }
+    }
+    out.configEcho = configEcho;
+  }
+  return { args: out, dropped, respelled };
 }
 function normalizeArgsReport(raw) {
   const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
@@ -4814,8 +4830,11 @@ function compactMethodology(m) {
 async function runWith(ctx, rawArgs) {
   const entry = entryArgs(rawArgs);
   if (!entry.ok) return entry.envelope;
-  const { args: A, dropped: droppedNulls } = normalizeArgsReport(entry.waist);
-  const nullArgGaps = nullToleranceRejectedKeys(A, droppedNulls).map(nullToleranceGap);
+  const { args: A, dropped: droppedNulls, respelled: respelledNulls } = normalizeArgsReport(entry.waist);
+  const nullArgGaps = [
+    ...nullToleranceRejectedKeys(A, droppedNulls).map(nullToleranceGap),
+    ...respelledNulls.map(nullRespellGap),
+  ];
   const check = validateArgs(A);
   if (!check.ok) {
     return makeArgsRejectEnvelope(

--- a/workflows/src/args.js
+++ b/workflows/src/args.js
@@ -71,16 +71,17 @@ const positiveDigits = (value) => digits(value) && !/^0+$/.test(value);
 export const safeReceiptValue = (value) => typeof value === 'string' && !CONTROL_RE.test(value) && !value.includes('`');
 
 export const KNOB_REGISTRY = [
-  { key: 'model_tier', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['fixed'] }, valueRule: (value) => value === 'optimized' },
-  { key: 'delivery', modes: ['headless'], allowedSources: { headless: ['env', 'review_md', 'default'] }, valueRule: deliveryValue },
-  { key: 'post_mode', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['dry-run', 'live'].includes(value) },
-  { key: 'pr_comment_cap', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['env', 'default'] }, valueRule: (value, mode) => mode === 'headless' ? positiveDigits(value) : (value === 'null' || digits(value)) },
-  { key: 'delivery_tier', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['env', 'default'] }, valueRule: (value) => DELIVERY_TIERS.includes(value) },
-  { key: 'draft_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['review', 'skip'].includes(value) },
-  { key: 'reviewed_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['incremental', 'full', 'skip'].includes(value) },
-  { key: 'pr_not_found_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['local', 'error'].includes(value) },
-  { key: 'trivial_scope', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => SCOPE_ANSWERS.includes(value) },
-  { key: 'review_md', modes: ['interactive'], allowedSources: { interactive: ['discovery'] }, valueRule: (value) => ['present', 'absent'].includes(value) },
+  { key: 'model_tier', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['fixed'] }, valueRule: (value) => value === 'optimized', example: { headless: ['optimized', 'default'], interactive: ['optimized', 'fixed'] } },
+  { key: 'delivery', modes: ['headless'], allowedSources: { headless: ['env', 'review_md', 'default'] }, valueRule: deliveryValue, example: { headless: ['markdown', 'default'] } },
+  { key: 'post_mode', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['dry-run', 'live'].includes(value), example: { headless: ['dry-run', 'default'] } },
+  // The receipt is the printed token. A JSON null is accepted only interactively as the spelling of printed null.
+  { key: 'pr_comment_cap', modes: ['headless', 'interactive'], nullReceipt: ['interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['env', 'default'] }, valueRule: (value, mode) => mode === 'headless' ? positiveDigits(value) : (value === 'null' || digits(value)), example: { headless: ['6', 'default'], interactive: ['null', 'default'] } },
+  { key: 'delivery_tier', modes: ['headless', 'interactive'], allowedSources: { headless: ['env', 'default'], interactive: ['env', 'default'] }, valueRule: (value) => DELIVERY_TIERS.includes(value), example: { headless: ['all', 'default'], interactive: ['all', 'default'] } },
+  { key: 'draft_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['review', 'skip'].includes(value), example: { headless: ['review', 'default'] } },
+  { key: 'reviewed_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['incremental', 'full', 'skip'].includes(value), example: { headless: ['full', 'default'] } },
+  { key: 'pr_not_found_policy', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => ['local', 'error'].includes(value), example: { headless: ['error', 'default'] } },
+  { key: 'trivial_scope', modes: ['headless'], allowedSources: { headless: ['env', 'default'] }, valueRule: (value) => SCOPE_ANSWERS.includes(value), example: { headless: ['full', 'default'] } },
+  { key: 'review_md', modes: ['interactive'], allowedSources: { interactive: ['discovery'] }, valueRule: (value) => ['present', 'absent'].includes(value), example: { interactive: ['absent', 'discovery'] } },
 ];
 
 // Shared with PATH_CONTROL_RE further down (declared locally there because it sits inside
@@ -204,6 +205,12 @@ export function nullToleranceGap(key) {
   return `null_arg: args.${key} arrived as a literal null and was treated as ABSENT — ${why}. Omit ${key} entirely (or stamp a well-formed value); do not stamp null.`;
 }
 
+// nullRespellGap(key) -> the disclosure for a JSON null respelled as a printed receipt token.
+// The receipt and typed configuration stay unchanged; only the receipt spelling crosses the waist.
+export function nullRespellGap(key) {
+  return `null_receipt: args.${key} arrived as a literal null and was spelled as the printed token "null"; the receipt and the configuration are unchanged; stamp the string "null".`;
+}
+
 // nullToleranceRejectedKeys(cleanArgs, dropped) -> the subset of `dropped` whose stamped null
 // validateArgs would ACTUALLY have rejected — i.e. the keys where the tolerance changed the
 // outcome and there is therefore something to disclose.
@@ -246,7 +253,7 @@ function withNullAt(args, key) {
   return out;
 }
 
-// stripNullOptionalsReport(args) -> { args, dropped }
+// stripNullOptionalsReport(args) -> { args, dropped, respelled }
 // Drops a literal top-level null for the narrow NULLABLE_TOP_LEVEL allowlist (and, inside a
 // present `delivery` object, a literal null for its `prIdentity`/`tier` sub-fields), and
 // names every key it dropped so the caller can DISCLOSE the substitution.
@@ -255,8 +262,9 @@ function withNullAt(args, key) {
 // are still there). Non-object input (undefined, null, a string) passes through as-is with
 // an empty `dropped`; there is nothing to strip.
 export function stripNullOptionalsReport(args) {
-  if (!args || typeof args !== 'object' || Array.isArray(args)) return { args, dropped: [] };
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return { args, dropped: [], respelled: [] };
   const dropped = [];
+  const respelled = [];
   const out = { ...args };
   for (const k of NULLABLE_TOP_LEVEL) {
     if (out[k] === null) { delete out[k]; dropped.push(k); }
@@ -290,7 +298,21 @@ export function stripNullOptionalsReport(args) {
     }
     out.limits = limits;
   }
-  return { args: out, dropped };
+  // The receipt is the printed token: interactively, a JSON null is accepted as the spelling
+  // of printed null, disclosed as a gap while validateConfigEcho remains strict.
+  if (isPlainObject(out.configEcho) && typeof out.mode === 'string') {
+    const configEcho = { ...out.configEcho };
+    for (const descriptor of KNOB_REGISTRY) {
+      if (!descriptor.nullReceipt || !descriptor.nullReceipt.includes(out.mode)) continue;
+      const entry = configEcho[descriptor.key];
+      if (isPlainObject(entry) && entry.value === null) {
+        configEcho[descriptor.key] = { ...entry, value: 'null' };
+        respelled.push(`configEcho.${descriptor.key}.value`);
+      }
+    }
+    out.configEcho = configEcho;
+  }
+  return { args: out, dropped, respelled };
 }
 
 export function normalizeArgsReport(raw) {

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -21,7 +21,7 @@ import { merge } from './mergeFindings.js';
 import { applyValidations, pyIntStrict, REACHABILITY_VALUES } from './applyValidations.js';
 import { applyFilterPipeline, applyInjectedProseStrip, applyReplayInjectionScan, normalizeFieldNames, scopeMatchesFile } from './filterFindings.js';
 import { applyChallenges, rankFindings, deepClone } from './applyChallenges.js';
-import { normalizeArgsReport, nullToleranceGap, nullToleranceRejectedKeys, validateArgs, entryArgs, makeArgsRejectEnvelope, SKILL_RECOVERY_LINE, LIMIT_DEFAULTS, resolveReviewConfig, computeLightEligible } from './args.js';
+import { normalizeArgsReport, nullToleranceGap, nullRespellGap, nullToleranceRejectedKeys, validateArgs, entryArgs, makeArgsRejectEnvelope, SKILL_RECOVERY_LINE, LIMIT_DEFAULTS, resolveReviewConfig, computeLightEligible } from './args.js';
 import { renderReport, coerceReportFindings } from './renderReport.js';
 
 // Runtime globals are injected by the workflow host; under node:test they are absent,
@@ -3839,8 +3839,11 @@ export async function runWith(ctx, rawArgs) {
   // Normalize from entry.waist, not rawArgs: entryArgs has already unwrapped every JSON
   // layer, and normalizeArgsReport peels exactly one — re-normalizing the raw value would
   // hand validateArgs a string for any waist encoded more than once.
-  const { args: A, dropped: droppedNulls } = normalizeArgsReport(entry.waist);
-  const nullArgGaps = nullToleranceRejectedKeys(A, droppedNulls).map(nullToleranceGap);
+  const { args: A, dropped: droppedNulls, respelled: respelledNulls } = normalizeArgsReport(entry.waist);
+  const nullArgGaps = [
+    ...nullToleranceRejectedKeys(A, droppedNulls).map(nullToleranceGap),
+    ...respelledNulls.map(nullRespellGap),
+  ];
   const check = validateArgs(A);
   if (!check.ok) {
     // The field list says WHAT is wrong; SKILL_RECOVERY_LINE says where the fields come

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -780,9 +780,13 @@ test('stripNullOptionalsReport does NOT strip policy.subagentModel: null (no-ove
 test('stripNullOptionalsReport leaves a non-null, non-allowlisted-field waist untouched', () => {
   assert.deepEqual(stripNullOptionalsReport(good).args, good);
 });
-test('stripNullOptionalsReport passes through non-object input (undefined, string) without throwing', () => {
-  assert.equal(stripNullOptionalsReport(undefined).args, undefined);
-  assert.equal(stripNullOptionalsReport(null).args, null);
+test('stripNullOptionalsReport passes through non-object input without throwing', () => {
+  for (const input of [undefined, null, 'not an object', ['not', 'an', 'object']]) {
+    const report = stripNullOptionalsReport(input);
+    assert.equal(report.args, input);
+    assert.deepEqual(report.dropped, []);
+    assert.deepEqual(report.respelled, []);
+  }
 });
 
 test('normalizeArgs strips stamped nulls on the object-passthrough form so validateArgs accepts them', () => {
@@ -936,6 +940,39 @@ test('T303-ARGS: interactive JSON null cap is respelled, validated, and reported
   assert.deepEqual(validateArgs(normalized), { ok: true, errors: [] });
   assert.deepEqual(input, before, 'normalization must not mutate the caller object');
   assert.equal(nullRespellGap(report.respelled[0]).includes('printed token "null"'), true);
+});
+
+test('T303-ARGS: null respelling consults the nullReceipt mode allowlist', () => {
+  const input = {
+    ...good,
+    mode: 'Interactive',
+    configEcho: { ...good.configEcho, pr_comment_cap: { value: null, source: 'default' } },
+  };
+  const report = normalizeArgsReport(JSON.stringify(input));
+
+  assert.equal(report.args.configEcho.pr_comment_cap.value, null);
+  assert.deepEqual(report.respelled, []);
+  const result = validateArgs(report.args);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.includes('invalid mode: Interactive'));
+});
+
+test('T303-ARGS: an absent receipt value is not respelled', () => {
+  const input = {
+    ...good,
+    configEcho: { ...good.configEcho, pr_comment_cap: { source: 'default' } },
+  };
+  const report = normalizeArgsReport(input);
+
+  assert.equal('value' in report.args.configEcho.pr_comment_cap, false);
+  assert.deepEqual(report.respelled, []);
+});
+
+test('T303-ARGS: nullRespellGap keeps its complete operator disclosure', () => {
+  assert.equal(
+    nullRespellGap('pr_comment_cap'),
+    'null_receipt: args.pr_comment_cap arrived as a literal null and was spelled as the printed token "null"; the receipt and the configuration are unchanged; stamp the string "null".',
+  );
 });
 
 test('T303-ARGS: headless JSON null cap is still refused', () => {

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   ARGS_VERSION, normalizeArgs, validateArgs, parseEntryArgs,
-  stripNullOptionalsReport, normalizeArgsReport, nullToleranceGap, LIMIT_DEFAULTS,
+  stripNullOptionalsReport, normalizeArgsReport, nullToleranceGap, nullRespellGap, LIMIT_DEFAULTS,
   resolveReviewConfig, computeLightEligible, nullToleranceRejectedKeys, KNOB_REGISTRY, safeReceiptValue,
 } from '../src/args.js';
 
@@ -198,6 +198,18 @@ test('T182-ARGS: every registry receipt value rule and source rule is focused', 
   assert.equal(validateArgs({ ...interactive, configEcho: { ...interactive.configEcho, review_md: { value: 'present', source: 'discovery' } } }).ok, false);
   const interactiveInvalid = validateArgs({ ...interactive, configEcho: { ...interactive.configEcho, review_md: { value: 'other', source: 'discovery' } } });
   assert.ok(interactiveInvalid.errors.some((error) => error.includes('configEcho.review_md.value')));
+});
+
+test('T303-ARGS: every registry example satisfies its value and source rules', () => {
+  for (const descriptor of KNOB_REGISTRY) {
+    for (const mode of descriptor.modes) {
+      const example = descriptor.example[mode];
+      assert.ok(Array.isArray(example), `${descriptor.key} needs a ${mode} example`);
+      const [value, source] = example;
+      assert.equal(descriptor.valueRule(value, mode), true, `${mode} ${descriptor.key} example value`);
+      assert.ok(descriptor.allowedSources[mode].includes(source), `${mode} ${descriptor.key} example source`);
+    }
+  }
 });
 
 test('T182-ARGS: receipt lockstep rejects mismatches before any stage can dispatch', () => {
@@ -907,6 +919,57 @@ test('normalizeArgsReport reports drops on both the object and JSON-string forms
   const r2 = normalizeArgsReport(JSON.stringify({ ...good, exclusionPatterns: null, persist: null }));
   assert.deepEqual(r2.dropped.slice().sort(), ['exclusionPatterns', 'persist']);
   assert.deepEqual(normalizeArgsReport(good).dropped, []);
+});
+
+test('T303-ARGS: interactive JSON null cap is respelled, validated, and reported without mutation', () => {
+  const input = {
+    ...good,
+    limits: { ...good.limits, deliveryCap: null },
+    configEcho: { ...good.configEcho, pr_comment_cap: { value: null, source: 'default' } },
+  };
+  const before = JSON.parse(JSON.stringify(input));
+  const normalized = normalizeArgs(input);
+  const report = normalizeArgsReport(input);
+
+  assert.equal(normalized.configEcho.pr_comment_cap.value, 'null');
+  assert.deepEqual(report.respelled, ['configEcho.pr_comment_cap.value']);
+  assert.deepEqual(validateArgs(normalized), { ok: true, errors: [] });
+  assert.deepEqual(input, before, 'normalization must not mutate the caller object');
+  assert.equal(nullRespellGap(report.respelled[0]).includes('printed token "null"'), true);
+});
+
+test('T303-ARGS: headless JSON null cap is still refused', () => {
+  const headless = {
+    ...good,
+    mode: 'headless',
+    limits: { ...good.limits, deliveryCap: null },
+    configEcho: {
+      model_tier: { value: 'optimized', source: 'default' },
+      delivery: { value: 'markdown', source: 'default' },
+      post_mode: { value: 'dry-run', source: 'default' },
+      pr_comment_cap: { value: null, source: 'default' },
+      delivery_tier: { value: 'all', source: 'default' },
+      draft_policy: { value: 'review', source: 'default' },
+      reviewed_policy: { value: 'full', source: 'default' },
+      pr_not_found_policy: { value: 'error', source: 'default' },
+      trivial_scope: { value: 'full', source: 'default' },
+    },
+  };
+  const report = normalizeArgsReport(JSON.stringify(headless));
+  assert.deepEqual(report.respelled, []);
+  const result = validateArgs(report.args);
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.some((error) => error.includes('configEcho.pr_comment_cap.value')));
+});
+
+test('T303-ARGS: interactive JSON null on model_tier is still refused', () => {
+  const input = {
+    ...good,
+    configEcho: { ...good.configEcho, model_tier: { value: null, source: 'fixed' } },
+  };
+  const normalized = normalizeArgs(input);
+  assert.equal(normalized.configEcho.model_tier.value, null);
+  assert.equal(validateArgs(normalized).ok, false);
 });
 test('parseEntryArgs does NOT strip stamped nulls — runWith owns the strip so it can disclose it', () => {
   // If the entry stripped first, runWith would see an already-clean waist and the silent

--- a/workflows/test/pipeline_run.test.js
+++ b/workflows/test/pipeline_run.test.js
@@ -739,6 +739,27 @@ test('a clean waist records NO null_arg gap (disclosure is not noise)', async ()
   assert.deepEqual(out.gaps.filter((g) => /null_arg/.test(g)), []);
 });
 
+test('T303: interactive null receipt is respelled, disclosed, and rendered as the printed token', async () => {
+  const args = validArgs({
+    mode: 'interactive',
+    limits: { deliveryCap: null },
+    configEcho: {
+      model_tier: { value: 'optimized', source: 'fixed' },
+      pr_comment_cap: { value: null, source: 'default' },
+      delivery_tier: { value: 'all', source: 'default' },
+      review_md: { value: 'absent', source: 'discovery' },
+    },
+  });
+  let persisted = null;
+  const out = await runWith(makeCtx(args, { onPersist: (payload) => { persisted = payload; } }), args);
+
+  assert.equal(out.ok, true, `a receipt null must not reject the run; gaps: ${out.gaps}`);
+  assert.ok(out.gaps.some((gap) => gap.startsWith('null_receipt: args.configEcho.pr_comment_cap.value')));
+  assert.ok(persisted, 'the report must reach the persistence seam');
+  assert.match(persisted.report, /pr_comment_cap=null \(default\)/);
+  assert.equal(args.configEcho.pr_comment_cap.value, null, 'the input waist stays unchanged');
+});
+
 test('L3-1: a stamped persist:null runs instead of hard-rejecting the whole run, and is disclosed', async () => {
   // persist was added to the waist but left OFF the null-tolerance allowlist the same diff
   // introduced for its siblings, so `persist: null` rejected the run outright.


### PR DESCRIPTION
## Why?

Closes #303 (Wave 5 of #101, adjacent from the #300 gauntlet run). `configEcho` is the receipt of the printed resolved-config block, so every value is the printed token as a string and an unset interactive cap is the string `"null"`, while `limits.deliveryCap` carries the typed null. Nothing in the skill said so; the args skeleton showed an untyped `{ value, source }`, and a live run stamped a JSON null and was refused at `validateArgs` after Phases 1-2.

## What Changed?

- **Registry declares the tolerance.** The `pr_comment_cap` row of `KNOB_REGISTRY` (`workflows/src/args.js`) gains `nullReceipt: ['interactive']`; every row gains `example: { mode: [value, source] }`.
- **Respell with disclosure.** `normalizeArgs` respells a JSON-null receipt as `"null"` only for rows whose `nullReceipt` names the waist's mode, reports the dotted key in a `respelled` list, and `runWith` (`workflows/src/stages.js`) discloses it as an envelope gap through `nullRespellGap`. `validateConfigEcho` stays strict; headless still refuses a JSON null.
- **Generated receipts.** `scripts/generate_contract_requirements.py` imports `KNOB_REGISTRY`, and a new `config_receipt` identity fence in `skills/code-gauntlet/SKILL.md` carries the rule sentence plus the interactive and headless receipts in registry order, kept fresh by the generator's `--check`. The skeleton's `configEcho` line types the value as the printed token; `references/phase2-triage.md` and `references/phase1-preflight.md` say the same in one clause each.
- **Tests.** args tests cover the respelling, the headless and `model_tier` refusals, non-mutation of the input, the nullReceipt lookup under an unvalidated mode string, strict-null only, the passthrough report shape, the exact gap text, and registry-example validity; a `runWith` seam test pins the envelope gap and the rendered `pr_comment_cap=null (default)` line; `tests/test_docs_registry.py` pins the generated receipts to the registry examples; the generator oracle uses two synthetic knobs; the boundary-parity fixture follows registry order.

## Additional Notes

- **Evidence.** Issue #303 records the live refusal (`configEcho.pr_comment_cap.value must be a string`) from the #300 gauntlet run on plugin 3.30.0.
- **Mutation proof.** Reverting the respelling branch, swapping the nullReceipt lookup for `valueRule('null', mode)`, loosening `=== null`, dropping the passthrough `respelled: []`, or shortening the gap text each turns a named test red; a stale generated fence fails `--check`. Pipeline tests 2089, workflow tests 1329, bench 615; scripts coverage 94.83 (floor 93.8, no ratchet).
- Design red-teamed by one Claude opus and one Codex sol lens (both converged on declaring the tolerance in the registry, disclosing the respelling, and generating the examples); built on Codex luna; reviewed by two Codex luna lenses with one fix round and a round-2 mutation check. The owner's code-gauntlet run in another session is the cross-family pass.
- **Merge note.** The #302 PR also rebuilds `workflows/pipeline.js`; whichever merges second needs a rebase and rebuild.
- **Out of scope, filed as #305.** One code-owned resolver emitting the printed block, `configEcho` and `limits.deliveryCap` from a single value, which both lenses named as the root cause of the duplication.

- [x] Pipeline tests pass: `python -m pytest tests/ -q`
- [x] Bench self-tests pass: `python -m pytest bench/tests/ -q`
- [x] Workflow tests pass: `node --test workflows/test/*.test.js` (Node 24)
- [x] JS lint passes: `python3 workflows/test/tools/biome_check.py`
- [x] Bundle rebuilt and byte-exact: a second `node workflows/build.js` leaves `workflows/pipeline.js` unchanged
- [ ] Plugin manifests valid: `claude plugin validate .` (CI runs it)
- [x] Parity fixtures: no deterministic transform changed
- [x] Linters/hooks pass: `pre-commit run --all-files`
- [x] Docs, skill references, and agent contracts updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfPY5K9ekC3KEeVJE6wj2y
