### PR TITLE
feat(lint): verify generated contract fences at commit time (#317)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: "24.18.0"
+
 jobs:
   lint:
     name: Run Linting
@@ -25,6 +28,11 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install pre-commit
         run: pip install pre-commit==4.6.1
@@ -61,6 +69,11 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install pytest
         if: matrix.python-version != '3.12'
@@ -117,7 +130,7 @@ jobs:
         with:
           # Exact patch: coverage percentages move across Node builds; 24.18.0 is
           # the sandboxed runtime / reference build this repo develops against.
-          node-version: "24.18.0"
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Run node test suite
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,6 +100,17 @@ repos:
         files: ^(CLAUDE\.md|AGENTS\.md|[^/]+/(AGENTS|CLAUDE)\.md|scripts/sync_agent_rules\.py)$
         pass_filenames: false
 
+      # This checks generated contract fences and tables against the registry and renderer.
+      # Its scope is the owning roots because targets and inputs are derived by the
+      # generator, so a new target under an existing root needs no hook edit. Node 24 must
+      # be on PATH; the JavaScript suite already requires it.
+      - id: contract-fences-current
+        name: generated contract fences are current (regenerate with scripts/generate_contract_requirements.py)
+        entry: python3 scripts/generate_contract_requirements.py --check
+        language: system
+        files: ^(agents|skills/code-gauntlet|scripts|workflows)/
+        pass_filenames: false
+
       - id: zizmor
         name: audit GitHub Actions workflows with zizmor
         entry: zizmor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,8 @@ ladder, costs, and pre-registered owner options.
 1. Fork and clone the repository.
 2. Ensure you have Python 3.10 or newer installed (for the test suite and pre-commit hooks). CI runs the pipeline
    suite on 3.10, 3.11, and 3.12.
-3. Set up the development environment:
+3. Ensure Node `24.18.0` is installed; the `contract-fences-current` pre-commit hook uses it to verify generated fences.
+4. Set up the development environment:
 
 ```bash
 pip install pre-commit

--- a/scripts/generate_contract_requirements.py
+++ b/scripts/generate_contract_requirements.py
@@ -108,14 +108,98 @@ _WORKFLOW_RELATIVE_IMPORT_RE = re.compile(
     r"^\s*(?:import|export)\b.*?\bfrom\s+['\"](\.[^'\"]+)['\"]",
     re.MULTILINE,
 )
-_SCRIPT_INPUTS = (
-    "scripts/generate_contract_requirements.py",
-    "scripts/resolve_config.py",
-    "scripts/post_review.py",
-    "scripts/detect_prior_review.py",
-    "scripts/diff_lines.py",
-    "scripts/review_marker.py",
+_PYTHON_FROM_IMPORT_RE = re.compile(
+    r"^\s*from\s+(?P<module>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*)\s+import\s+"
+    r"(?P<names>[^\n#]+)$",
+    re.MULTILINE,
 )
+_PYTHON_IMPORT_RE = re.compile(
+    r"^\s*import\s+(?P<modules>[^\n#]+)$",
+    re.MULTILINE,
+)
+_DYNAMIC_SCRIPT_PATH_RE = re.compile(
+    r"os\.path\.join\(\s*repo_root\s*,\s*['\"]scripts['\"]\s*,\s*"
+    r"['\"](?P<path>[^'\"]+\.py)['\"]\s*\)",
+)
+_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _script_module_path(module, repo_root):
+    """Resolve a module name to a Python file under scripts/, if it exists."""
+    if module == "scripts":
+        return None
+    if module.startswith("scripts."):
+        module = module[len("scripts.") :]
+    elif "." in module:
+        return None
+    rel_path = os.path.join("scripts", *module.split(".")) + ".py"
+    if os.path.isfile(os.path.join(repo_root, rel_path)):
+        return rel_path
+    return None
+
+
+def _python_imported_script_paths(source, repo_root):
+    """Find local Python modules named by absolute or direct-invocation imports."""
+    imported = set()
+    for match in _PYTHON_FROM_IMPORT_RE.finditer(source):
+        module = match.group("module")
+        names = [part.strip().split()[0] for part in match.group("names").split(",")]
+        if module == "scripts":
+            for name in names:
+                path = _script_module_path(f"scripts.{name}", repo_root)
+                if path:
+                    imported.add(path)
+        else:
+            path = _script_module_path(module, repo_root)
+            if path:
+                imported.add(path)
+    for match in _PYTHON_IMPORT_RE.finditer(source):
+        for part in match.group("modules").split(","):
+            module = part.strip().split()[0]
+            path = _script_module_path(module, repo_root)
+            if path:
+                imported.add(path)
+    for match in _DYNAMIC_SCRIPT_PATH_RE.finditer(source):
+        rel_path = os.path.normpath(os.path.join("scripts", match.group("path")))
+        if rel_path.startswith("scripts/") and os.path.isfile(
+            os.path.join(repo_root, rel_path)
+        ):
+            imported.add(rel_path)
+    return imported
+
+
+def _python_import_closure(repo_root):
+    """Return the generator and every local Python module in its import closure."""
+    pending = ["scripts/generate_contract_requirements.py"]
+    seen = set()
+    while pending:
+        rel_path = pending.pop()
+        if rel_path in seen:
+            continue
+        seen.add(rel_path)
+        path = os.path.join(repo_root, rel_path)
+        with open(path, encoding="utf-8") as handle:
+            source = handle.read()
+        for imported in _python_imported_script_paths(source, repo_root):
+            if imported not in seen:
+                pending.append(imported)
+    return seen
+
+
+def _stderr_tail(stderr):
+    """Return a single-line, bounded tail from a failed child process."""
+    for line in reversed((stderr or "").splitlines()):
+        clean = _CONTROL_RE.sub("", line)
+        if clean.strip():
+            return clean[-200:]
+    return ""
+
+
+def _node_failure_message(command, stderr=None):
+    command_text = " ".join(_CONTROL_RE.sub("", part) for part in command)
+    message = "generate_contract_requirements: node 24 command failed: " + command_text
+    tail = _stderr_tail(stderr)
+    return f"{message}: {tail}" if tail else message
 
 
 def _run_node(node_src, repo_root):
@@ -129,11 +213,10 @@ def _run_node(node_src, repo_root):
             text=True,
             check=True,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        raise SystemExit(
-            "generate_contract_requirements: node 24 command failed: "
-            + " ".join(command)
-        ) from None
+    except FileNotFoundError:
+        raise SystemExit(_node_failure_message(command)) from None
+    except subprocess.CalledProcessError as error:
+        raise SystemExit(_node_failure_message(command, error.stderr)) from None
 
 
 def _workflow_import_closure(repo_root):
@@ -158,7 +241,7 @@ def _workflow_import_closure(repo_root):
 
 def declared_inputs(repo_root=REPO_ROOT):
     """Return generator sources and every local module that can affect its output."""
-    return set(_SCRIPT_INPUTS) | _workflow_import_closure(repo_root)
+    return _python_import_closure(repo_root) | _workflow_import_closure(repo_root)
 
 
 def load_registry(repo_root=REPO_ROOT):

--- a/scripts/generate_contract_requirements.py
+++ b/scripts/generate_contract_requirements.py
@@ -99,6 +99,68 @@ _CONDITIONAL_NOUNS = {
 }
 
 
+_NODE_PROGRAM_ROOTS = (
+    "workflows/src/registry.js",
+    "workflows/src/args.js",
+    "workflows/src/renderReport.js",
+)
+_WORKFLOW_RELATIVE_IMPORT_RE = re.compile(
+    r"^\s*(?:import|export)\b.*?\bfrom\s+['\"](\.[^'\"]+)['\"]",
+    re.MULTILINE,
+)
+_SCRIPT_INPUTS = (
+    "scripts/generate_contract_requirements.py",
+    "scripts/resolve_config.py",
+    "scripts/post_review.py",
+    "scripts/detect_prior_review.py",
+    "scripts/diff_lines.py",
+    "scripts/review_marker.py",
+)
+
+
+def _run_node(node_src, repo_root):
+    """Run one of the generator's Node programs with a concise failure diagnostic."""
+    command = ["node", "--input-type=module", "-e", node_src]
+    try:
+        return subprocess.run(
+            command,
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        raise SystemExit(
+            "generate_contract_requirements: node 24 command failed: "
+            + " ".join(command)
+        ) from None
+
+
+def _workflow_import_closure(repo_root):
+    """Return the relative workflows/src modules used by both Node programs."""
+    pending = list(_NODE_PROGRAM_ROOTS)
+    seen = set()
+    while pending:
+        rel_path = pending.pop()
+        if rel_path in seen:
+            continue
+        seen.add(rel_path)
+        path = os.path.join(repo_root, rel_path)
+        with open(path, encoding="utf-8") as handle:
+            source = handle.read()
+        base = os.path.dirname(rel_path)
+        for specifier in _WORKFLOW_RELATIVE_IMPORT_RE.findall(source):
+            imported = os.path.normpath(os.path.join(base, specifier))
+            if imported not in seen:
+                pending.append(imported)
+    return seen
+
+
+def declared_inputs(repo_root=REPO_ROOT):
+    """Return generator sources and every local module that can affect its output."""
+    return set(_SCRIPT_INPUTS) | _workflow_import_closure(repo_root)
+
+
 def load_registry(repo_root=REPO_ROOT):
     """Import the live schemas and keep finding and waist required lists distinct."""
     node_src = (
@@ -124,13 +186,7 @@ def load_registry(repo_root=REPO_ROOT):
         "  derivedFrom: Object.fromEntries(Object.entries(a.DERIVED_FROM).map(([name, d]) => [name, d.describe])),"
         "})))"
     )
-    out = subprocess.run(
-        ["node", "--input-type=module", "-e", node_src],
-        cwd=repo_root,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    out = _run_node(node_src, repo_root)
     return json.loads(out.stdout)
 
 
@@ -571,13 +627,7 @@ def render_template_block(repo_root, identity):
         "import('./workflows/src/renderReport.js').then(m => "
         "process.stdout.write(m.renderReport(" + json.dumps(fixture) + ")))"
     )
-    out = subprocess.run(
-        ["node", "--input-type=module", "-e", node_src],
-        cwd=repo_root,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    out = _run_node(node_src, repo_root)
     return "````markdown\n" + out.stdout + "\n````"
 
 

--- a/tests/test_contribution_surface.py
+++ b/tests/test_contribution_surface.py
@@ -135,6 +135,26 @@ def _pre_commit_hook_block(text, hook_id):
     return text[start:end]
 
 
+def _pre_commit_repo_block(text, hook_id):
+    """Return the unique enclosing repo block for a hook."""
+    hook_start, _ = _pre_commit_hook_span(text, hook_id)
+    repo_markers = list(re.finditer(r"(?m)^  - repo:\s*[^\n]*$", text))
+    enclosing = []
+    for index, marker in enumerate(repo_markers):
+        end = (
+            repo_markers[index + 1].start()
+            if index + 1 < len(repo_markers)
+            else len(text)
+        )
+        if marker.start() < hook_start < end:
+            enclosing.append(text[marker.start() : end])
+    if len(enclosing) != 1:
+        raise AssertionError(
+            f"expected exactly one enclosing repo block for {hook_id}, found {len(enclosing)}"
+        )
+    return enclosing[0]
+
+
 def _pre_commit_hook_value(block, key):
     matches = re.findall(rf"(?m)^        {re.escape(key)}:\s*(.*?)\s*$", block)
     if len(matches) != 1:
@@ -1272,6 +1292,16 @@ def _ci_step_run_bodies(step: str) -> list[str]:
     return inline + _ci_run_blocks(step)
 
 
+def _ci_setup_node_steps(text: str) -> list[tuple[str, int, str]]:
+    """Every setup-node step, with its job and zero-based step index."""
+    return [
+        (job_id, index, step)
+        for job_id, job in _ci_job_blocks(text)
+        for index, step in enumerate(_ci_step_blocks(job))
+        if "actions/setup-node@" in step
+    ]
+
+
 def _copy_tracked_tree(destination: Path) -> None:
     result = subprocess.run(
         ["git", "ls-files", "-z"],
@@ -1314,6 +1344,14 @@ class TestContractFenceHook(unittest.TestCase):
         self.assertGreater(contract_start, agent_start)
 
         block = _pre_commit_hook_block(text, "contract-fences-current")
+        repo_block = _pre_commit_repo_block(text, "contract-fences-current")
+        repo_header = re.match(r"(?m)^  - repo:\s*(.*?)\s*$", repo_block)
+        self.assertIsNotNone(repo_header)
+        self.assertEqual(_unquote(repo_header.group(1)), "local")
+        self.assertEqual(
+            _pre_commit_hook_value(block, "name"),
+            "generated contract fences are current (regenerate with scripts/generate_contract_requirements.py)",
+        )
         self.assertEqual(
             _pre_commit_hook_value(block, "entry"),
             "python3 scripts/generate_contract_requirements.py --check",
@@ -1331,8 +1369,17 @@ class TestContractFenceHook(unittest.TestCase):
         )
         scope = re.compile(files_pattern)
 
+        declared_inputs = contract_gen.declared_inputs(str(REPO))
+        self.assertTrue(
+            {
+                "scripts/post_review.py",
+                "scripts/resolve_config.py",
+                "scripts/review_marker.py",
+            }.issubset(declared_inputs),
+            declared_inputs,
+        )
         paths = set(contract_gen.compute_targets(str(REPO)))
-        paths.update(contract_gen.declared_inputs(str(REPO)))
+        paths.update(declared_inputs)
         for path in sorted(paths):
             with self.subTest(path=path):
                 self.assertIsNotNone(scope.match(path), path)
@@ -1392,20 +1439,28 @@ class TestCiNodePin(unittest.TestCase):
     def test_node_is_pinned_before_every_relevant_ci_job(self):
         text = _read(".github/workflows/ci.yml")
         version = _ci_workflow_tests_node_version(text)
-        self.assertEqual(
-            re.findall(
-                r'(?m)^env:\n  NODE_VERSION:\s*["\']?([^"\'\s]+)["\']?\s*$',
-                text,
-            ),
-            [version],
-        )
-        setup_node_uses = re.findall(
-            r"(?m)^\s+uses:\s*actions/setup-node@([0-9a-f]{40})\s+#\s+v\S+$",
-            text,
-        )
-        self.assertTrue(setup_node_uses)
+        workflow_versions = re.findall(r"(?m)^env:\n  NODE_VERSION:\s*(.*?)\s*$", text)
+        self.assertEqual(len(workflow_versions), 1)
+        self.assertEqual(_unquote(workflow_versions[0]), version)
+        self.assertEqual(len(re.findall(r"(?m)^  NODE_VERSION:", text)), 1)
+
+        setup_steps = _ci_setup_node_steps(text)
+        self.assertTrue(setup_steps)
+        self.assertEqual(text.count("actions/setup-node@"), len(setup_steps))
+        setup_node_uses = []
+        for job_id, index, step in setup_steps:
+            with self.subTest(setup_node=(job_id, index)):
+                uses = re.search(
+                    r"(?m)^\s+uses:\s*actions/setup-node@([0-9a-f]{40})\s+#\s+v\S+$",
+                    step,
+                )
+                self.assertIsNotNone(uses)
+                setup_node_uses.append(uses.group(1))
+                self.assertEqual(
+                    re.findall(r"(?m)^\s+node-version:\s*(.*?)\s*$", step),
+                    ["${{ env.NODE_VERSION }}"],
+                )
         self.assertEqual(len(set(setup_node_uses)), 1)
-        self.assertEqual(text.count("actions/setup-node@"), len(setup_node_uses))
 
         bare_node = re.compile(r"(?<![A-Za-z0-9_-])node ")
         consumer_markers = ("pre-commit run", "python -m pytest tests/")
@@ -1430,18 +1485,6 @@ class TestCiNodePin(unittest.TestCase):
             with self.subTest(job=job_id):
                 self.assertTrue(setup_indexes)
                 self.assertLess(min(setup_indexes), min(consumer_indexes))
-                for index in setup_indexes:
-                    step = steps[index]
-                    uses = re.search(
-                        r"(?m)^\s+uses:\s*actions/setup-node@([0-9a-f]{40})\s+#\s+v\S+$",
-                        step,
-                    )
-                    self.assertIsNotNone(uses)
-                    self.assertEqual(uses.group(1), setup_node_uses[0])
-                    node_versions = re.findall(
-                        r"(?m)^\s+node-version:\s*(.*?)\s*$", step
-                    )
-                    self.assertEqual(node_versions, ["${{ env.NODE_VERSION }}"])
 
         contributing = _read("CONTRIBUTING.md")
         self.assertIn(f"CI pins Node `{version}` exactly", contributing)
@@ -1473,13 +1516,26 @@ class TestCoverageGateCommandIdentity(unittest.TestCase):
         self.assertEqual(set(flags), set(scope["includes"]))
 
     def test_contributing_documents_the_ci_node_version_pin(self):
-        version = _ci_workflow_tests_node_version(_read(".github/workflows/ci.yml"))
+        text = _read(".github/workflows/ci.yml")
+        version = _ci_workflow_tests_node_version(text)
         contributing = _read("CONTRIBUTING.md")
         self.assertIn(f"`{version}`", contributing)
-        self.assertIn(
-            "node-version: ${{ env.NODE_VERSION }}",
-            _read(".github/workflows/ci.yml"),
-        )
+        setup_steps = _ci_setup_node_steps(text)
+        self.assertTrue(setup_steps)
+        uses = []
+        for job_id, index, step in setup_steps:
+            with self.subTest(setup_node=(job_id, index)):
+                pinned = re.search(
+                    r"(?m)^\s+uses:\s*actions/setup-node@([0-9a-f]{40})\s+#\s+v\S+$",
+                    step,
+                )
+                self.assertIsNotNone(pinned)
+                uses.append(pinned.group(1))
+                self.assertEqual(
+                    re.findall(r"(?m)^\s+node-version:\s*(.*?)\s*$", step),
+                    ["${{ env.NODE_VERSION }}"],
+                )
+        self.assertEqual(len(set(uses)), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_contribution_surface.py
+++ b/tests/test_contribution_surface.py
@@ -25,11 +25,14 @@ would make a test vacuously pass.
 import json
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
 from pathlib import Path
+
+from scripts import generate_contract_requirements as contract_gen
 
 REPO = Path(__file__).resolve().parents[1]
 FORMS = REPO / ".github" / "ISSUE_TEMPLATE"
@@ -111,6 +114,34 @@ RESERVED_OPTIONS = {"none", "true", "false", "yes", "no", "on", "off"}
 
 def _read(path):
     return (REPO / path).read_text(encoding="utf-8")
+
+
+def _pre_commit_hook_span(text, hook_id):
+    """Return the unique local hook's character span, failing closed on drift."""
+    marker = re.compile(rf"(?m)^      - id: {re.escape(hook_id)}\s*$")
+    matches = list(marker.finditer(text))
+    if len(matches) != 1:
+        raise AssertionError(
+            f"expected exactly one {hook_id} hook block, found {len(matches)}"
+        )
+    start = matches[0].start()
+    following = re.search(r"(?m)^      - id: [^\n]+$", text[matches[0].end() :])
+    end = matches[0].end() + following.start() if following else len(text)
+    return start, end
+
+
+def _pre_commit_hook_block(text, hook_id):
+    start, end = _pre_commit_hook_span(text, hook_id)
+    return text[start:end]
+
+
+def _pre_commit_hook_value(block, key):
+    matches = re.findall(rf"(?m)^        {re.escape(key)}:\s*(.*?)\s*$", block)
+    if len(matches) != 1:
+        raise AssertionError(
+            f"expected exactly one {key}: key in hook block, found {len(matches)}"
+        )
+    return _unquote(matches[0])
 
 
 def _unquote(value):
@@ -1196,6 +1227,67 @@ def _ci_run_blocks(text: str) -> list[str]:
     return blocks
 
 
+def _ci_job_blocks(text: str) -> list[tuple[str, str]]:
+    """Job bodies from ci.yml, using the file's fixed two-space job indentation."""
+    lines = text.splitlines()
+    jobs_index = next(
+        (index for index, line in enumerate(lines) if line == "jobs:"), None
+    )
+    if jobs_index is None:
+        raise AssertionError("ci.yml is missing jobs:")
+    starts = []
+    for index in range(jobs_index + 1, len(lines)):
+        line = lines[index]
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+        match = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+        if match:
+            starts.append((index, match.group(1)))
+    jobs = []
+    for position, (start, job_id) in enumerate(starts):
+        end = starts[position + 1][0] if position + 1 < len(starts) else len(lines)
+        jobs.append((job_id, "\n".join(lines[start:end])))
+    return jobs
+
+
+def _ci_step_blocks(job: str) -> list[str]:
+    """Step bodies from one ci.yml job."""
+    lines = job.splitlines()
+    starts = [index for index, line in enumerate(lines) if re.match(r"^      - ", line)]
+    return [
+        "\n".join(
+            lines[
+                start : starts[position + 1]
+                if position + 1 < len(starts)
+                else len(lines)
+            ]
+        )
+        for position, start in enumerate(starts)
+    ]
+
+
+def _ci_step_run_bodies(step: str) -> list[str]:
+    """Inline and block-scalar run bodies from one step."""
+    inline = re.findall(r"(?m)^\s+run:\s+(?!\|-?$)(.+?)\s*$", step)
+    return inline + _ci_run_blocks(step)
+
+
+def _copy_tracked_tree(destination: Path) -> None:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO,
+        check=True,
+        capture_output=True,
+    )
+    for relative in result.stdout.decode().split("\0"):
+        if not relative:
+            continue
+        source = REPO / relative
+        target = destination / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+
+
 def _ci_gate_commands(text: str) -> set[str]:
     return {
         b for b in _ci_run_blocks(text) if any(marker in b for marker in GATE_MARKERS)
@@ -1203,21 +1295,167 @@ def _ci_gate_commands(text: str) -> set[str]:
 
 
 def _ci_workflow_tests_node_version(text: str) -> str:
-    """The node-version: value under the workflow-tests job (stdlib; no PyYAML)."""
-    lines = text.splitlines()
-    in_job = False
-    for line in lines:
-        if re.match(r"^  workflow-tests:\s*$", line):
-            in_job = True
-            continue
-        if in_job and re.match(r"^  \S", line):
-            break
-        if not in_job:
-            continue
-        match = re.match(r'^\s+node-version:\s*["\']?([^"\']+)["\']?\s*$', line)
-        if match:
-            return match.group(1).strip()
-    raise AssertionError("ci.yml workflow-tests job missing node-version:")
+    """The workflow-level Node version used by ci.yml."""
+    matches = re.findall(
+        r'(?m)^env:\n  NODE_VERSION:\s*["\']?([^"\'\s]+)["\']?\s*$', text
+    )
+    if len(matches) != 1:
+        raise AssertionError(
+            f"ci.yml must declare exactly one workflow NODE_VERSION, found {len(matches)}"
+        )
+    return str(matches[0])
+
+
+class TestContractFenceHook(unittest.TestCase):
+    def test_contract_fence_hook_is_scoped_and_covers_derived_inputs(self):
+        text = _read(".pre-commit-config.yaml")
+        contract_start, _ = _pre_commit_hook_span(text, "contract-fences-current")
+        agent_start, _ = _pre_commit_hook_span(text, "agent-instruction-layout")
+        self.assertGreater(contract_start, agent_start)
+
+        block = _pre_commit_hook_block(text, "contract-fences-current")
+        self.assertEqual(
+            _pre_commit_hook_value(block, "entry"),
+            "python3 scripts/generate_contract_requirements.py --check",
+        )
+        self.assertEqual(_pre_commit_hook_value(block, "pass_filenames"), "false")
+        self.assertEqual(_pre_commit_hook_value(block, "language"), "system")
+        self.assertNotRegex(block, r"(?m)^\s+always_run:")
+        stage_values = re.findall(r"(?m)^        stages:\s*(.*?)\s*$", block)
+        if stage_values:
+            stages = _unquote(stage_values[0])
+            self.assertRegex(stages, r"\[\s*pre-commit(?:\s*,|\s*\])")
+        files_pattern = _pre_commit_hook_value(block, "files")
+        self.assertEqual(
+            files_pattern, "^(agents|skills/code-gauntlet|scripts|workflows)/"
+        )
+        scope = re.compile(files_pattern)
+
+        paths = set(contract_gen.compute_targets(str(REPO)))
+        paths.update(contract_gen.declared_inputs(str(REPO)))
+        for path in sorted(paths):
+            with self.subTest(path=path):
+                self.assertIsNotNone(scope.match(path), path)
+
+    def test_contract_fence_hook_rejects_stale_fence_without_writing(self):
+        config = _read(".pre-commit-config.yaml")
+        block = _pre_commit_hook_block(config, "contract-fences-current")
+        entry = shlex.split(_pre_commit_hook_value(block, "entry"))
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            _copy_tracked_tree(root)
+            target = root / "skills/code-gauntlet/references/phase1-preflight.md"
+            clean_result = subprocess.run(
+                entry,
+                cwd=root,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(
+                clean_result.returncode,
+                0,
+                clean_result.stdout + clean_result.stderr,
+            )
+
+            lines = target.read_text(encoding="utf-8").splitlines(keepends=True)
+            open_marker, close_marker = contract_gen.identity_marker_lines(
+                "derived_waist_fields",
+                "skills/code-gauntlet/references/phase1-preflight.md",
+            )
+            open_index = lines.index(open_marker + "\n")
+            close_index = lines.index(close_marker + "\n")
+            body_index = next(
+                index
+                for index in range(open_index + 1, close_index)
+                if lines[index].strip()
+            )
+            lines[body_index] = lines[body_index].rstrip("\n") + " stale\n"
+            corrupted = "".join(lines).encode()
+            target.write_bytes(corrupted)
+
+            stale_result = subprocess.run(
+                entry,
+                cwd=root,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(stale_result.returncode, 1)
+            self.assertIn(
+                "skills/code-gauntlet/references/phase1-preflight.md",
+                stale_result.stderr,
+            )
+            self.assertEqual(target.read_bytes(), corrupted)
+
+
+class TestCiNodePin(unittest.TestCase):
+    def test_node_is_pinned_before_every_relevant_ci_job(self):
+        text = _read(".github/workflows/ci.yml")
+        version = _ci_workflow_tests_node_version(text)
+        self.assertEqual(
+            re.findall(
+                r'(?m)^env:\n  NODE_VERSION:\s*["\']?([^"\'\s]+)["\']?\s*$',
+                text,
+            ),
+            [version],
+        )
+        setup_node_uses = re.findall(
+            r"(?m)^\s+uses:\s*actions/setup-node@([0-9a-f]{40})\s+#\s+v\S+$",
+            text,
+        )
+        self.assertTrue(setup_node_uses)
+        self.assertEqual(len(set(setup_node_uses)), 1)
+        self.assertEqual(text.count("actions/setup-node@"), len(setup_node_uses))
+
+        bare_node = re.compile(r"(?<![A-Za-z0-9_-])node ")
+        consumer_markers = ("pre-commit run", "python -m pytest tests/")
+        for job_id, job in _ci_job_blocks(text):
+            steps = _ci_step_blocks(job)
+            consumer_indexes = [
+                index
+                for index, step in enumerate(steps)
+                if any(
+                    marker in body or bare_node.search(body)
+                    for body in _ci_step_run_bodies(step)
+                    for marker in consumer_markers
+                )
+            ]
+            if not consumer_indexes:
+                continue
+            setup_indexes = [
+                index
+                for index, step in enumerate(steps)
+                if "actions/setup-node@" in step
+            ]
+            with self.subTest(job=job_id):
+                self.assertTrue(setup_indexes)
+                self.assertLess(min(setup_indexes), min(consumer_indexes))
+                for index in setup_indexes:
+                    step = steps[index]
+                    uses = re.search(
+                        r"(?m)^\s+uses:\s*actions/setup-node@([0-9a-f]{40})\s+#\s+v\S+$",
+                        step,
+                    )
+                    self.assertIsNotNone(uses)
+                    self.assertEqual(uses.group(1), setup_node_uses[0])
+                    node_versions = re.findall(
+                        r"(?m)^\s+node-version:\s*(.*?)\s*$", step
+                    )
+                    self.assertEqual(node_versions, ["${{ env.NODE_VERSION }}"])
+
+        contributing = _read("CONTRIBUTING.md")
+        self.assertIn(f"CI pins Node `{version}` exactly", contributing)
+
+    def test_getting_started_declares_the_node_prerequisite_for_the_hook(self):
+        text = _read("CONTRIBUTING.md")
+        section = text.split("## Getting Started\n", 1)[1].split("\n## ", 1)[0]
+        version = _ci_workflow_tests_node_version(_read(".github/workflows/ci.yml"))
+        sentences = re.findall(r"(?m)^.*contract-fences-current.*\.$", section)
+        self.assertEqual(len(sentences), 1)
+        self.assertIn(f"Node `{version}`", sentences[0])
+        self.assertLess(
+            section.index(sentences[0]), section.index("pre-commit install")
+        )
 
 
 class TestCoverageGateCommandIdentity(unittest.TestCase):
@@ -1238,7 +1476,10 @@ class TestCoverageGateCommandIdentity(unittest.TestCase):
         version = _ci_workflow_tests_node_version(_read(".github/workflows/ci.yml"))
         contributing = _read("CONTRIBUTING.md")
         self.assertIn(f"`{version}`", contributing)
-        self.assertIn(f'node-version: "{version}"', _read(".github/workflows/ci.yml"))
+        self.assertIn(
+            "node-version: ${{ env.NODE_VERSION }}",
+            _read(".github/workflows/ci.yml"),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_contribution_surface.py
+++ b/tests/test_contribution_surface.py
@@ -1378,10 +1378,28 @@ class TestContractFenceHook(unittest.TestCase):
             }.issubset(declared_inputs),
             declared_inputs,
         )
+        self.assertTrue(
+            {
+                "workflows/src/registry.js",
+                "workflows/src/args.js",
+                "workflows/src/renderReport.js",
+            }.issubset(declared_inputs),
+            declared_inputs,
+        )
+        self.assertTrue(
+            {
+                "workflows/src/filterFindings.js",
+                "workflows/src/applyChallenges.js",
+                "workflows/src/applyValidations.js",
+            }.issubset(declared_inputs),
+            declared_inputs,
+        )
         paths = set(contract_gen.compute_targets(str(REPO)))
         paths.update(declared_inputs)
         for path in sorted(paths):
             with self.subTest(path=path):
+                if path in declared_inputs:
+                    self.assertTrue((REPO / path).is_file(), path)
                 self.assertIsNotNone(scope.match(path), path)
 
     def test_contract_fence_hook_rejects_stale_fence_without_writing(self):

--- a/tests/test_generate_contract_requirements.py
+++ b/tests/test_generate_contract_requirements.py
@@ -69,6 +69,17 @@ class TestNodeDiagnostic(unittest.TestCase):
             r"node --input-type=module -e .+\n$",
         )
 
+    def test_failed_node_reports_the_child_stderr_tail(self):
+        node_src = (
+            "process.on('uncaughtException', error => { console.error(error.message); "
+            "process.exit(1); }); throw new Error('forced JS failure')"
+        )
+        with self.assertRaises(SystemExit) as raised:
+            gen._run_node(node_src, str(REPO))
+        message = str(raised.exception)
+        self.assertTrue(message.endswith(": forced JS failure"), message)
+        self.assertEqual(message.count("\n"), 0)
+
 
 class TestConditionalParagraphs(unittest.TestCase):
     def setUp(self):

--- a/tests/test_generate_contract_requirements.py
+++ b/tests/test_generate_contract_requirements.py
@@ -5,6 +5,7 @@ dicts and small file fragments, so a regression in the splice/table-rewrite/sent
 logic fails here without needing `node` or the real agent files.
 """
 
+import os
 import re
 import shutil
 import subprocess
@@ -41,6 +42,32 @@ class TestDispatchRequiredSentence(unittest.TestCase):
         self.assertIn("all must always be present", sentence)
         self.assertNotIn("either", sentence)
         self.assertNotIn("both", sentence)
+
+
+class TestNodeDiagnostic(unittest.TestCase):
+    def test_missing_node_reports_one_actionable_line(self):
+        with tempfile.TemporaryDirectory() as empty_path:
+            env = os.environ.copy()
+            env["PATH"] = empty_path
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "scripts" / "generate_contract_requirements.py"),
+                    "--check",
+                ],
+                cwd=REPO,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr.count("\n"), 1, result.stderr)
+        self.assertRegex(
+            result.stderr,
+            r"^generate_contract_requirements: node 24 command failed: "
+            r"node --input-type=module -e .+\n$",
+        )
 
 
 class TestConditionalParagraphs(unittest.TestCase):


### PR DESCRIPTION
This PR adds a scoped local pre-commit hook that checks generated contract fences at commit time. `tests/test_dimensions_registry.py` already makes `--check` an unskippable CI gate. The hook adds local feedback for registry and Markdown fence edits missed by the pre-push pytest hook. It also adds a one-line node diagnostic to the generator, derived input coverage, one CI node pin, and the contributor prerequisite.

Closes #317

## Mechanism

- `.pre-commit-config.yaml`: Adds `contract-fences-current` after `agent-instruction-layout`, scoped to owning roots.
- `scripts/generate_contract_requirements.py`: Routes both Node executions through `_run_node`, which turns a missing node into a one-line exit 1 and appends a bounded stderr tail when the child fails. `declared_inputs()` derives the generator's Python import closure from its source and the JavaScript relative-import closure from the three node program roots, so no input list is hand-typed.
- `.github/workflows/ci.yml`: Defines `NODE_VERSION` once and sets up Node before relevant consumers.
- `CONTRIBUTING.md`: Documents Node `24.18.0` before the pre-commit installation step.

## Decisions of record

- H1 uses owning roots because targets and inputs are derived from the generator.
- H1 omits `always_run` so README-only commits do not require Node.
- H2 uses one helper for both Node programs and reports the failed command.
- H3 derives inputs so new inputs outside the hook scope fail the test; hand-typed anchors (post_review.py, review_marker.py, the three JS roots, three relative-import-only modules) keep a scanner that returns nothing from passing.
- H3 fails closed on missing or duplicate hook blocks.
- H4 runs the parsed hook in a copied tree and checks stale output without writes.
- H5 hoists Node `24.18.0` to a workflow-level `env.NODE_VERSION`; every setup-node step reads it and shares one action SHA.
- H6 derives the node-needing jobs from their run bodies and requires a setup-node step before each consumer, reading `${{ env.NODE_VERSION }}` literally (a literal version on any step goes red).
- H7 places the Node prerequisite inside Getting Started before `pre-commit install`.
- `validateArgs` and generated fence bodies remain out of scope.

## Tests

- `TestContractFenceHook`: goes red when the hook is deleted, the enclosing repo is not `local`, the name changes, `agents` is dropped from the scope, `--check` is removed, or `declared_inputs()` loses either its Python or its JavaScript closure.
- Hook execution test: goes red when `--check` is removed because write mode returns zero and rewrites the fence.
- `TestCiNodePin`: goes red when setup-node is deleted, moved below its consumer, or its pin diverges.
- Getting Started documentation test: goes red when the Node prerequisite sentence is removed.
- `TestNodeDiagnostic`: goes red when `_run_node` is removed or the stderr tail is dropped.

## Gates

- `python -m pytest tests/ -q` - `2146 passed, 1635 subtests passed in 30.23s` (final commit)
- `python -m pytest bench/tests/ -q` - `645 passed, 106 subtests passed in 21.64s`
- `python3 scripts/generate_contract_requirements.py --check` - `generated registry blocks are current`
- `python3 -m unittest tests.test_agent_instruction_layout` - `OK`
- PATH fallback `pre-commit run --all-files` - `mypy ... Passed`
- Hook proof - stale fence: `stale generated registry blocks: skills/code-gauntlet/SKILL.md`; restored: `...Passed`; README-only: `...Skipped` with exit 0

## Review record

Three luna review rounds (mutation ledger and spec conformance lenses in detached worktrees): round 1 found three majors in the tests (a literal node pin stayed green, a hand-typed input list could drift, `repo: local` and the hook name were unasserted) and one minor (no stderr tail); round 2 found one major (the JavaScript half of the input closure was unanchored); round 3 passed both lenses with 10 and 6 mutations red. CI is green on every commit.

## Adjacent

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrPvPqRF4KPVvodPKdVuYr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes affect developer hooks, CI Node setup, and the contract generator’s diagnostics—not runtime review pipeline behavior for shipped plugin users.
> 
> **Overview**
> Adds a **local pre-commit hook** (`contract-fences-current`) that runs `scripts/generate_contract_requirements.py --check` when files under `agents/`, `skills/code-gauntlet/`, `scripts/`, or `workflows/` change, so stale registry-derived fences fail at commit time instead of only in CI.
> 
> The generator now routes Node invocations through **`_run_node`** (single-line errors when Node is missing or the child fails) and exposes **`declared_inputs()`** so tests can assert the hook’s file scope covers the full Python/JS input closure without hand-maintained lists.
> 
> **CI** hoists Node **`24.18.0`** to `env.NODE_VERSION`, wires **`setup-node`** into lint and test jobs before pre-commit/pytest, and makes every setup step use `${{ env.NODE_VERSION }}`. **CONTRIBUTING** documents the Node prerequisite before `pre-commit install`.
> 
> New tests lock hook metadata, stale-fence behavior (check mode, no writes), and CI Node pin ordering/documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38fbe01f94ec6bfe83b3c8ddc72b3b8a1d865db0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->