### PR TITLE
fix(bench): scrub ambient CODE_GAUNTLET_* pins from bench children; derive BENCH_ENV and EXPECTED_ECHO from the knob registry (#308)

### DIFF
--- a/bench/MEASUREMENT.md
+++ b/bench/MEASUREMENT.md
@@ -117,7 +117,7 @@ A red checker does **not** by itself mean the change under test is broken. Two
 failure modes fire on clean code and both have been observed on branches that
 were otherwise correct, so triage the reason before drawing a conclusion.
 
-**`config_echo_mismatch` — the eight/nine-knob echo floor.** This label means
+**`config_echo_mismatch` — the registry-knob echo floor.** This label means
 the runner did not find every expected configuration knob in any accepted source;
 it is separate from the G4 identity check for `pipeline_version` and `plugin_root`.
 The report now carries the code-rendered knob receipt, so once the report is

--- a/bench/run.py
+++ b/bench/run.py
@@ -840,10 +840,17 @@ def _child_auth_for(args, run_id=None):
 
 
 def _write_manifest(run_dir, run_id, tier, urls, timeout_s, args):
-    env_fingerprint = dict(invoke.BENCH_ENV)  # the 9 CODE_GAUNTLET_* values
+    """Write run provenance, including the shell scrub observed at manifest time.
+
+    A resume in a different shell does not rewrite this manifest.
+    """
+    env_fingerprint = dict(invoke.BENCH_ENV)  # the registry CODE_GAUNTLET_* values
     env_fingerprint["timeout_s"] = timeout_s
     child_auth = _resolve_child_auth(getattr(args, "child_auth", None))
     env_fingerprint["child_auth"] = child_auth
+    _, ambient_scrubbed = invoke.scrub_ambient(os.environ)
+    env_fingerprint["config_echo"] = invoke.EXPECTED_ECHO_RECEIPT
+    env_fingerprint["ambient_scrubbed"] = ambient_scrubbed
     invocation = (
         f"naive:single-pass max-turns={NAIVE_MAX_TURNS}"
         if args.anchor == "naive"

--- a/bench/runner/invoke.py
+++ b/bench/runner/invoke.py
@@ -1,6 +1,6 @@
 """Headless invoker for a single golden PR (spec H3 "Per-PR flow", H8 hang guard).
 
-``build_env`` assembles the pinned, isolated invocation context: the 9 bench
+``build_env`` assembles the pinned, isolated invocation context: the registry-pinned bench
 ``CODE_GAUNTLET_*`` knobs, the per-run output dir, ``GH_REPO``, and an isolated
 ``HOME``/``CLAUDE_CONFIG_DIR`` so operator config can never leak in. It also pre-seeds
 the isolated ``.claude.json`` with the worktree marked trusted -- a headless run cannot
@@ -29,12 +29,24 @@ from pathlib import Path
 
 from bench.runner.costs import parse_costs
 from bench.runner.ledger import API_AUTH_MODE, AUTH_MODES, SUBSCRIPTION_AUTH_MODE
+from scripts.resolve_config import (
+    KNOB_REGISTRY,
+    ResolverError,
+    ResolverSetupError,
+    matches_rule,
+    resolve,
+)
 
 __all__ = [
+    "BENCH_ENV",
+    "BENCH_PINS",
+    "EXPECTED_ECHO",
+    "EXPECTED_ECHO_RECEIPT",
     "PIPELINE_META_NAME",
     "InvokeResult",
     "_claude_home",
     "api_key_helper_files",
+    "build_bench_env",
     "build_env",
     "collect_workflow_records",
     "extract_identity_receipt",
@@ -48,6 +60,7 @@ __all__ = [
     "resolve_claude_home",
     "script_path_matches_repo",
     "scriptpath_from_record",
+    "scrub_ambient",
     "snapshot_workflow_records",
     "supersede_attempt_artifacts",
     "supersede_workflow_records",
@@ -80,24 +93,9 @@ PIPELINE_META_NAME = _read_pipeline_meta_name()
 # here into every child env. A module global so tests can repoint it at a tempfile.
 ENV_PATH = REPO_ROOT / "bench" / ".env"
 
-# The 9 bench values (spec H2 table, bench overrides): pinned explicitly on every run
-# so the harness is drift-immune even though the skill defines its own defaults.
-BENCH_ENV = {
-    "CODE_GAUNTLET_HEADLESS": "1",
-    "CODE_GAUNTLET_MODEL_TIER": "optimized",
-    "CODE_GAUNTLET_DELIVERY": "pr_comments,markdown",
-    "CODE_GAUNTLET_POST_MODE": "dry-run",
-    "CODE_GAUNTLET_PR_COMMENT_CAP": "25",
-    "CODE_GAUNTLET_DRAFT_POLICY": "review",
-    "CODE_GAUNTLET_REVIEWED_POLICY": "full",
-    "CODE_GAUNTLET_PR_NOT_FOUND_POLICY": "error",
-    "CODE_GAUNTLET_TRIVIAL_SCOPE": "full",
-}
-
-# The resolved-config receipt the runner asserts against (Task 3 echo format). Keys are
-# the 9 knob lines under the "Headless config:" header; CODE_GAUNTLET_HEADLESS itself is
-# the master switch and is not echoed as a knob. Values are the bench expectations.
-EXPECTED_ECHO = {
+# Bench owns this policy and pins every headless registry knob with an env name. Registry
+# defaults never feed the bench, so a registry default drift cannot silently change a run.
+BENCH_PINS = {
     "model_tier": "optimized",
     "delivery": "pr_comments,markdown",
     "post_mode": "dry-run",
@@ -108,6 +106,54 @@ EXPECTED_ECHO = {
     "pr_not_found_policy": "error",
     "trivial_scope": "full",
 }
+
+
+def build_bench_env(pins, registry):
+    """Build the bench-owned headless env from a complete, validated pin map."""
+    rows = [
+        row
+        for row in registry
+        if "headless" in row.get("modes", []) and isinstance(row.get("env"), str)
+    ]
+    expected_keys = {row.get("key") for row in rows}
+    actual_keys = set(pins)
+    if actual_keys != expected_keys:
+        missing = expected_keys - actual_keys
+        extra = actual_keys - expected_keys
+        details = []
+        if missing:
+            details.append(
+                "missing key(s) "
+                + ", ".join(repr(key) for key in sorted(missing, key=repr))
+            )
+        if extra:
+            details.append(
+                "unexpected key(s) "
+                + ", ".join(repr(key) for key in sorted(extra, key=repr))
+            )
+        raise ValueError("BENCH_PINS key set mismatch: " + "; ".join(details))
+
+    env = {"CODE_GAUNTLET_HEADLESS": "1"}
+    for row in rows:
+        key = row["key"]
+        value = pins[key]
+        if not matches_rule(row.get("rule"), value, "headless"):
+            raise ValueError(f"BENCH_PINS[{key!r}]={value!r} is invalid for headless")
+        env[row["env"]] = value
+    return env
+
+
+BENCH_ENV = build_bench_env(BENCH_PINS, KNOB_REGISTRY)
+
+
+try:
+    EXPECTED_ECHO_RECEIPT = resolve("headless", BENCH_ENV, None, "pr")["configEcho"]
+except (ResolverError, ResolverSetupError) as exc:
+    raise RuntimeError(
+        f"BENCH_PINS cannot resolve the expected echo receipt: {exc}"
+    ) from exc
+
+EXPECTED_ECHO = {key: entry["value"] for key, entry in EXPECTED_ECHO_RECEIPT.items()}
 
 ALL_DEGRADED_PREFIX = "all-degraded:"
 
@@ -614,6 +660,13 @@ def _claude_auth_env(base_env, child_auth):
     )
 
 
+def scrub_ambient(env):
+    """Remove every CODE_GAUNTLET_* variable and return the clean env and names removed."""
+    removed = sorted(name for name in env if name.startswith("CODE_GAUNTLET_"))
+    clean = {name: value for name, value in env.items() if name not in removed}
+    return clean, removed
+
+
 def build_env(pr, run_dir, base_env, child_auth=API_AUTH_MODE):
     """Assemble the pinned isolated env for one PR invocation (side effect: seeds trust).
 
@@ -631,7 +684,7 @@ def build_env(pr, run_dir, base_env, child_auth=API_AUTH_MODE):
     is an ambient prerequisite, not part of the claude-config isolation.
     """
     run_dir = Path(run_dir)
-    env = dict(base_env)
+    env, _ = scrub_ambient(base_env)
     env.update(BENCH_ENV)
     auth_updates, auth_removals = _claude_auth_env(base_env, child_auth)
     for name in auth_removals:

--- a/bench/tests/fakes/fake_claude.py
+++ b/bench/tests/fakes/fake_claude.py
@@ -2,7 +2,7 @@
 """Fake ``claude`` binary for invoke.py tests. Placed on PATH as ``claude``.
 
 Behavior is selected by env ``FAKE_CLAUDE_MODE``:
-  ok             -> canned "Headless config:" echo (9 bench knobs) + a success result
+  ok             -> canned resolver "Headless config:" echo + a success result
                     envelope (total_cost_usd 1.23, modelUsage, usage, empty
                     permission_denials), and a fake post-review-payload.json under
                     $CODE_GAUNTLET_OUTPUT_DIR.
@@ -109,19 +109,19 @@ def _session_workflow_script_path(config_dir):
 
 
 def echo_lines(plugin_root=None, pipeline_version=None):
+    plugin_root_from_argv = _plugin_dir_from_argv()
+    if plugin_root_from_argv and plugin_root_from_argv not in sys.path:
+        sys.path.insert(0, plugin_root_from_argv)
+    from bench.runner import invoke
+
     root = plugin_root if plugin_root is not None else _plugin_dir_from_argv()
     ver = pipeline_version if pipeline_version is not None else _pipeline_version(root)
     return [
         "Headless config:",
-        "  model_tier=optimized (env)",
-        "  delivery=pr_comments,markdown (env)",
-        "  post_mode=dry-run (env)",
-        "  pr_comment_cap=25 (env)",
-        "  delivery_tier=all (default)",
-        "  draft_policy=review (env)",
-        "  reviewed_policy=full (env)",
-        "  pr_not_found_policy=error (env)",
-        "  trivial_scope=full (env)",
+        *[
+            f"  {key}={entry['value']} ({entry['source']})"
+            for key, entry in invoke.EXPECTED_ECHO_RECEIPT.items()
+        ],
         f"  pipeline_version={ver} (bundle)",
         f"  plugin_root={root} (resolved)",
     ]

--- a/bench/tests/fakes/fake_claude.py
+++ b/bench/tests/fakes/fake_claude.py
@@ -114,7 +114,7 @@ def echo_lines(plugin_root=None, pipeline_version=None):
         sys.path.insert(0, plugin_root_from_argv)
     from bench.runner import invoke
 
-    root = plugin_root if plugin_root is not None else _plugin_dir_from_argv()
+    root = plugin_root if plugin_root is not None else plugin_root_from_argv
     ver = pipeline_version if pipeline_version is not None else _pipeline_version(root)
     return [
         "Headless config:",

--- a/bench/tests/test_headless_echo_contract.py
+++ b/bench/tests/test_headless_echo_contract.py
@@ -95,6 +95,15 @@ class HeadlessEchoIdentityContractTest(unittest.TestCase):
         with patch.object(invoke, "EXPECTED_ECHO", DOC_ECHO_VALUES):
             self.assertTrue(invoke._echo_in_text("\n".join(substituted)))
 
+    def test_every_doc_knob_line_uses_the_resolver_receipt_source(self):
+        block = self._echo_block()
+        for key, entry in invoke.EXPECTED_ECHO_RECEIPT.items():
+            match = re.search(
+                rf"(?m)^[ \t]*{re.escape(key)}=[^\n]+ \(([^)]+)\)$", block
+            )
+            self.assertIsNotNone(match, f"missing doc line for {key}")
+            self.assertEqual(match.group(1), entry["source"], key)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bench/tests/test_invoke.py
+++ b/bench/tests/test_invoke.py
@@ -11,6 +11,7 @@ import json
 import os
 import shutil
 import stat
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -33,6 +34,30 @@ BUNDLE_TEXT = BUNDLE_BYTES.decode("utf-8")
 DIFFERENT_BUNDLE_TEXT = ("x" if BUNDLE_TEXT[0] != "x" else "y") + BUNDLE_TEXT[1:]
 # Hand-typed oracle for the parser, independent of the implementation constant.
 EXPECTED_PIPELINE_META_NAME = "code-gauntlet-pipeline"
+
+HAND_TYPED_BENCH_ENV = {
+    "CODE_GAUNTLET_HEADLESS": "1",
+    "CODE_GAUNTLET_MODEL_TIER": "optimized",
+    "CODE_GAUNTLET_DELIVERY": "pr_comments,markdown",
+    "CODE_GAUNTLET_POST_MODE": "dry-run",
+    "CODE_GAUNTLET_PR_COMMENT_CAP": "25",
+    "CODE_GAUNTLET_DELIVERY_TIER": "all",
+    "CODE_GAUNTLET_DRAFT_POLICY": "review",
+    "CODE_GAUNTLET_REVIEWED_POLICY": "full",
+    "CODE_GAUNTLET_PR_NOT_FOUND_POLICY": "error",
+    "CODE_GAUNTLET_TRIVIAL_SCOPE": "full",
+}
+HAND_TYPED_ECHO_RECEIPT = {
+    "model_tier": {"value": "optimized", "source": "env"},
+    "delivery": {"value": "pr_comments,markdown", "source": "env"},
+    "post_mode": {"value": "dry-run", "source": "env"},
+    "pr_comment_cap": {"value": "25", "source": "env"},
+    "delivery_tier": {"value": "all", "source": "env"},
+    "draft_policy": {"value": "review", "source": "env"},
+    "reviewed_policy": {"value": "full", "source": "env"},
+    "pr_not_found_policy": {"value": "error", "source": "env"},
+    "trivial_scope": {"value": "full", "source": "env"},
+}
 
 PR = {
     "owner": "octo",
@@ -84,6 +109,9 @@ class InvokeTestBase(unittest.TestCase):
         bindir = self.install_fake()
         overrides = {
             "PATH": str(bindir) + os.pathsep + os.environ.get("PATH", ""),
+            "PYTHONPATH": str(REPO_ROOT)
+            + os.pathsep
+            + os.environ.get("PYTHONPATH", ""),
             "FAKE_CLAUDE_MODE": mode,
         }
         if extra_env:
@@ -139,17 +167,142 @@ class PrDirNameTest(unittest.TestCase):
 
 
 class BuildEnvTest(InvokeTestBase):
-    def test_sets_nine_bench_values(self):
+    def test_sets_ten_bench_values(self):
         env = build_env(PR, self.run_dir, {})
+        self.assertEqual(
+            {key: env[key] for key in HAND_TYPED_BENCH_ENV}, HAND_TYPED_BENCH_ENV
+        )
+
+    def test_scrubs_all_ambient_bench_prefixes_before_overlay(self):
+        ambient = {
+            "CODE_GAUNTLET_TASKS_DIR": "/junk/tasks",
+            "CODE_GAUNTLET_BIOME_CACHE": "/junk/biome",
+            "CODE_GAUNTLET_FUTURE_SENTINEL": "x",
+            "CODE_GAUNTLET_HEADLESS": "0",
+            "CODE_GAUNTLET_MODEL_TIER": "optimized",
+            "CODE_GAUNTLET_DELIVERY": "chat",
+            "CODE_GAUNTLET_POST_MODE": "live",
+            "CODE_GAUNTLET_PR_COMMENT_CAP": "1",
+            "CODE_GAUNTLET_DELIVERY_TIER": "main_only",
+            "CODE_GAUNTLET_DRAFT_POLICY": "skip",
+            "CODE_GAUNTLET_REVIEWED_POLICY": "skip",
+            "CODE_GAUNTLET_PR_NOT_FOUND_POLICY": "local",
+            "CODE_GAUNTLET_TRIVIAL_SCOPE": "light",
+            "OTHER": "preserved",
+        }
+        env = build_env(PR, self.run_dir, ambient)
+        self.assertEqual(
+            {key for key in env if key.startswith("CODE_GAUNTLET_")},
+            set(invoke.BENCH_ENV) | {"CODE_GAUNTLET_OUTPUT_DIR"},
+        )
         self.assertEqual(env["CODE_GAUNTLET_HEADLESS"], "1")
-        self.assertEqual(env["CODE_GAUNTLET_MODEL_TIER"], "optimized")
-        self.assertEqual(env["CODE_GAUNTLET_DELIVERY"], "pr_comments,markdown")
-        self.assertEqual(env["CODE_GAUNTLET_POST_MODE"], "dry-run")
-        self.assertEqual(env["CODE_GAUNTLET_PR_COMMENT_CAP"], "25")
-        self.assertEqual(env["CODE_GAUNTLET_DRAFT_POLICY"], "review")
-        self.assertEqual(env["CODE_GAUNTLET_REVIEWED_POLICY"], "full")
-        self.assertEqual(env["CODE_GAUNTLET_PR_NOT_FOUND_POLICY"], "error")
-        self.assertEqual(env["CODE_GAUNTLET_TRIVIAL_SCOPE"], "full")
+        self.assertEqual(env["OTHER"], "preserved")
+
+    def test_scrub_ambient_returns_clean_copy_and_sorted_removed_names(self):
+        clean, removed = invoke.scrub_ambient(
+            {
+                "CODE_GAUNTLET_Z": "z",
+                "KEEP": "yes",
+                "CODE_GAUNTLET_A": "a",
+            }
+        )
+        self.assertEqual(clean, {"KEEP": "yes"})
+        self.assertEqual(removed, ["CODE_GAUNTLET_A", "CODE_GAUNTLET_Z"])
+
+    def test_real_resolver_subprocess_receives_the_built_env(self):
+        ambient = dict(os.environ)
+        ambient.update(
+            {
+                "CODE_GAUNTLET_TASKS_DIR": "/junk/tasks",
+                "CODE_GAUNTLET_BIOME_CACHE": "/junk/biome",
+                "CODE_GAUNTLET_HEADLESS": "0",
+                "CODE_GAUNTLET_MODEL_TIER": "optimized",
+                "CODE_GAUNTLET_DELIVERY": "chat",
+                "CODE_GAUNTLET_POST_MODE": "live",
+                "CODE_GAUNTLET_PR_COMMENT_CAP": "1",
+                "CODE_GAUNTLET_DELIVERY_TIER": "main_only",
+                "CODE_GAUNTLET_DRAFT_POLICY": "skip",
+                "CODE_GAUNTLET_REVIEWED_POLICY": "skip",
+                "CODE_GAUNTLET_PR_NOT_FOUND_POLICY": "local",
+                "CODE_GAUNTLET_TRIVIAL_SCOPE": "light",
+            }
+        )
+        built = build_env(PR, self.run_dir, ambient)
+        result = subprocess.run(
+            ["python3", "scripts/resolve_config.py", "--target", "pr"],
+            cwd=REPO_ROOT,
+            env=built,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        receipt = json.loads(result.stdout)["waist"]["configEcho"]
+        self.assertEqual(receipt, HAND_TYPED_ECHO_RECEIPT)
+        self.assertNotIn("CODE_GAUNTLET_TASKS_DIR", built)
+        self.assertNotIn("CODE_GAUNTLET_BIOME_CACHE", built)
+
+    def test_build_bench_env_rejects_missing_and_extra_pin_keys(self):
+        registry = [
+            {
+                "key": "example",
+                "modes": ["headless"],
+                "env": "CODE_GAUNTLET_EXAMPLE",
+                "rule": {"kind": "enum", "values": ["ok"]},
+            }
+        ]
+        with self.assertRaisesRegex(ValueError, r"BENCH_PINS.*'example'"):
+            invoke.build_bench_env({}, registry)
+        with self.assertRaisesRegex(ValueError, r"BENCH_PINS.*'extra'"):
+            invoke.build_bench_env(
+                {"example": "ok", "extra": "ok"},
+                registry,
+            )
+
+    def test_build_bench_env_rejects_invalid_pin_value(self):
+        registry = [
+            {
+                "key": "example",
+                "modes": ["headless"],
+                "env": "CODE_GAUNTLET_EXAMPLE",
+                "rule": {"kind": "enum", "values": ["ok"]},
+            }
+        ]
+        with self.assertRaisesRegex(ValueError, r"BENCH_PINS\['example'\]"):
+            invoke.build_bench_env({"example": "bad"}, registry)
+
+    def test_expected_echo_is_the_resolver_receipt_and_bench_pin_oracle(self):
+        self.assertEqual(invoke.EXPECTED_ECHO_RECEIPT, HAND_TYPED_ECHO_RECEIPT)
+        self.assertEqual(
+            invoke.EXPECTED_ECHO,
+            {key: entry["value"] for key, entry in HAND_TYPED_ECHO_RECEIPT.items()},
+        )
+        headless_rows = [
+            row
+            for row in invoke.KNOB_REGISTRY
+            if "headless" in row["modes"] and row.get("env")
+        ]
+        self.assertEqual(
+            {row["env"]: invoke.BENCH_ENV[row["env"]] for row in headless_rows},
+            {
+                key: value
+                for key, value in HAND_TYPED_BENCH_ENV.items()
+                if key != "CODE_GAUNTLET_HEADLESS"
+            },
+        )
+        self.assertEqual(
+            {row["key"]: invoke.BENCH_ENV[row["env"]] for row in headless_rows},
+            invoke.EXPECTED_ECHO,
+        )
+        self.assertEqual(
+            {row["key"] for row in headless_rows}, set(HAND_TYPED_ECHO_RECEIPT)
+        )
+        self.assertTrue(
+            all(
+                entry["source"] == "env"
+                for entry in invoke.EXPECTED_ECHO_RECEIPT.values()
+            )
+        )
 
     def test_output_dir_and_gh_repo(self):
         env = build_env(PR, self.run_dir, {})

--- a/bench/tests/test_invoke.py
+++ b/bench/tests/test_invoke.py
@@ -251,9 +251,15 @@ class BuildEnvTest(InvokeTestBase):
                 "rule": {"kind": "enum", "values": ["ok"]},
             }
         ]
-        with self.assertRaisesRegex(ValueError, r"BENCH_PINS.*'example'"):
+        # Each arm names its own guard message: a deleted key-set guard would fall through
+        # to a KeyError on the missing pin, which the missing-arm regex must not accept.
+        with self.assertRaisesRegex(
+            ValueError, r"BENCH_PINS key set mismatch: missing key\(s\) 'example'$"
+        ):
             invoke.build_bench_env({}, registry)
-        with self.assertRaisesRegex(ValueError, r"BENCH_PINS.*'extra'"):
+        with self.assertRaisesRegex(
+            ValueError, r"BENCH_PINS key set mismatch: unexpected key\(s\) 'extra'$"
+        ):
             invoke.build_bench_env(
                 {"example": "ok", "extra": "ok"},
                 registry,

--- a/bench/tests/test_run_cli.py
+++ b/bench/tests/test_run_cli.py
@@ -852,6 +852,67 @@ class MultiRunTest(RunTestBase):
         self.assertEqual(fingerprint["CODE_GAUNTLET_MODEL_TIER"], "optimized")
         self.assertEqual(fingerprint["timeout_s"], 45 * 60)
 
+    def test_manifest_records_config_echo_and_ambient_scrub(self):
+        import types
+
+        args = types.SimpleNamespace(
+            anchor=None,
+            fidelity="dry-run",
+            tool="deep-review-v3",
+            child_model=None,
+            child_auth="api",
+        )
+        run_dir = self.tmp / "manifest-provenance"
+        run_dir.mkdir()
+        with patch.dict(
+            os.environ,
+            {
+                "PATH": os.environ.get("PATH", ""),
+                "CODE_GAUNTLET_TASKS_DIR": "/junk/tasks",
+                "CODE_GAUNTLET_FUTURE_SENTINEL": "x",
+            },
+            clear=True,
+        ):
+            expected_removed = run.invoke.scrub_ambient(os.environ)[1]
+            run._write_manifest(run_dir, "rid", "smoke", [], 60, args)
+        manifest = json.loads((run_dir / "run.json").read_text())
+        fingerprint = manifest["env_fingerprint"]
+        self.assertEqual(
+            set(fingerprint),
+            {
+                "CODE_GAUNTLET_HEADLESS",
+                "CODE_GAUNTLET_MODEL_TIER",
+                "CODE_GAUNTLET_DELIVERY",
+                "CODE_GAUNTLET_POST_MODE",
+                "CODE_GAUNTLET_PR_COMMENT_CAP",
+                "CODE_GAUNTLET_DELIVERY_TIER",
+                "CODE_GAUNTLET_DRAFT_POLICY",
+                "CODE_GAUNTLET_REVIEWED_POLICY",
+                "CODE_GAUNTLET_PR_NOT_FOUND_POLICY",
+                "CODE_GAUNTLET_TRIVIAL_SCOPE",
+                "timeout_s",
+                "child_auth",
+                "config_echo",
+                "ambient_scrubbed",
+            },
+        )
+        self.assertEqual(
+            set(fingerprint["config_echo"]),
+            {
+                "model_tier",
+                "delivery",
+                "post_mode",
+                "pr_comment_cap",
+                "delivery_tier",
+                "draft_policy",
+                "reviewed_policy",
+                "pr_not_found_policy",
+                "trivial_scope",
+            },
+        )
+        self.assertEqual(fingerprint["config_echo"], run.invoke.EXPECTED_ECHO_RECEIPT)
+        self.assertEqual(fingerprint["ambient_scrubbed"], expected_removed)
+
 
 class ToolWiringTest(RunTestBase):
     """--tool threads into the manifest and forwards to invoke_review (v3 default)."""

--- a/skills/code-gauntlet/references/headless-mode.md
+++ b/skills/code-gauntlet/references/headless-mode.md
@@ -105,7 +105,7 @@ Headless config:
   delivery=pr_comments,markdown (env)
   post_mode=dry-run (env)
   pr_comment_cap=25 (env)
-  delivery_tier=all (default)
+  delivery_tier=all (env)
   draft_policy=review (env)
   reviewed_policy=full (env)
   pr_not_found_policy=error (env)
@@ -116,7 +116,7 @@ Headless config:
 
 The nine echoed knobs are followed by `pipeline_version` and `plugin_root` identity lines. The report renders the validated waist, and the Phase 1 Bash result carries the resolver block.
 
-The example shows a bench-configured run (env overrides throughout) except `delivery_tier`, which bench leaves unset so it resolves to the `all` default — the benchmark posts every challenge-survivor, which is the intended default. A run relying on headless defaults would show e.g. `delivery=markdown (default)` and `pr_comment_cap=6 (default)`, and a REVIEW.md-sourced value would show e.g. `delivery=chat (review_md)`.
+The example shows a bench-configured run with environment pins. A run relying on headless defaults would show e.g. `delivery=markdown (default)` and `pr_comment_cap=6 (default)`, and a REVIEW.md-sourced value would show e.g. `delivery=chat (review_md)`.
 
 The pipeline renders the block in the report's last `Review Methodology` section. At delivery, point the chat methodology to that section and include the materialization proof, patches path, delivery outcome, post-report gaps, and duration.
 If no report materializes, repeat the block in the final message as the fallback receipt.


### PR DESCRIPTION
## Summary

Bench children no longer inherit ambient `CODE_GAUNTLET_*` pins from the developer shell, and the bench's env and expected receipt are derived from the knob registry instead of being hand-copied. `build_env` now strips every `CODE_GAUNTLET_*` variable from the parent environment before it overlays the bench pins, so an exported `CODE_GAUNTLET_DELIVERY_TIER=main_only` (or a `CODE_GAUNTLET_TASKS_DIR` pointing at a developer's task directory) cannot reach a child. `BENCH_PINS` is the one bench-owned policy map, keyed by knob and hand-typed per value; a pure `build_bench_env` turns it into `BENCH_ENV` using the registry's env names and refuses a pin set that does not match the registry's headless knobs exactly, or a value the knob's rule rejects. `EXPECTED_ECHO` is the resolver's own receipt over that env. The run manifest records the receipt with sources and the ambient names that were scrubbed.

## What changed

| Area | Files | What |
| --- | --- | --- |
| Bench env | `bench/runner/invoke.py` | `scrub_ambient` (prefix scrub, returns the removed names); `BENCH_PINS` + `build_bench_env` (exact key set and rule validation against the registry); `EXPECTED_ECHO_RECEIPT` / `EXPECTED_ECHO` resolved from the pins through `scripts/resolve_config.resolve`. |
| Manifest | `bench/run.py` | `env_fingerprint` gains `config_echo` (the receipt with sources) and `ambient_scrubbed` (from the same scrub helper over the parent environment at manifest time). |
| Source-bearing copies | `bench/tests/fakes/fake_claude.py`, `skills/code-gauntlet/references/headless-mode.md`, `bench/MEASUREMENT.md` | The fake echo derives its lines from the receipt; the documented bench block shows `delivery_tier=all (env)` and the "bench leaves it unset" carve-out is gone; count wording replaced by the registry derivation. |
| Tests | `bench/tests/test_invoke.py`, `bench/tests/test_run_cli.py`, `bench/tests/test_headless_echo_contract.py` | Hand-typed ten-pair env oracle and nine-pair receipt oracle; scrub key-set test seeded with `TASKS_DIR`, `BIOME_CACHE` and an unknown future name; the issue's ask 3 as a real subprocess run of the resolver over the built env; pin-validation failure arms; manifest key-set pin; doc-line source pin. |

## Design decisions of record

Two Claude opus lenses and one Codex sol max lens red-teamed the plan; the rulings below came out of that review.

1. Prefix scrub, not a registry-name list. The tree carries two live non-registry names (`CODE_GAUNTLET_TASKS_DIR`, honoured by the awaiter and materializer, and `CODE_GAUNTLET_BIOME_CACHE`), and a future knob added without a bench edit must be scrubbed too. No child needs an inherited `CODE_GAUNTLET_*` value; `OUTPUT_DIR` is re-set after the overlay.
2. Derive the key set, pin every value. Falling back to registry defaults would let a default flip silently change what the benchmark measures, with the receipt moving in lockstep. `BENCH_PINS` stays bench-owned policy and must cover exactly the registry's headless env-bearing knobs, so a new knob forces an explicit bench decision at import.
3. The hand oracle moved, it was not deleted. `EXPECTED_ECHO` is derived, and the ten `key=value` pairs are pinned by hand in `bench/tests`, where a changed pin goes red.
4. The manifest records provenance from the same helper `build_env` uses, over the same source (`os.environ`). A resume in a different shell does not rewrite it; the docstring says so.

## Verification

All three suites, the coverage floors, the generator check, the bundle fixed point and `pre-commit run --all-files` are green on the final commit.

| Gate | Measured | Floor |
| --- | --- | --- |
| `pytest tests/` coverage | 94.28 | 93.8 |
| `pytest bench/tests/` coverage | 89.32 | 88.2 |
| JS lines / branches / functions | 98.84 / 90.53 / 98.28 | 98.2 / 89.6 / 97.6 |

```bash
python -m pytest tests/ -q            # 2129 passed
python -m pytest bench/tests/ -q      # 645 passed
node --test workflows/test/*.test.js  # 1334 passed (Node 24)
python3 scripts/generate_contract_requirements.py --check
node workflows/build.js && git diff --exit-code workflows/pipeline.js
pre-commit run --all-files
```

This branch carries the one-line test fix from #310 as a cherry-pick (the 3.33.0 release bump left `tests/test_resolve_config.py` pinned to the previous version, so `main` is red on that one test). Merge #310 first; this branch then rebases onto it cleanly.

## Review record

- Recon and brief by the orchestrator; two Claude opus lenses and one Codex sol max lens red-teamed the plan (verdict revise on all three; the sol mechanism lens timed out). The rulings in the design section are the adjudication. Both families converged on the prefix scrub and on keeping every bench value hand-pinned.
- Build on Codex luna xhigh, then two luna lenses (mutation ledger, spec conformance) in a detached worktree. Conformance passed with one minor. The mutation lens found the orchestrator's own version-pin fix tautological (expected value computed by the helper under test) and a pin-key guard whose deletion passed through a neighbouring `KeyError`.
- Fix round: the version oracle is now `.claude-plugin/plugin.json`, which the resolver never reads; each pin-key arm asserts its own anchored message. The orchestrator ran the key-set mutation by hand (red, then green on restore).
- Round-2 mutation lens: pass, thirteen mutations red, zero findings. The orchestrator ran every gate above on the final commit. Lee's own code-gauntlet run is the cross-family pass still to come.

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BpXjxXF77KytbhLWWj6vi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every bench child is configured and what the smoke checker expects for config echo—core measurement isolation—with broad test coverage but real risk if registry/pin drift is mis-handled.
> 
> **Overview**
> Bench review children no longer inherit the operator shell’s `CODE_GAUNTLET_*` variables: **`build_env` strips every such prefix** via `scrub_ambient` before applying the harness pins, so stray exports like `CODE_GAUNTLET_DELIVERY_TIER` or developer-only vars cannot change what a run measures.
> 
> **`BENCH_ENV` and the expected Headless config receipt are no longer hand-maintained.** Bench policy lives in `BENCH_PINS` (including an explicit `delivery_tier=all` pin); `build_bench_env` maps pins to registry env names, rejects missing/extra knobs or invalid values, and **`EXPECTED_ECHO` / `EXPECTED_ECHO_RECEIPT` come from `scripts/resolve_config.resolve`**. Run manifests record that receipt plus the list of ambient names scrubbed at manifest time (fixed on first write, not on resume).
> 
> Tests, `fake_claude`, and headless docs were aligned so echoes and sources match the resolver; `test_resolve_config` now compares `pipeline_version` to `.claude-plugin/plugin.json` instead of a hardcoded version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d87cc200890cc56a0de7d7ebf19ddf3417f53e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->