### PR TITLE
feat(args): registry-driven waist lockstep and scopeAnswer presence rule (#315, #316)

### DIFF
--- a/scripts/generate_contract_requirements.py
+++ b/scripts/generate_contract_requirements.py
@@ -835,7 +835,7 @@ def _derived_waist_body(identity):
     if waist_rows:
         lines.extend(
             [
-                "The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; the receipt is its only source.",
+                "The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; when a listed derivation applies, a stamped value that disagrees with its receipt is refused before dispatch.",
                 "",
             ]
         )

--- a/skills/code-gauntlet/SKILL.md
+++ b/skills/code-gauntlet/SKILL.md
@@ -336,7 +336,7 @@ Read `CLAUDE_CODE_SUBAGENT_MODEL` from the environment into `policy.subagentMode
 
 Copy `configResult.waist.configEcho` verbatim.
 <!-- generated-from-registry-identity:derived_waist_fields — do not edit; run scripts/generate_contract_requirements.py -->
-The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; the receipt is its only source.
+The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; when a listed derivation applies, a stamped value that disagrees with its receipt is refused before dispatch.
 
 - `limits.deliveryCap` (headless and interactive runs): from `configEcho.pr_comment_cap`; digits derive as a JSON number; on interactive runs the receipt spelling `null` derives as JSON `null`. Stamp `limits` and leave `deliveryCap` out of it.
 - `delivery.tier` (headless and interactive runs): from `configEcho.delivery_tier`. Leave `tier` out of any stamped `delivery`.
@@ -518,10 +518,10 @@ Invoke the workflow in **one** `Workflow` tool call. This single call runs the e
 
 No pre-dispatch scope check is needed here: `deriveAgentFlags` (`workflows/src/args.js` /
 `workflows/src/stages.js`) computes the dimension flags from `riskTable`/`changedLines`/
-`scopeAnswer` inside the workflow itself, and `validateArgs` refuses an incoherent waist (a
-`scopeAnswer: "light"` the riskTable doesn't support, or a light-eligible waist with no
-`scopeAnswer`) before any agent is dispatched — there is no longer a second, prompt-level
-place the decision could silently drop.
+`scopeAnswer` inside the workflow itself, and `validateArgs` refuses a `scopeAnswer` on a
+riskTable/changedLines that is not light-eligible, a light-eligible waist with no
+`scopeAnswer`, or any derived waist field that disagrees with its receipt before any agent is
+dispatched — there is no longer a second, prompt-level place the decision could silently drop.
 
 ```
 Workflow(

--- a/skills/code-gauntlet/references/phase1-preflight.md
+++ b/skills/code-gauntlet/references/phase1-preflight.md
@@ -190,7 +190,7 @@ The resolver owns configuration values. The generated block below names the wais
 | Delivery destination | The resolver owns headless delivery methods. Interactive delivery remains the Phase 8 question after the report exists (`references/phase8-delivery.md` Stage 1). |
 
 <!-- generated-from-registry-identity:derived_waist_fields — do not edit; run scripts/generate_contract_requirements.py -->
-The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; the receipt is its only source.
+The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; when a listed derivation applies, a stamped value that disagrees with its receipt is refused before dispatch.
 
 - `limits.deliveryCap` (headless and interactive runs): from `configEcho.pr_comment_cap`; digits derive as a JSON number; on interactive runs the receipt spelling `null` derives as JSON `null`. Stamp `limits` and leave `deliveryCap` out of it.
 - `delivery.tier` (headless and interactive runs): from `configEcho.delivery_tier`. Leave `tier` out of any stamped `delivery`.

--- a/skills/code-gauntlet/references/phase2-triage.md
+++ b/skills/code-gauntlet/references/phase2-triage.md
@@ -371,7 +371,7 @@ Keep `reviewConfigPath: null` when REVIEW.md is absent; it records provenance.
 | `delivery` | For PR/MR targets, stamp only `{ prIdentity: { owner, repo, pr_number, sha_full, title? } }`. Omit it for local targets. |
 
 <!-- generated-from-registry-identity:derived_waist_fields — do not edit; run scripts/generate_contract_requirements.py -->
-The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; the receipt is its only source.
+The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; when a listed derivation applies, a stamped value that disagrees with its receipt is refused before dispatch.
 
 - `limits.deliveryCap` (headless and interactive runs): from `configEcho.pr_comment_cap`; digits derive as a JSON number; on interactive runs the receipt spelling `null` derives as JSON `null`. Stamp `limits` and leave `deliveryCap` out of it.
 - `delivery.tier` (headless and interactive runs): from `configEcho.delivery_tier`. Leave `tier` out of any stamped `delivery`.

--- a/skills/code-gauntlet/references/phase2-triage.md
+++ b/skills/code-gauntlet/references/phase2-triage.md
@@ -394,7 +394,7 @@ The Challenge stage applies the receipt-backed tier and cap before Phase 8 posts
 
 **Other inputs (optional unless noted):**
 
-- `scopeAnswer` — `"light"` or `"full"`, the 2e trivial-scope gate's answer, stamped ONLY when that gate actually asked (every changed file low-risk and `changedLines < 50`; see 2e). Omit otherwise — the workflow refuses a `scopeAnswer` incoherent with `riskTable`/`changedLines` (a `"light"` answer to a riskTable that wasn't light-eligible, or a light-eligible riskTable with no `scopeAnswer` at all).
+- `scopeAnswer` — `"light"` or `"full"`, the 2e trivial-scope gate's answer, stamped ONLY when that gate actually asked (every changed file low-risk and `changedLines < 50`; see 2e). Omit otherwise — the workflow refuses a `scopeAnswer` incoherent with `riskTable`/`changedLines` (any present `scopeAnswer` when the riskTable is not light-eligible, or a light-eligible riskTable with no `scopeAnswer` at all).
 - `contextLines` / `contextChars` — the shared context file's measured size, from the write step above. **Not provenance — consumed.** `contextReadPlan` turns them into the exact `Read` calls the Summarize/Discover/Validate prompts enumerate, so the agent is told which calls to make instead of having to notice an unannounced truncation. Both optional (absent ⇒ count-free read-to-end wording); `contextChars` requires `contextLines`; both must be positive integers.
 - `changedFilesPath` — `{output_dir}/code-gauntlet-files-{head_sha_short}.json`, the on-disk companion to `changedFiles`. Optional provenance only — the workflow has no disk access and never opens it.
 - `baseBranch` — the base branch name (verify/blame).

--- a/tests/test_generate_contract_requirements.py
+++ b/tests/test_generate_contract_requirements.py
@@ -701,7 +701,7 @@ class TestIdentityFenceGuards(unittest.TestCase):
             "skills/code-gauntlet/SKILL.md",
             "derived_waist_fields",
         ): (
-            "The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; the receipt is its only source.\n"
+            "The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; when a listed derivation applies, a stamped value that disagrees with its receipt is refused before dispatch.\n"
             "\n"
             "- `optional.beta` (headless runs): from `configEcho.beta`. Leave `beta` out of any stamped `optional`.\n"
             "- `nested.gamma` (headless and interactive runs, when the gamma condition holds): from `configEcho.gamma`; `raw` derives as `mapped`. Stamp `nested` and leave `gamma` out of it.\n"
@@ -717,7 +717,7 @@ class TestIdentityFenceGuards(unittest.TestCase):
             "skills/code-gauntlet/references/phase2-triage.md",
             "derived_waist_fields",
         ): (
-            "The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; the receipt is its only source.\n"
+            "The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; when a listed derivation applies, a stamped value that disagrees with its receipt is refused before dispatch.\n"
             "\n"
             "- `optional.beta` (headless runs): from `configEcho.beta`. Leave `beta` out of any stamped `optional`.\n"
             "- `nested.gamma` (headless and interactive runs, when the gamma condition holds): from `configEcho.gamma`; `raw` derives as `mapped`. Stamp `nested` and leave `gamma` out of it.\n"
@@ -733,7 +733,7 @@ class TestIdentityFenceGuards(unittest.TestCase):
             "skills/code-gauntlet/references/phase1-preflight.md",
             "derived_waist_fields",
         ): (
-            "The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; the receipt is its only source.\n"
+            "The workflow derives these waist fields from the copied `configEcho` receipt. Do not stamp a derived field; when a listed derivation applies, a stamped value that disagrees with its receipt is refused before dispatch.\n"
             "\n"
             "- `optional.beta` (headless runs): from `configEcho.beta`. Leave `beta` out of any stamped `optional`.\n"
             "- `nested.gamma` (headless and interactive runs, when the gamma condition holds): from `configEcho.gamma`; `raw` derives as `mapped`. Stamp `nested` and leave `gamma` out of it.\n"

--- a/tests/test_resolve_config.py
+++ b/tests/test_resolve_config.py
@@ -650,7 +650,7 @@ class TestGeneratedDataContracts(unittest.TestCase):
         }
         expected = {
             ("skills/code-gauntlet/SKILL.md", "limits.deliveryCap"): 2,
-            ("skills/code-gauntlet/SKILL.md", "scopeAnswer"): 7,
+            ("skills/code-gauntlet/SKILL.md", "scopeAnswer"): 6,
             (
                 "skills/code-gauntlet/references/delivery-guide.md",
                 "limits.deliveryCap",

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -2447,10 +2447,13 @@ function deriveWhenHolds(descriptor, args) {
   return descriptor.deriveWhen === null
     || (Object.hasOwn(DERIVE_WHEN, descriptor.deriveWhen) && DERIVE_WHEN[descriptor.deriveWhen].holds(args));
 }
-function deriveConfigWaist(args, derivedPaths = []) {
-  if (!isPlainObject(args) || !isPlainObject(args.configEcho) || typeof args.mode !== 'string') return args;
+function deriveConfigWaist(args) {
+  if (!isPlainObject(args) || !isPlainObject(args.configEcho) || typeof args.mode !== 'string') {
+    return { args, derivedPaths: [] };
+  }
   const out = { ...args };
   const configEcho = { ...args.configEcho };
+  const derivedPaths = [];
   let configEchoChanged = false;
   for (const descriptor of KNOB_REGISTRY) {
     if (!descriptor.modes.includes(args.mode)) continue;
@@ -2477,13 +2480,14 @@ function deriveConfigWaist(args, derivedPaths = []) {
     }
   }
   if (configEchoChanged) out.configEcho = configEcho;
-  return out;
+  return { args: out, derivedPaths };
 }
 function normalizeArgsReport(raw) {
   const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
   const report = stripNullOptionalsReport(parsed);
-  report.derivedPaths = [];
-  report.args = deriveConfigWaist(report.args, report.derivedPaths);
+  const { args, derivedPaths } = deriveConfigWaist(report.args);
+  report.args = args;
+  report.derivedPaths = derivedPaths;
   return report;
 }
 function normalizeArgs(raw) {
@@ -2998,14 +3002,16 @@ function validateArgs(args) {
     const capDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'pr_comment_cap');
     const capEntry = capDescriptor ? receiptEntryFor(args, capDescriptor) : null;
     if (isPlainObject(args.limits) && capEntry !== null) {
-      if (args.mode === 'headless' && typeof args.limits.deliveryCap !== 'number') {
-        const capShapeError = 'limits.deliveryCap must be null, absent, or a non-negative safe integer when present';
-        const shapeErrorIndex = errors.indexOf(capShapeError);
-        if (shapeErrorIndex !== -1) errors.splice(shapeErrorIndex, 1);
+      const capValue = args.limits.deliveryCap;
+      const capShapeInvalid = capValue !== undefined && capValue !== null
+        && (!Number.isSafeInteger(capValue) || capValue < 0);
+      if (capShapeInvalid) {
+        reported.add('limits.deliveryCap');
+      } else if (args.mode === 'headless' && (capValue === undefined || capValue === null)) {
         errors.push('headless limits.deliveryCap must be a number matching configEcho.pr_comment_cap');
         reported.add('limits.deliveryCap');
       } else if (args.mode === 'interactive'
-        && (args.limits.deliveryCap === null || args.limits.deliveryCap === undefined)
+        && (capValue === null || capValue === undefined)
         && capEntry.value !== 'null') {
         errors.push('configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null');
         reported.add('limits.deliveryCap');
@@ -3025,7 +3031,7 @@ function validateArgs(args) {
       const trivialEntry = trivialDescriptor ? receiptEntryFor(args, trivialDescriptor) : null;
       if (trivialEntry !== null && trivialEntry.value === 'light'
         && !computeLightEligible(args.riskTable, args.changedLines)) {
-        errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked; omit scopeAnswer`);
+        errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked`);
         reported.add('scopeAnswer');
       }
       const deliveryEcho = configEchoValue(args, 'delivery');

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -2308,10 +2308,13 @@ function nullToleranceGap(key) {
 function nullRespellGap(key) {
   return `null_receipt: args.${key} arrived as a literal null and was spelled as the printed token "null"; the receipt and the configuration are unchanged; stamp the string "null".`;
 }
-function nullToleranceRejectedKeys(cleanArgs, dropped) {
+function nullToleranceRejectedKeys(cleanArgs, dropped, derivedPaths = []) {
   if (!Array.isArray(dropped) || dropped.length === 0) return [];
+  const derived = new Set(Array.isArray(derivedPaths) ? derivedPaths : []);
   const baseline = validateArgs(cleanArgs).errors.length;
-  return dropped.filter((key) => validateArgs(withNullAt(cleanArgs, key)).errors.length > baseline);
+  return dropped
+    .filter((key) => !derived.has(key))
+    .filter((key) => validateArgs(withNullAt(cleanArgs, key)).errors.length > baseline);
 }
 function withNullAt(args, key) {
   const base = (args && typeof args === 'object' && !Array.isArray(args)) ? args : {};
@@ -2440,7 +2443,11 @@ const DERIVED_FROM = {
     describe: '`present` when `reviewConfigPath` is set, else `absent`',
   },
 };
-function deriveConfigWaist(args) {
+function deriveWhenHolds(descriptor, args) {
+  return descriptor.deriveWhen === null
+    || (Object.hasOwn(DERIVE_WHEN, descriptor.deriveWhen) && DERIVE_WHEN[descriptor.deriveWhen].holds(args));
+}
+function deriveConfigWaist(args, derivedPaths = []) {
   if (!isPlainObject(args) || !isPlainObject(args.configEcho) || typeof args.mode !== 'string') return args;
   const out = { ...args };
   const configEcho = { ...args.configEcho };
@@ -2463,11 +2470,11 @@ function deriveConfigWaist(args) {
     if (out[root] === undefined && REQUIRED.includes(root)) continue;
     const entry = receiptEntryFor(args, descriptor);
     if (!entry) continue;
-    if (descriptor.deriveWhen !== null
-      && (!Object.hasOwn(DERIVE_WHEN, descriptor.deriveWhen)
-        || !DERIVE_WHEN[descriptor.deriveWhen].holds(args))) continue;
+    if (!deriveWhenHolds(descriptor, args)) continue;
     const value = mappedReceiptValue(descriptor, entry.value);
-    if (value !== undefined) setDottedValue(out, descriptor.waistPath, value);
+    if (value !== undefined && setDottedValue(out, descriptor.waistPath, value)) {
+      derivedPaths.push(descriptor.waistPath);
+    }
   }
   if (configEchoChanged) out.configEcho = configEcho;
   return out;
@@ -2475,7 +2482,8 @@ function deriveConfigWaist(args) {
 function normalizeArgsReport(raw) {
   const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
   const report = stripNullOptionalsReport(parsed);
-  report.args = deriveConfigWaist(report.args);
+  report.derivedPaths = [];
+  report.args = deriveConfigWaist(report.args, report.derivedPaths);
   return report;
 }
 function normalizeArgs(raw) {
@@ -2712,11 +2720,12 @@ function validateArgs(args) {
   const scopeAnswerWellFormed = args.scopeAnswer === undefined || SCOPE_ANSWERS.includes(args.scopeAnswer);
   if (riskTableWellFormed && scopeAnswerWellFormed && typeof args.changedLines === 'number') {
     const lightEligible = computeLightEligible(args.riskTable, args.changedLines);
-    if (args.scopeAnswer === 'light' && !lightEligible) {
-      errors.push(`scopeAnswer is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked`);
-    }
-    if (lightEligible && args.scopeAnswer === undefined) {
-      errors.push('riskTable/changedLines are light-eligible but scopeAnswer is missing — the light/full gate must have asked, and its answer must be stamped as scopeAnswer');
+    if ((args.scopeAnswer !== undefined) !== lightEligible) {
+      if (args.scopeAnswer !== undefined) {
+        errors.push(`scopeAnswer is "${args.scopeAnswer}" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked; omit scopeAnswer`);
+      } else {
+        errors.push('riskTable/changedLines are light-eligible but scopeAnswer is missing — the light/full gate must have asked, and its answer must be stamped as scopeAnswer');
+      }
     }
   }
   if (args.policy && typeof args.policy === 'object' && !Array.isArray(args.policy)
@@ -2984,54 +2993,74 @@ function validateArgs(args) {
       }
     }
   }
-  const deliveryTierEcho = configEchoValue(args, 'delivery_tier');
-  if (deliveryTierEcho !== undefined && (args.delivery === undefined || args.delivery === null || isPlainObject(args.delivery))) {
-    const effectiveTier = isPlainObject(args.delivery) && args.delivery.tier != null ? args.delivery.tier : 'all';
-    if (deliveryTierEcho === 'all' || deliveryTierEcho === 'main_only') {
-      if (deliveryTierEcho !== effectiveTier) errors.push('configEcho.delivery_tier does not match delivery.tier');
-    }
-  }
-  const capEcho = configEchoValue(args, 'pr_comment_cap');
-  if (capEcho !== undefined && isPlainObject(args.limits)) {
+  const reported = new Set();
+  if (isPlainObject(args.configEcho)) {
     const capDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'pr_comment_cap');
-    const capValueWellFormed = capDescriptor && matchesRule(capDescriptor.rule, capEcho, args.mode);
-    if (!capValueWellFormed) {
-    } else if (args.mode === 'headless' && typeof args.limits.deliveryCap !== 'number') {
-      errors.push('headless limits.deliveryCap must be a number matching configEcho.pr_comment_cap');
-    } else if (typeof args.limits.deliveryCap === 'number' && capEcho !== String(args.limits.deliveryCap)) {
-      errors.push('configEcho.pr_comment_cap does not match limits.deliveryCap');
-    } else if (args.mode === 'interactive' && (args.limits.deliveryCap === null || args.limits.deliveryCap === undefined) && capEcho !== 'null') {
-      errors.push('configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null');
-    }
-  }
-  if (args.mode === 'headless') {
-    const reviewedPolicyEcho = configEchoValue(args, 'reviewed_policy');
-    const reviewedPolicyDescriptor = KNOB_REGISTRY.find(({ key }) => key === 'reviewed_policy');
-    if (isPriorReviewDetector(args) && isPlainObject(args.reviewScope)
-      && reviewedPolicyDescriptor && ['incremental', 'full', 'skip'].includes(reviewedPolicyEcho)) {
-      const requestedScope = mappedReceiptValue(reviewedPolicyDescriptor, reviewedPolicyEcho);
-      if (args.reviewScope.requested !== requestedScope) {
-        errors.push('reviewScope.requested does not match configEcho.reviewed_policy');
+    const capEntry = capDescriptor ? receiptEntryFor(args, capDescriptor) : null;
+    if (isPlainObject(args.limits) && capEntry !== null) {
+      if (args.mode === 'headless' && typeof args.limits.deliveryCap !== 'number') {
+        const capShapeError = 'limits.deliveryCap must be null, absent, or a non-negative safe integer when present';
+        const shapeErrorIndex = errors.indexOf(capShapeError);
+        if (shapeErrorIndex !== -1) errors.splice(shapeErrorIndex, 1);
+        errors.push('headless limits.deliveryCap must be a number matching configEcho.pr_comment_cap');
+        reported.add('limits.deliveryCap');
+      } else if (args.mode === 'interactive'
+        && (args.limits.deliveryCap === null || args.limits.deliveryCap === undefined)
+        && capEntry.value !== 'null') {
+        errors.push('configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null');
+        reported.add('limits.deliveryCap');
       }
     }
-    const trivialEcho = configEchoValue(args, 'trivial_scope');
-    if (trivialEcho === 'light' && !computeLightEligible(args.riskTable, args.changedLines)) {
-      errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked`);
+    const tierDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'delivery_tier');
+    const tierEntry = tierDescriptor ? receiptEntryFor(args, tierDescriptor) : null;
+    const stampedTier = dottedValue(args, 'delivery.tier');
+    if (tierEntry !== null
+      && (args.delivery === undefined || args.delivery === null || isPlainObject(args.delivery))
+      && (stampedTier === undefined || stampedTier === null)) {
+      reported.add('delivery.tier');
+      if (tierEntry.value !== 'all') errors.push('configEcho.delivery_tier does not match delivery.tier');
     }
-    if (args.scopeAnswer !== undefined && trivialEcho !== undefined && args.scopeAnswer !== trivialEcho) {
-      errors.push('scopeAnswer does not match configEcho.trivial_scope');
-    }
-    const deliveryEcho = configEchoValue(args, 'delivery');
-    if (deliveryEcho && deliveryEcho.split(',').includes('pr_comments')
-      && (!isPlainObject(args.delivery) || args.delivery.prIdentity === undefined || args.delivery.prIdentity === null)) {
-      errors.push('delivery.prIdentity is required when configEcho.delivery contains pr_comments');
+    if (args.mode === 'headless') {
+      const trivialDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'trivial_scope');
+      const trivialEntry = trivialDescriptor ? receiptEntryFor(args, trivialDescriptor) : null;
+      if (trivialEntry !== null && trivialEntry.value === 'light'
+        && !computeLightEligible(args.riskTable, args.changedLines)) {
+        errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked; omit scopeAnswer`);
+        reported.add('scopeAnswer');
+      }
+      const deliveryEcho = configEchoValue(args, 'delivery');
+      if (deliveryEcho && deliveryEcho.split(',').includes('pr_comments')
+        && (!isPlainObject(args.delivery) || args.delivery.prIdentity === undefined || args.delivery.prIdentity === null)) {
+        errors.push('delivery.prIdentity is required when configEcho.delivery contains pr_comments');
+      }
     }
   }
-  if (args.mode === 'interactive') {
-    const reviewMdEcho = configEchoValue(args, 'review_md');
-    if (['present', 'absent'].includes(reviewMdEcho)) {
-      const expectedReviewMd = args.reviewConfigPath != null ? 'present' : 'absent';
-      if (reviewMdEcho !== expectedReviewMd) errors.push('configEcho.review_md does not match reviewConfigPath');
+  if (isPlainObject(args.configEcho)) {
+    for (const descriptor of KNOB_REGISTRY) {
+      if (!descriptor.modes.includes(args.mode) || descriptor.waistPath === null) continue;
+      if (reported.has(descriptor.waistPath)) continue;
+      const entry = receiptEntryFor(args, descriptor);
+      if (entry === null) continue;
+      if (!deriveWhenHolds(descriptor, args)) continue;
+      const stamped = dottedValue(args, descriptor.waistPath);
+      if (stamped === undefined) continue;
+      const expected = mappedReceiptValue(descriptor, entry.value);
+      if (expected === undefined) continue;
+      const matches = descriptor.type === 'csv_list'
+        ? Array.isArray(stamped)
+          && stamped.length === expected.length
+          && stamped.every((value, index) => value === expected[index])
+        : stamped === expected;
+      if (!matches) errors.push(`${descriptor.waistPath} does not match configEcho.${descriptor.key}`);
+    }
+    for (const descriptor of KNOB_REGISTRY) {
+      if (!descriptor.modes.includes(args.mode)
+        || descriptor.derivedFrom === null
+        || !Object.hasOwn(DERIVED_FROM, descriptor.derivedFrom)) continue;
+      const entry = receiptEntryFor(args, descriptor);
+      if (entry !== null && entry.value !== DERIVED_FROM[descriptor.derivedFrom].fill(args)) {
+        errors.push(`configEcho.${descriptor.key} does not match ${descriptor.derivedFrom}`);
+      }
     }
   }
   return { ok: errors.length === 0, errors };
@@ -4942,9 +4971,14 @@ function compactMethodology(m) {
 async function runWith(ctx, rawArgs) {
   const entry = entryArgs(rawArgs);
   if (!entry.ok) return entry.envelope;
-  const { args: A, dropped: droppedNulls, respelled: respelledNulls } = normalizeArgsReport(entry.waist);
+  const {
+    args: A,
+    dropped: droppedNulls,
+    respelled: respelledNulls,
+    derivedPaths,
+  } = normalizeArgsReport(entry.waist);
   const nullArgGaps = [
-    ...nullToleranceRejectedKeys(A, droppedNulls).map(nullToleranceGap),
+    ...nullToleranceRejectedKeys(A, droppedNulls, derivedPaths).map(nullToleranceGap),
     ...respelledNulls.map(nullRespellGap),
   ];
   const check = validateArgs(A);

--- a/workflows/pipeline.js
+++ b/workflows/pipeline.js
@@ -2388,6 +2388,10 @@ function receiptEntryFor(args, descriptor) {
   if (!descriptor.allowedSources[mode] || !descriptor.allowedSources[mode].includes(entry.source)) return null;
   return entry;
 }
+function receiptEntryForKey(args, key) {
+  const descriptor = KNOB_REGISTRY.find((candidate) => candidate.key === key);
+  return descriptor ? receiptEntryFor(args, descriptor) : null;
+}
 function dottedValue(object, path) {
   let current = object;
   for (const part of path.split('.')) {
@@ -2999,8 +3003,7 @@ function validateArgs(args) {
   }
   const reported = new Set();
   if (isPlainObject(args.configEcho)) {
-    const capDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'pr_comment_cap');
-    const capEntry = capDescriptor ? receiptEntryFor(args, capDescriptor) : null;
+    const capEntry = receiptEntryForKey(args, 'pr_comment_cap');
     if (isPlainObject(args.limits) && capEntry !== null) {
       const capValue = args.limits.deliveryCap;
       const capShapeInvalid = capValue !== undefined && capValue !== null
@@ -3017,8 +3020,7 @@ function validateArgs(args) {
         reported.add('limits.deliveryCap');
       }
     }
-    const tierDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'delivery_tier');
-    const tierEntry = tierDescriptor ? receiptEntryFor(args, tierDescriptor) : null;
+    const tierEntry = receiptEntryForKey(args, 'delivery_tier');
     const stampedTier = dottedValue(args, 'delivery.tier');
     if (tierEntry !== null
       && (args.delivery === undefined || args.delivery === null || isPlainObject(args.delivery))
@@ -3027,8 +3029,7 @@ function validateArgs(args) {
       if (tierEntry.value !== 'all') errors.push('configEcho.delivery_tier does not match delivery.tier');
     }
     if (args.mode === 'headless') {
-      const trivialDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'trivial_scope');
-      const trivialEntry = trivialDescriptor ? receiptEntryFor(args, trivialDescriptor) : null;
+      const trivialEntry = receiptEntryForKey(args, 'trivial_scope');
       if (trivialEntry !== null && trivialEntry.value === 'light'
         && !computeLightEligible(args.riskTable, args.changedLines)) {
         errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked`);

--- a/workflows/src/args.js
+++ b/workflows/src/args.js
@@ -334,6 +334,11 @@ function receiptEntryFor(args, descriptor) {
   return entry;
 }
 
+function receiptEntryForKey(args, key) {
+  const descriptor = KNOB_REGISTRY.find((candidate) => candidate.key === key);
+  return descriptor ? receiptEntryFor(args, descriptor) : null;
+}
+
 function dottedValue(object, path) {
   let current = object;
   for (const part of path.split('.')) {
@@ -439,7 +444,8 @@ function deriveConfigWaist(args) {
 }
 
 // normalizeArgsReport(raw) -> { args, dropped, respelled, derivedPaths }
-// `derivedPaths` identifies dropped nulls whose fields were immediately re-derived.
+// `derivedPaths` identifies waist paths the receipt filled because they were absent after null-stripping,
+// whether originally missing or dropped as an explicit null.
 export function normalizeArgsReport(raw) {
   const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
   const report = stripNullOptionalsReport(parsed);
@@ -1278,8 +1284,7 @@ export function validateArgs(args) {
   // refusals from also producing the generic waist-path mismatch below.
   const reported = new Set();
   if (isPlainObject(args.configEcho)) {
-    const capDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'pr_comment_cap');
-    const capEntry = capDescriptor ? receiptEntryFor(args, capDescriptor) : null;
+    const capEntry = receiptEntryForKey(args, 'pr_comment_cap');
     if (isPlainObject(args.limits) && capEntry !== null) {
       const capValue = args.limits.deliveryCap;
       const capShapeInvalid = capValue !== undefined && capValue !== null
@@ -1297,8 +1302,7 @@ export function validateArgs(args) {
       }
     }
 
-    const tierDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'delivery_tier');
-    const tierEntry = tierDescriptor ? receiptEntryFor(args, tierDescriptor) : null;
+    const tierEntry = receiptEntryForKey(args, 'delivery_tier');
     const stampedTier = dottedValue(args, 'delivery.tier');
     if (tierEntry !== null
       && (args.delivery === undefined || args.delivery === null || isPlainObject(args.delivery))
@@ -1308,8 +1312,7 @@ export function validateArgs(args) {
     }
 
     if (args.mode === 'headless') {
-      const trivialDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'trivial_scope');
-      const trivialEntry = trivialDescriptor ? receiptEntryFor(args, trivialDescriptor) : null;
+      const trivialEntry = receiptEntryForKey(args, 'trivial_scope');
       if (trivialEntry !== null && trivialEntry.value === 'light'
         && !computeLightEligible(args.riskTable, args.changedLines)) {
         errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked`);

--- a/workflows/src/args.js
+++ b/workflows/src/args.js
@@ -402,10 +402,13 @@ function deriveWhenHolds(descriptor, args) {
     || (Object.hasOwn(DERIVE_WHEN, descriptor.deriveWhen) && DERIVE_WHEN[descriptor.deriveWhen].holds(args));
 }
 
-function deriveConfigWaist(args, derivedPaths = []) {
-  if (!isPlainObject(args) || !isPlainObject(args.configEcho) || typeof args.mode !== 'string') return args;
+function deriveConfigWaist(args) {
+  if (!isPlainObject(args) || !isPlainObject(args.configEcho) || typeof args.mode !== 'string') {
+    return { args, derivedPaths: [] };
+  }
   const out = { ...args };
   const configEcho = { ...args.configEcho };
+  const derivedPaths = [];
   let configEchoChanged = false;
   for (const descriptor of KNOB_REGISTRY) {
     if (!descriptor.modes.includes(args.mode)) continue;
@@ -432,7 +435,7 @@ function deriveConfigWaist(args, derivedPaths = []) {
     }
   }
   if (configEchoChanged) out.configEcho = configEcho;
-  return out;
+  return { args: out, derivedPaths };
 }
 
 // normalizeArgsReport(raw) -> { args, dropped, respelled, derivedPaths }
@@ -440,8 +443,9 @@ function deriveConfigWaist(args, derivedPaths = []) {
 export function normalizeArgsReport(raw) {
   const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
   const report = stripNullOptionalsReport(parsed);
-  report.derivedPaths = [];
-  report.args = deriveConfigWaist(report.args, report.derivedPaths);
+  const { args, derivedPaths } = deriveConfigWaist(report.args);
+  report.args = args;
+  report.derivedPaths = derivedPaths;
   return report;
 }
 
@@ -1277,14 +1281,16 @@ export function validateArgs(args) {
     const capDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'pr_comment_cap');
     const capEntry = capDescriptor ? receiptEntryFor(args, capDescriptor) : null;
     if (isPlainObject(args.limits) && capEntry !== null) {
-      if (args.mode === 'headless' && typeof args.limits.deliveryCap !== 'number') {
-        const capShapeError = 'limits.deliveryCap must be null, absent, or a non-negative safe integer when present';
-        const shapeErrorIndex = errors.indexOf(capShapeError);
-        if (shapeErrorIndex !== -1) errors.splice(shapeErrorIndex, 1);
+      const capValue = args.limits.deliveryCap;
+      const capShapeInvalid = capValue !== undefined && capValue !== null
+        && (!Number.isSafeInteger(capValue) || capValue < 0);
+      if (capShapeInvalid) {
+        reported.add('limits.deliveryCap');
+      } else if (args.mode === 'headless' && (capValue === undefined || capValue === null)) {
         errors.push('headless limits.deliveryCap must be a number matching configEcho.pr_comment_cap');
         reported.add('limits.deliveryCap');
       } else if (args.mode === 'interactive'
-        && (args.limits.deliveryCap === null || args.limits.deliveryCap === undefined)
+        && (capValue === null || capValue === undefined)
         && capEntry.value !== 'null') {
         errors.push('configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null');
         reported.add('limits.deliveryCap');
@@ -1306,7 +1312,7 @@ export function validateArgs(args) {
       const trivialEntry = trivialDescriptor ? receiptEntryFor(args, trivialDescriptor) : null;
       if (trivialEntry !== null && trivialEntry.value === 'light'
         && !computeLightEligible(args.riskTable, args.changedLines)) {
-        errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked; omit scopeAnswer`);
+        errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked`);
         reported.add('scopeAnswer');
       }
       const deliveryEcho = configEchoValue(args, 'delivery');

--- a/workflows/src/args.js
+++ b/workflows/src/args.js
@@ -217,9 +217,10 @@ export function nullRespellGap(key) {
   return `null_receipt: args.${key} arrived as a literal null and was spelled as the printed token "null"; the receipt and the configuration are unchanged; stamp the string "null".`;
 }
 
-// nullToleranceRejectedKeys(cleanArgs, dropped) -> the subset of `dropped` whose stamped null
-// validateArgs would ACTUALLY have rejected — i.e. the keys where the tolerance changed the
-// outcome and there is therefore something to disclose.
+// nullToleranceRejectedKeys(cleanArgs, dropped, derivedPaths) -> the subset of `dropped` whose
+// stamped null validateArgs would ACTUALLY have rejected — i.e. the keys where the tolerance
+// changed the outcome and there is therefore something to disclose. A dropped field that
+// normalizeArgs immediately re-derived is not a changed outcome and is filtered first.
 //
 // `checkpoints` is why this exists (issue #38 F4-3): validateArgs has never carried a
 // checkpoints shape check, so a stamped `checkpoints: null` was ALWAYS equivalent to absence.
@@ -231,10 +232,13 @@ export function nullRespellGap(key) {
 // stripped waist, vs the same waist with that null put back). A second hand-maintained list
 // would drift the moment someone adds or removes a shape check. Pure — validateArgs is pure,
 // and the probe objects are shallow copies, so the caller's waist is untouched.
-export function nullToleranceRejectedKeys(cleanArgs, dropped) {
+export function nullToleranceRejectedKeys(cleanArgs, dropped, derivedPaths = []) {
   if (!Array.isArray(dropped) || dropped.length === 0) return [];
+  const derived = new Set(Array.isArray(derivedPaths) ? derivedPaths : []);
   const baseline = validateArgs(cleanArgs).errors.length;
-  return dropped.filter((key) => validateArgs(withNullAt(cleanArgs, key)).errors.length > baseline);
+  return dropped
+    .filter((key) => !derived.has(key))
+    .filter((key) => validateArgs(withNullAt(cleanArgs, key)).errors.length > baseline);
 }
 
 // The stripped waist with ONE dropped null put back, addressed by the same full dotted
@@ -393,7 +397,12 @@ export const DERIVED_FROM = {
   },
 };
 
-function deriveConfigWaist(args) {
+function deriveWhenHolds(descriptor, args) {
+  return descriptor.deriveWhen === null
+    || (Object.hasOwn(DERIVE_WHEN, descriptor.deriveWhen) && DERIVE_WHEN[descriptor.deriveWhen].holds(args));
+}
+
+function deriveConfigWaist(args, derivedPaths = []) {
   if (!isPlainObject(args) || !isPlainObject(args.configEcho) || typeof args.mode !== 'string') return args;
   const out = { ...args };
   const configEcho = { ...args.configEcho };
@@ -416,20 +425,23 @@ function deriveConfigWaist(args) {
     if (out[root] === undefined && REQUIRED.includes(root)) continue;
     const entry = receiptEntryFor(args, descriptor);
     if (!entry) continue;
-    if (descriptor.deriveWhen !== null
-      && (!Object.hasOwn(DERIVE_WHEN, descriptor.deriveWhen)
-        || !DERIVE_WHEN[descriptor.deriveWhen].holds(args))) continue;
+    if (!deriveWhenHolds(descriptor, args)) continue;
     const value = mappedReceiptValue(descriptor, entry.value);
-    if (value !== undefined) setDottedValue(out, descriptor.waistPath, value);
+    if (value !== undefined && setDottedValue(out, descriptor.waistPath, value)) {
+      derivedPaths.push(descriptor.waistPath);
+    }
   }
   if (configEchoChanged) out.configEcho = configEcho;
   return out;
 }
 
+// normalizeArgsReport(raw) -> { args, dropped, respelled, derivedPaths }
+// `derivedPaths` identifies dropped nulls whose fields were immediately re-derived.
 export function normalizeArgsReport(raw) {
   const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
   const report = stripNullOptionalsReport(parsed);
-  report.args = deriveConfigWaist(report.args);
+  report.derivedPaths = [];
+  report.args = deriveConfigWaist(report.args, report.derivedPaths);
   return report;
 }
 
@@ -873,11 +885,12 @@ export function validateArgs(args) {
   const scopeAnswerWellFormed = args.scopeAnswer === undefined || SCOPE_ANSWERS.includes(args.scopeAnswer);
   if (riskTableWellFormed && scopeAnswerWellFormed && typeof args.changedLines === 'number') {
     const lightEligible = computeLightEligible(args.riskTable, args.changedLines);
-    if (args.scopeAnswer === 'light' && !lightEligible) {
-      errors.push(`scopeAnswer is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked`);
-    }
-    if (lightEligible && args.scopeAnswer === undefined) {
-      errors.push('riskTable/changedLines are light-eligible but scopeAnswer is missing — the light/full gate must have asked, and its answer must be stamped as scopeAnswer');
+    if ((args.scopeAnswer !== undefined) !== lightEligible) {
+      if (args.scopeAnswer !== undefined) {
+        errors.push(`scopeAnswer is "${args.scopeAnswer}" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked; omit scopeAnswer`);
+      } else {
+        errors.push('riskTable/changedLines are light-eligible but scopeAnswer is missing — the light/full gate must have asked, and its answer must be stamped as scopeAnswer');
+      }
     }
   }
   // policy.provider drives which arm of registry.js's model resolution runs (full-ID pin
@@ -1256,59 +1269,82 @@ export function validateArgs(args) {
     }
   }
 
-  // The receipt is a structured copy of the same resolved decisions that drive the stages.
-  // Compare only well-formed values so malformed fields produce their focused shape errors
-  // above rather than a cascade of misleading coherence errors.
-  const deliveryTierEcho = configEchoValue(args, 'delivery_tier');
-  if (deliveryTierEcho !== undefined && (args.delivery === undefined || args.delivery === null || isPlainObject(args.delivery))) {
-    const effectiveTier = isPlainObject(args.delivery) && args.delivery.tier != null ? args.delivery.tier : 'all';
-    if (deliveryTierEcho === 'all' || deliveryTierEcho === 'main_only') {
-      if (deliveryTierEcho !== effectiveTier) errors.push('configEcho.delivery_tier does not match delivery.tier');
-    }
-  }
-  const capEcho = configEchoValue(args, 'pr_comment_cap');
-  if (capEcho !== undefined && isPlainObject(args.limits)) {
+  // A few coherence rules are not row equality: they enforce presence or effective values
+  // that the generic registry pass intentionally skips. `reported` prevents those special
+  // refusals from also producing the generic waist-path mismatch below.
+  const reported = new Set();
+  if (isPlainObject(args.configEcho)) {
     const capDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'pr_comment_cap');
-    const capValueWellFormed = capDescriptor && matchesRule(capDescriptor.rule, capEcho, args.mode);
-    if (!capValueWellFormed) {
-      // The focused registry value error is sufficient for malformed receipt values;
-      // lockstep is only meaningful for a value that could represent a cap.
-    } else if (args.mode === 'headless' && typeof args.limits.deliveryCap !== 'number') {
-      errors.push('headless limits.deliveryCap must be a number matching configEcho.pr_comment_cap');
-    } else if (typeof args.limits.deliveryCap === 'number' && capEcho !== String(args.limits.deliveryCap)) {
-      errors.push('configEcho.pr_comment_cap does not match limits.deliveryCap');
-    } else if (args.mode === 'interactive' && (args.limits.deliveryCap === null || args.limits.deliveryCap === undefined) && capEcho !== 'null') {
-      errors.push('configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null');
-    }
-  }
-  if (args.mode === 'headless') {
-    const reviewedPolicyEcho = configEchoValue(args, 'reviewed_policy');
-    const reviewedPolicyDescriptor = KNOB_REGISTRY.find(({ key }) => key === 'reviewed_policy');
-    if (isPriorReviewDetector(args) && isPlainObject(args.reviewScope)
-      && reviewedPolicyDescriptor && ['incremental', 'full', 'skip'].includes(reviewedPolicyEcho)) {
-      const requestedScope = mappedReceiptValue(reviewedPolicyDescriptor, reviewedPolicyEcho);
-      if (args.reviewScope.requested !== requestedScope) {
-        errors.push('reviewScope.requested does not match configEcho.reviewed_policy');
+    const capEntry = capDescriptor ? receiptEntryFor(args, capDescriptor) : null;
+    if (isPlainObject(args.limits) && capEntry !== null) {
+      if (args.mode === 'headless' && typeof args.limits.deliveryCap !== 'number') {
+        const capShapeError = 'limits.deliveryCap must be null, absent, or a non-negative safe integer when present';
+        const shapeErrorIndex = errors.indexOf(capShapeError);
+        if (shapeErrorIndex !== -1) errors.splice(shapeErrorIndex, 1);
+        errors.push('headless limits.deliveryCap must be a number matching configEcho.pr_comment_cap');
+        reported.add('limits.deliveryCap');
+      } else if (args.mode === 'interactive'
+        && (args.limits.deliveryCap === null || args.limits.deliveryCap === undefined)
+        && capEntry.value !== 'null') {
+        errors.push('configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null');
+        reported.add('limits.deliveryCap');
       }
     }
-    const trivialEcho = configEchoValue(args, 'trivial_scope');
-    if (trivialEcho === 'light' && !computeLightEligible(args.riskTable, args.changedLines)) {
-      errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked`);
+
+    const tierDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'delivery_tier');
+    const tierEntry = tierDescriptor ? receiptEntryFor(args, tierDescriptor) : null;
+    const stampedTier = dottedValue(args, 'delivery.tier');
+    if (tierEntry !== null
+      && (args.delivery === undefined || args.delivery === null || isPlainObject(args.delivery))
+      && (stampedTier === undefined || stampedTier === null)) {
+      reported.add('delivery.tier');
+      if (tierEntry.value !== 'all') errors.push('configEcho.delivery_tier does not match delivery.tier');
     }
-    if (args.scopeAnswer !== undefined && trivialEcho !== undefined && args.scopeAnswer !== trivialEcho) {
-      errors.push('scopeAnswer does not match configEcho.trivial_scope');
-    }
-    const deliveryEcho = configEchoValue(args, 'delivery');
-    if (deliveryEcho && deliveryEcho.split(',').includes('pr_comments')
-      && (!isPlainObject(args.delivery) || args.delivery.prIdentity === undefined || args.delivery.prIdentity === null)) {
-      errors.push('delivery.prIdentity is required when configEcho.delivery contains pr_comments');
+
+    if (args.mode === 'headless') {
+      const trivialDescriptor = KNOB_REGISTRY.find((descriptor) => descriptor.key === 'trivial_scope');
+      const trivialEntry = trivialDescriptor ? receiptEntryFor(args, trivialDescriptor) : null;
+      if (trivialEntry !== null && trivialEntry.value === 'light'
+        && !computeLightEligible(args.riskTable, args.changedLines)) {
+        errors.push(`configEcho.trivial_scope is "light" but the riskTable/changedLines are not light-eligible (not every file is low risk, or changedLines >= ${LIGHT_SCOPE_MAX_CHANGED_LINES}) — the orchestrator answered a light/full question the gate never asked; omit scopeAnswer`);
+        reported.add('scopeAnswer');
+      }
+      const deliveryEcho = configEchoValue(args, 'delivery');
+      if (deliveryEcho && deliveryEcho.split(',').includes('pr_comments')
+        && (!isPlainObject(args.delivery) || args.delivery.prIdentity === undefined || args.delivery.prIdentity === null)) {
+        errors.push('delivery.prIdentity is required when configEcho.delivery contains pr_comments');
+      }
     }
   }
-  if (args.mode === 'interactive') {
-    const reviewMdEcho = configEchoValue(args, 'review_md');
-    if (['present', 'absent'].includes(reviewMdEcho)) {
-      const expectedReviewMd = args.reviewConfigPath != null ? 'present' : 'absent';
-      if (reviewMdEcho !== expectedReviewMd) errors.push('configEcho.review_md does not match reviewConfigPath');
+
+  // This is the registry-driven lockstep authority. Keep it after the retained special arms
+  // so a malformed receipt or a special absence rule produces only its focused refusal.
+  if (isPlainObject(args.configEcho)) {
+    for (const descriptor of KNOB_REGISTRY) {
+      if (!descriptor.modes.includes(args.mode) || descriptor.waistPath === null) continue;
+      if (reported.has(descriptor.waistPath)) continue;
+      const entry = receiptEntryFor(args, descriptor);
+      if (entry === null) continue;
+      if (!deriveWhenHolds(descriptor, args)) continue;
+      const stamped = dottedValue(args, descriptor.waistPath);
+      if (stamped === undefined) continue;
+      const expected = mappedReceiptValue(descriptor, entry.value);
+      if (expected === undefined) continue;
+      const matches = descriptor.type === 'csv_list'
+        ? Array.isArray(stamped)
+          && stamped.length === expected.length
+          && stamped.every((value, index) => value === expected[index])
+        : stamped === expected;
+      if (!matches) errors.push(`${descriptor.waistPath} does not match configEcho.${descriptor.key}`);
+    }
+    for (const descriptor of KNOB_REGISTRY) {
+      if (!descriptor.modes.includes(args.mode)
+        || descriptor.derivedFrom === null
+        || !Object.hasOwn(DERIVED_FROM, descriptor.derivedFrom)) continue;
+      const entry = receiptEntryFor(args, descriptor);
+      if (entry !== null && entry.value !== DERIVED_FROM[descriptor.derivedFrom].fill(args)) {
+        errors.push(`configEcho.${descriptor.key} does not match ${descriptor.derivedFrom}`);
+      }
     }
   }
   return { ok: errors.length === 0, errors };

--- a/workflows/src/stages.js
+++ b/workflows/src/stages.js
@@ -3839,9 +3839,14 @@ export async function runWith(ctx, rawArgs) {
   // Normalize from entry.waist, not rawArgs: entryArgs has already unwrapped every JSON
   // layer, and normalizeArgsReport peels exactly one — re-normalizing the raw value would
   // hand validateArgs a string for any waist encoded more than once.
-  const { args: A, dropped: droppedNulls, respelled: respelledNulls } = normalizeArgsReport(entry.waist);
+  const {
+    args: A,
+    dropped: droppedNulls,
+    respelled: respelledNulls,
+    derivedPaths,
+  } = normalizeArgsReport(entry.waist);
   const nullArgGaps = [
-    ...nullToleranceRejectedKeys(A, droppedNulls).map(nullToleranceGap),
+    ...nullToleranceRejectedKeys(A, droppedNulls, derivedPaths).map(nullToleranceGap),
     ...respelledNulls.map(nullRespellGap),
   ];
   const check = validateArgs(A);

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -877,8 +877,11 @@ test('T9: special cap arms report one fault and suppress the generic template', 
   const headless = headlessArgs();
   headless.limits = { ...headless.limits, deliveryCap: '1' };
   const headlessResult = validateArgs(headless);
-  assert.equal(headlessResult.errors.length, 1);
-  assert.equal(headlessResult.errors.some((error) => /does not match configEcho/.test(error)), false);
+  // Mutation: restore the every-non-number presence arm; a present string must keep its shape
+  // error rather than being rewritten as a receipt-presence error.
+  assert.deepEqual(headlessResult.errors, [
+    'limits.deliveryCap must be null, absent, or a non-negative safe integer when present',
+  ]);
 
   const interactive = { ...good, limits: { ...good.limits, deliveryCap: null }, configEcho: {
     ...good.configEcho, pr_comment_cap: { value: '5', source: 'default' },
@@ -964,7 +967,10 @@ test('T15: ineligible light receipt plus a present scopeAnswer uses the two dedi
   args.configEcho.trivial_scope = { value: 'light', source: 'default' };
   const result = validateArgs(args);
   assert.ok(result.errors.some((error) => error.startsWith('scopeAnswer is "full"')));
-  assert.ok(result.errors.some((error) => error.startsWith('configEcho.trivial_scope is "light"')));
+  const receiptError = result.errors.find((error) => error.startsWith('configEcho.trivial_scope is "light"'));
+  assert.ok(receiptError);
+  // Mutation: append the scopeAnswer fix to the receipt arm, which has no waist operand.
+  assert.doesNotMatch(receiptError, /omit scopeAnswer/);
   // Mutation: retain the deleted scopeAnswer equality arm; no generic equality is valid here.
   assert.equal(result.errors.some((error) => error.includes('scopeAnswer does not match configEcho')), false);
 });
@@ -1343,7 +1349,12 @@ test('T182-ARGS: headless deliveryCap must be numeric for the receipt', () => {
     if (label !== 'absent') limits.deliveryCap = deliveryCap;
     const result = validateArgs({ ...base, limits });
     assert.equal(result.ok, false, label);
-    assert.ok(result.errors.some((error) => error.includes('headless limits.deliveryCap must be a number')), `${label}: ${result.errors.join('; ')}`);
+    // Mutation: restore the every-non-number presence arm; the string case must retain only
+    // its focused shape error.
+    const expected = label === 'non-number'
+      ? 'limits.deliveryCap must be null, absent, or a non-negative safe integer when present'
+      : 'headless limits.deliveryCap must be a number matching configEcho.pr_comment_cap';
+    assert.deepEqual(result.errors, [expected], label);
   }
 });
 

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -714,7 +714,7 @@ test('T4: unknown deriveWhen names fail closed without throwing', () => {
   }
 });
 
-test('T1: a newly registered waist row is validated against its mapped receipt', () => {
+test('T315-ARGS: a newly registered waist row is validated against its mapped receipt', () => {
   const originalLength = KNOB_REGISTRY.length;
   try {
     KNOB_REGISTRY.push({
@@ -737,7 +737,7 @@ test('T1: a newly registered waist row is validated against its mapped receipt',
   }
 });
 
-test('T2: every real waist row and mode has one exact lockstep oracle pair', () => {
+test('T315-ARGS: every real waist row and mode has one exact lockstep oracle pair', () => {
   const cases = {
     'headless:limits.deliveryCap': {
       path: 'limits.deliveryCap', key: 'pr_comment_cap', receipt: '6',
@@ -793,7 +793,7 @@ test('T2: every real waist row and mode has one exact lockstep oracle pair', () 
   }
 });
 
-test('T3: derivedFrom rows reject a receipt that disagrees with their source', () => {
+test('T315-ARGS: derivedFrom rows reject a receipt that disagrees with their source', () => {
   const originalLength = KNOB_REGISTRY.length;
   try {
     KNOB_REGISTRY.push({
@@ -815,7 +815,7 @@ test('T3: derivedFrom rows reject a receipt that disagrees with their source', (
   }
 });
 
-test('T5: an unhandled registry type is accepted without a false lockstep violation', () => {
+test('T315-ARGS: an unhandled registry type is accepted without a false lockstep violation', () => {
   const originalLength = KNOB_REGISTRY.length;
   try {
     KNOB_REGISTRY.push({
@@ -834,7 +834,7 @@ test('T5: an unhandled registry type is accepted without a false lockstep violat
   }
 });
 
-test('T6: csv_list lockstep equality is ordered and element-wise', () => {
+test('T315-ARGS: csv_list lockstep equality is ordered and element-wise', () => {
   const originalLength = KNOB_REGISTRY.length;
   try {
     KNOB_REGISTRY.push({
@@ -856,7 +856,7 @@ test('T6: csv_list lockstep equality is ordered and element-wise', () => {
   }
 });
 
-test('T7: a stamped null is data and is compared by the generic pass', () => {
+test('T315-ARGS: a stamped null is data and is compared by the generic pass', () => {
   const originalLength = KNOB_REGISTRY.length;
   try {
     KNOB_REGISTRY.push({
@@ -875,7 +875,7 @@ test('T7: a stamped null is data and is compared by the generic pass', () => {
   }
 });
 
-test('T8: malformed receipts produce focused errors without lockstep cascades', () => {
+test('T315-ARGS: malformed receipts produce focused errors without lockstep cascades', () => {
   const cap = headlessArgs();
   cap.configEcho.pr_comment_cap = { value: '007', source: 'default' };
   cap.limits = { ...cap.limits, deliveryCap: 1 };
@@ -888,7 +888,7 @@ test('T8: malformed receipts produce focused errors without lockstep cascades', 
   assert.deepEqual(validateArgs(tier).errors, ['configEcho.delivery_tier.source is invalid for headless']);
 });
 
-test('T9: special cap arms report one fault and suppress the generic template', () => {
+test('T315-ARGS: special cap arms report one fault and suppress the generic template', () => {
   const headless = headlessArgs();
   headless.limits = { ...headless.limits, deliveryCap: '1' };
   const headlessResult = validateArgs(headless);
@@ -906,7 +906,7 @@ test('T9: special cap arms report one fault and suppress the generic template', 
   assert.deepEqual(interactiveResult.errors, ['configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null']);
 });
 
-test('T10: a mode twin is not lockstep-validated outside its declared modes', () => {
+test('T315-ARGS: a mode twin is not lockstep-validated outside its declared modes', () => {
   const originalLength = KNOB_REGISTRY.length;
   try {
     KNOB_REGISTRY.push({
@@ -927,7 +927,7 @@ test('T10: a mode twin is not lockstep-validated outside its declared modes', ()
   }
 });
 
-test('T11: missing or null configEcho stays a focused validation refusal', () => {
+test('T315-ARGS: missing or null configEcho stays a focused validation refusal', () => {
   for (const configEcho of [undefined, null]) {
     const args = { ...good };
     if (configEcho === undefined) delete args.configEcho;
@@ -938,7 +938,7 @@ test('T11: missing or null configEcho stays a focused validation refusal', () =>
   }
 });
 
-test('T12: any present scopeAnswer is refused when the light gate was ineligible', () => {
+test('T316-ARGS: any present scopeAnswer is refused when the light gate was ineligible', () => {
   // Mutation: revert the biconditional to the old light-only and missing-only checks.
   const interactive = validateArgs({ ...good, scopeAnswer: 'full' });
   assert.equal(interactive.errors.filter((error) => /scopeAnswer/.test(error)).length, 1);
@@ -952,7 +952,7 @@ test('T12: any present scopeAnswer is refused when the light gate was ineligible
   assert.match(result.errors.find((error) => /scopeAnswer is/.test(error)), /the orchestrator answered a light\/full question the gate never asked/);
 });
 
-test('T13: eligible scope accepts both values and a headless receipt derives either value', () => {
+test('T316-ARGS: eligible scope accepts both values and a headless receipt derives either value', () => {
   for (const scopeAnswer of ['light', 'full']) {
     // Mutation: implement the biconditional as scopeAnswer === "light" iff eligible.
     assert.deepEqual(validateArgs({ ...good, riskTable: [{ path: 'a.js', risk: 'low' }], changedLines: 10, scopeAnswer }), { ok: true, errors: [] });
@@ -965,7 +965,7 @@ test('T13: eligible scope accepts both values and a headless receipt derives eit
   assert.equal(derived.scopeAnswer, 'full');
 });
 
-test('T14: a headless caller-stamped scopeAnswer equal to the derived receipt stays accepted', () => {
+test('T316-ARGS: a headless caller-stamped scopeAnswer equal to the derived receipt stays accepted', () => {
   const args = headlessArgs();
   args.riskTable = [{ path: 'a.js', risk: 'low' }];
   args.changedLines = 10;
@@ -976,7 +976,7 @@ test('T14: a headless caller-stamped scopeAnswer equal to the derived receipt st
   assert.deepEqual(validateArgs(normalizeArgs(args)), { ok: true, errors: [] });
 });
 
-test('T15: ineligible light receipt plus a present scopeAnswer uses the two dedicated refusals', () => {
+test('T316-ARGS: ineligible light receipt plus a present scopeAnswer uses the two dedicated refusals', () => {
   const args = headlessArgs();
   args.riskTable = [{ path: 'a.js', risk: 'medium' }];
   args.scopeAnswer = 'full';
@@ -991,7 +991,7 @@ test('T15: ineligible light receipt plus a present scopeAnswer uses the two dedi
   assert.equal(result.errors.some((error) => error.includes('scopeAnswer does not match configEcho')), false);
 });
 
-test('T16: derived null scopeAnswer is disclosed as no gap after normalization', () => {
+test('T316-ARGS: derived null scopeAnswer is disclosed as no gap after normalization', () => {
   const input = headlessArgs();
   input.riskTable = [{ path: 'a.js', risk: 'low' }];
   input.changedLines = 10;
@@ -1004,7 +1004,7 @@ test('T16: derived null scopeAnswer is disclosed as no gap after normalization',
   assert.deepEqual(nullToleranceRejectedKeys(report.args, report.dropped, report.derivedPaths), []);
 });
 
-test('T18: direct special-arm fixtures isolate absence rules from generic equality', () => {
+test('T315-ARGS: direct special-arm fixtures isolate absence rules from generic equality', () => {
   const interactiveCap = {
     ...good,
     limits: { ...good.limits },

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -684,6 +684,21 @@ test('T4: unknown deriveWhen names fail closed without throwing', () => {
   const originalLength = KNOB_REGISTRY.length;
   try {
     KNOB_REGISTRY.push(...descriptors);
+    const unstampedInput = headlessArgs();
+    for (const descriptor of descriptors) {
+      unstampedInput.configEcho[descriptor.key] = { value: 'value', source: 'default' };
+    }
+    let unstampedReport;
+    assert.doesNotThrow(() => {
+      unstampedReport = normalizeArgsReport(unstampedInput);
+    });
+    // Mutation: bypass the unknown-name guard in deriveConfigWaist only. Neither
+    // unknown deriveWhen name may derive its waist path from a receipt.
+    for (const descriptor of descriptors) {
+      const root = descriptor.waistPath.split('.')[0];
+      assert.equal(unstampedReport.args[root], undefined, descriptor.deriveWhen);
+      assert.equal(unstampedReport.derivedPaths.includes(descriptor.waistPath), false, descriptor.deriveWhen);
+    }
     for (const descriptor of descriptors) {
       input[descriptor.waistPath.split('.')[0]] = { field: 'value' };
     }
@@ -904,6 +919,7 @@ test('T10: a mode twin is not lockstep-validated outside its declared modes', ()
     });
     const args = { ...good, configEcho: { ...good.configEcho, mode_twin_probe: { value: 'value', source: 'default' } }, modeTwinProbe: { value: 'wrong' } };
     const result = validateArgs(args);
+    // Mutation: removing descriptor.modes.includes(args.mode) from the lockstep pass turns it red.
     assert.equal(result.errors.some((error) => error.includes('configEcho has unexpected key(s): mode_twin_probe')), true);
     assert.equal(result.errors.some((error) => /does not match configEcho/.test(error)), false);
   } finally {

--- a/workflows/test/args.test.js
+++ b/workflows/test/args.test.js
@@ -684,14 +684,327 @@ test('T4: unknown deriveWhen names fail closed without throwing', () => {
   const originalLength = KNOB_REGISTRY.length;
   try {
     KNOB_REGISTRY.push(...descriptors);
+    for (const descriptor of descriptors) {
+      input[descriptor.waistPath.split('.')[0]] = { field: 'value' };
+    }
     const normalized = normalizeArgsReport(input).args;
     for (const descriptor of descriptors) {
-      assert.equal(normalized[descriptor.key], undefined, descriptor.deriveWhen);
-      assert.equal(normalized[descriptor.waistPath.split('.')[0]], undefined, descriptor.deriveWhen);
+      assert.deepEqual(normalized[descriptor.waistPath.split('.')[0]], { field: 'value' }, descriptor.deriveWhen);
+    }
+    // Mutation: remove the Object.hasOwn() half of deriveWhenHolds. Both an unknown
+    // own name and inherited Object.prototype.toString must still be accepted here.
+    assert.deepEqual(validateArgs(normalized), { ok: true, errors: [] });
+  } finally {
+    KNOB_REGISTRY.length = originalLength;
+  }
+});
+
+test('T1: a newly registered waist row is validated against its mapped receipt', () => {
+  const originalLength = KNOB_REGISTRY.length;
+  try {
+    KNOB_REGISTRY.push({
+      key: 'lockstep_probe', modes: ['headless'], allowedSources: { headless: ['default'] },
+      rule: { kind: 'enum', values: ['raw'] }, env: null, reviewMdKey: null,
+      defaults: { headless: ['raw', 'default'] }, type: 'string', waistPath: 'probeWaist.field',
+      waistMap: { raw: 'mapped' }, derivedFrom: null, deriveWhen: null, nullReceipt: [],
+      resolvedKey: false,
+    });
+    const base = headlessArgs();
+    base.configEcho.lockstep_probe = { value: 'raw', source: 'default' };
+    assert.deepEqual(
+      validateArgs({ ...base, probeWaist: { field: 'raw' } }).errors,
+      ['probeWaist.field does not match configEcho.lockstep_probe'],
+    );
+    // Mutation: delete the generic pass, or compare entry.value without applying waistMap.
+    assert.deepEqual(validateArgs({ ...base, probeWaist: { field: 'mapped' } }), { ok: true, errors: [] });
+  } finally {
+    KNOB_REGISTRY.length = originalLength;
+  }
+});
+
+test('T2: every real waist row and mode has one exact lockstep oracle pair', () => {
+  const cases = {
+    'headless:limits.deliveryCap': {
+      path: 'limits.deliveryCap', key: 'pr_comment_cap', receipt: '6',
+      agree: headlessArgs(),
+      disagree: { ...headlessArgs(), limits: { ...headlessArgs().limits, deliveryCap: 7 } },
+    },
+    'headless:delivery.tier': {
+      path: 'delivery.tier', key: 'delivery_tier', receipt: 'all',
+      agree: { ...headlessArgs(), delivery: { tier: 'all' } },
+      disagree: { ...headlessArgs(), delivery: { tier: 'main_only' } },
+    },
+    'headless:reviewScope.requested': {
+      path: 'reviewScope.requested', key: 'reviewed_policy', receipt: 'full',
+      agree: headlessArgs('full'),
+      disagree: headlessArgs('full', { requested: 'incremental' }),
+    },
+    'headless:scopeAnswer': {
+      path: 'scopeAnswer', key: 'trivial_scope', receipt: 'light',
+      agree: {
+        ...headlessArgs(), riskTable: [{ path: 'a.js', risk: 'low' }], changedLines: 1,
+        scopeAnswer: 'light',
+        configEcho: { ...headlessArgs().configEcho, trivial_scope: { value: 'light', source: 'default' } },
+      },
+      disagree: {
+        ...headlessArgs(), riskTable: [{ path: 'a.js', risk: 'low' }], changedLines: 1,
+        scopeAnswer: 'full',
+        configEcho: { ...headlessArgs().configEcho, trivial_scope: { value: 'light', source: 'default' } },
+      },
+    },
+    'interactive:limits.deliveryCap': {
+      path: 'limits.deliveryCap', key: 'pr_comment_cap', receipt: 'null',
+      agree: { ...good, limits: { ...good.limits, deliveryCap: null } },
+      disagree: { ...good, limits: { ...good.limits, deliveryCap: 1 } },
+    },
+    'interactive:delivery.tier': {
+      path: 'delivery.tier', key: 'delivery_tier', receipt: 'all',
+      agree: { ...good, delivery: { tier: 'all' } },
+      disagree: { ...good, delivery: { tier: 'main_only' } },
+    },
+  };
+  const registryPairs = KNOB_REGISTRY
+    .filter(({ waistPath }) => waistPath !== null)
+    .flatMap((descriptor) => descriptor.modes.map((mode) => `${mode}:${descriptor.waistPath}`));
+  assert.deepEqual(Object.keys(cases).sort(), registryPairs.sort());
+  for (const [pair, fixture] of Object.entries(cases)) {
+    assert.equal(fixture.agree.configEcho[fixture.key].value, fixture.receipt, pair);
+    assert.equal(fixture.disagree.configEcho[fixture.key].value, fixture.receipt, pair);
+    assert.deepEqual(validateArgs(fixture.agree).errors, [], `${pair} agreeing value`);
+    // Mutation: filter any registry row out of the pass, or retain an old equality arm.
+    assert.deepEqual(validateArgs(fixture.disagree).errors, [
+      `${fixture.path} does not match configEcho.${fixture.key}`,
+    ], `${pair} disagreeing value`);
+  }
+});
+
+test('T3: derivedFrom rows reject a receipt that disagrees with their source', () => {
+  const originalLength = KNOB_REGISTRY.length;
+  try {
+    KNOB_REGISTRY.push({
+      key: 'derived_probe', modes: ['interactive'],
+      allowedSources: { interactive: ['discovery'] },
+      rule: { kind: 'enum', values: ['present', 'absent'] }, env: null, reviewMdKey: null,
+      defaults: { interactive: ['absent', 'discovery'] }, type: 'string', waistPath: null,
+      waistMap: null, derivedFrom: 'reviewConfigPath', deriveWhen: null, nullReceipt: [],
+      resolvedKey: false,
+    });
+    const args = {
+      ...good,
+      configEcho: { ...good.configEcho, derived_probe: { value: 'present', source: 'discovery' } },
+    };
+    // Mutation: delete the generic derivedFrom loop.
+    assert.deepEqual(validateArgs(args).errors, ['configEcho.derived_probe does not match reviewConfigPath']);
+  } finally {
+    KNOB_REGISTRY.length = originalLength;
+  }
+});
+
+test('T5: an unhandled registry type is accepted without a false lockstep violation', () => {
+  const originalLength = KNOB_REGISTRY.length;
+  try {
+    KNOB_REGISTRY.push({
+      key: 'bool_probe', modes: ['headless'], allowedSources: { headless: ['default'] },
+      rule: { kind: 'enum', values: ['true'] }, env: null, reviewMdKey: null,
+      defaults: { headless: ['true', 'default'] }, type: 'bool', waistPath: 'boolProbe.value',
+      waistMap: null, derivedFrom: null, deriveWhen: null, nullReceipt: [], resolvedKey: false,
+    });
+    const args = headlessArgs();
+    args.configEcho.bool_probe = { value: 'true', source: 'default' };
+    args.boolProbe = { value: false };
+    // Mutation: remove the expected === undefined guard.
+    assert.deepEqual(validateArgs(args), { ok: true, errors: [] });
+  } finally {
+    KNOB_REGISTRY.length = originalLength;
+  }
+});
+
+test('T6: csv_list lockstep equality is ordered and element-wise', () => {
+  const originalLength = KNOB_REGISTRY.length;
+  try {
+    KNOB_REGISTRY.push({
+      key: 'csv_probe', modes: ['headless'], allowedSources: { headless: ['default'] },
+      rule: { kind: 'csv_subset', values: ['a', 'b'] }, env: null, reviewMdKey: null,
+      defaults: { headless: ['a,b', 'default'] }, type: 'csv_list', waistPath: 'csvProbe.items',
+      waistMap: null, derivedFrom: null, deriveWhen: null, nullReceipt: [], resolvedKey: false,
+    });
+    const base = headlessArgs();
+    base.configEcho.csv_probe = { value: 'a,b', source: 'default' };
+    for (const [value, expected] of [[['a', 'b'], true], [['b', 'a'], false], [['a'], false]]) {
+      const result = validateArgs({ ...base, csvProbe: { items: value } });
+      // Mutation: replace element-wise comparison with === or an always-true branch.
+      assert.equal(result.ok, expected, JSON.stringify(value));
+      if (!expected) assert.deepEqual(result.errors, ['csvProbe.items does not match configEcho.csv_probe']);
     }
   } finally {
     KNOB_REGISTRY.length = originalLength;
   }
+});
+
+test('T7: a stamped null is data and is compared by the generic pass', () => {
+  const originalLength = KNOB_REGISTRY.length;
+  try {
+    KNOB_REGISTRY.push({
+      key: 'null_probe', modes: ['headless'], allowedSources: { headless: ['default'] },
+      rule: { kind: 'enum', values: ['value'] }, env: null, reviewMdKey: null,
+      defaults: { headless: ['value', 'default'] }, type: 'string', waistPath: 'nullProbe.value',
+      waistMap: null, derivedFrom: null, deriveWhen: null, nullReceipt: [], resolvedKey: false,
+    });
+    const args = headlessArgs();
+    args.configEcho.null_probe = { value: 'value', source: 'default' };
+    args.nullProbe = { value: null };
+    // Mutation: change the undefined skip to a nullish skip.
+    assert.deepEqual(validateArgs(args).errors, ['nullProbe.value does not match configEcho.null_probe']);
+  } finally {
+    KNOB_REGISTRY.length = originalLength;
+  }
+});
+
+test('T8: malformed receipts produce focused errors without lockstep cascades', () => {
+  const cap = headlessArgs();
+  cap.configEcho.pr_comment_cap = { value: '007', source: 'default' };
+  cap.limits = { ...cap.limits, deliveryCap: 1 };
+  assert.deepEqual(validateArgs(cap).errors, ['configEcho.pr_comment_cap.value is invalid for headless']);
+
+  const tier = headlessArgs();
+  tier.configEcho.delivery_tier = { value: 'all', source: 'fixed' };
+  tier.delivery = { tier: 'main_only' };
+  // Mutation: read configEchoValue directly instead of receiptEntryFor in the pass.
+  assert.deepEqual(validateArgs(tier).errors, ['configEcho.delivery_tier.source is invalid for headless']);
+});
+
+test('T9: special cap arms report one fault and suppress the generic template', () => {
+  const headless = headlessArgs();
+  headless.limits = { ...headless.limits, deliveryCap: '1' };
+  const headlessResult = validateArgs(headless);
+  assert.equal(headlessResult.errors.length, 1);
+  assert.equal(headlessResult.errors.some((error) => /does not match configEcho/.test(error)), false);
+
+  const interactive = { ...good, limits: { ...good.limits, deliveryCap: null }, configEcho: {
+    ...good.configEcho, pr_comment_cap: { value: '5', source: 'default' },
+  } };
+  const interactiveResult = validateArgs(interactive);
+  // Mutation: remove the interactive absence arm or let it fall through to equality.
+  assert.deepEqual(interactiveResult.errors, ['configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null']);
+});
+
+test('T10: a mode twin is not lockstep-validated outside its declared modes', () => {
+  const originalLength = KNOB_REGISTRY.length;
+  try {
+    KNOB_REGISTRY.push({
+      key: 'mode_twin_probe', modes: ['headless'],
+      allowedSources: { headless: ['default'], interactive: ['default'] },
+      rule: { kind: 'enum', values: ['value'] }, env: null, reviewMdKey: null,
+      defaults: { headless: ['value', 'default'], interactive: ['value', 'default'] },
+      type: 'string', waistPath: 'modeTwinProbe.value', waistMap: null, derivedFrom: null,
+      deriveWhen: null, nullReceipt: [], resolvedKey: false,
+    });
+    const args = { ...good, configEcho: { ...good.configEcho, mode_twin_probe: { value: 'value', source: 'default' } }, modeTwinProbe: { value: 'wrong' } };
+    const result = validateArgs(args);
+    assert.equal(result.errors.some((error) => error.includes('configEcho has unexpected key(s): mode_twin_probe')), true);
+    assert.equal(result.errors.some((error) => /does not match configEcho/.test(error)), false);
+  } finally {
+    KNOB_REGISTRY.length = originalLength;
+  }
+});
+
+test('T11: missing or null configEcho stays a focused validation refusal', () => {
+  for (const configEcho of [undefined, null]) {
+    const args = { ...good };
+    if (configEcho === undefined) delete args.configEcho;
+    else args.configEcho = configEcho;
+    // Mutation: remove the isPlainObject(args.configEcho) guard around the pass.
+    assert.doesNotThrow(() => validateArgs(args));
+    assert.equal(validateArgs(args).errors.some((error) => error.includes('configEcho')), true);
+  }
+});
+
+test('T12: any present scopeAnswer is refused when the light gate was ineligible', () => {
+  // Mutation: revert the biconditional to the old light-only and missing-only checks.
+  const interactive = validateArgs({ ...good, scopeAnswer: 'full' });
+  assert.equal(interactive.errors.filter((error) => /scopeAnswer/.test(error)).length, 1);
+  assert.match(interactive.errors[interactive.errors.length - 1], /the orchestrator answered a light\/full question the gate never asked/);
+  assert.match(interactive.errors[interactive.errors.length - 1], /omit scopeAnswer/);
+
+  const headless = headlessArgs();
+  headless.scopeAnswer = 'full';
+  const result = validateArgs(headless);
+  assert.equal(result.errors.filter((error) => /scopeAnswer/.test(error)).length, 1);
+  assert.match(result.errors.find((error) => /scopeAnswer is/.test(error)), /the orchestrator answered a light\/full question the gate never asked/);
+});
+
+test('T13: eligible scope accepts both values and a headless receipt derives either value', () => {
+  for (const scopeAnswer of ['light', 'full']) {
+    // Mutation: implement the biconditional as scopeAnswer === "light" iff eligible.
+    assert.deepEqual(validateArgs({ ...good, riskTable: [{ path: 'a.js', risk: 'low' }], changedLines: 10, scopeAnswer }), { ok: true, errors: [] });
+  }
+  const derived = normalizeArgs({
+    ...headlessArgs(), riskTable: [{ path: 'a.js', risk: 'low' }], changedLines: 10,
+    configEcho: { ...headlessArgs().configEcho, trivial_scope: { value: 'full', source: 'default' } },
+  });
+  assert.deepEqual(validateArgs(derived), { ok: true, errors: [] });
+  assert.equal(derived.scopeAnswer, 'full');
+});
+
+test('T14: a headless caller-stamped scopeAnswer equal to the derived receipt stays accepted', () => {
+  const args = headlessArgs();
+  args.riskTable = [{ path: 'a.js', risk: 'low' }];
+  args.changedLines = 10;
+  args.scopeAnswer = 'light';
+  args.configEcho.trivial_scope = { value: 'light', source: 'default' };
+  // Mutation: add caller-provenance rejection even when the stamped value equals the receipt.
+  // Decision pin: caller provenance is intentionally not rejected when the value is correct.
+  assert.deepEqual(validateArgs(normalizeArgs(args)), { ok: true, errors: [] });
+});
+
+test('T15: ineligible light receipt plus a present scopeAnswer uses the two dedicated refusals', () => {
+  const args = headlessArgs();
+  args.riskTable = [{ path: 'a.js', risk: 'medium' }];
+  args.scopeAnswer = 'full';
+  args.configEcho.trivial_scope = { value: 'light', source: 'default' };
+  const result = validateArgs(args);
+  assert.ok(result.errors.some((error) => error.startsWith('scopeAnswer is "full"')));
+  assert.ok(result.errors.some((error) => error.startsWith('configEcho.trivial_scope is "light"')));
+  // Mutation: retain the deleted scopeAnswer equality arm; no generic equality is valid here.
+  assert.equal(result.errors.some((error) => error.includes('scopeAnswer does not match configEcho')), false);
+});
+
+test('T16: derived null scopeAnswer is disclosed as no gap after normalization', () => {
+  const input = headlessArgs();
+  input.riskTable = [{ path: 'a.js', risk: 'low' }];
+  input.changedLines = 10;
+  input.scopeAnswer = null;
+  input.configEcho.trivial_scope = { value: 'light', source: 'default' };
+  const report = normalizeArgsReport(input);
+  assert.equal(report.args.scopeAnswer, 'light');
+  assert.deepEqual(report.derivedPaths.sort(), ['delivery.tier', 'scopeAnswer']);
+  // Mutation: omit derivedPaths from nullToleranceRejectedKeys so the re-derived null is disclosed.
+  assert.deepEqual(nullToleranceRejectedKeys(report.args, report.dropped, report.derivedPaths), []);
+});
+
+test('T18: direct special-arm fixtures isolate absence rules from generic equality', () => {
+  const interactiveCap = {
+    ...good,
+    limits: { ...good.limits },
+    configEcho: { ...good.configEcho, pr_comment_cap: { value: '5', source: 'default' } },
+  };
+  assert.deepEqual(validateArgs(interactiveCap).errors, [
+    'configEcho.pr_comment_cap must be null when limits.deliveryCap is absent or null',
+  ]);
+
+  for (const delivery of [undefined, {}]) {
+    const args = { ...good, configEcho: { ...good.configEcho, delivery_tier: { value: 'main_only', source: 'default' } } };
+    if (delivery === undefined) delete args.delivery;
+    else args.delivery = delivery;
+    assert.deepEqual(validateArgs(args).errors, ['configEcho.delivery_tier does not match delivery.tier']);
+  }
+
+  const headlessCap = headlessArgs();
+  delete headlessCap.limits.deliveryCap;
+  // Mutation: delete the named presence arms; the generic pass skips undefined and misses these.
+  assert.deepEqual(validateArgs(headlessCap).errors, [
+    'headless limits.deliveryCap must be a number matching configEcho.pr_comment_cap',
+  ]);
 });
 
 test('T309-ARGS: local and branch scopes stay stamped while detector-backed lockstep is gated', () => {

--- a/workflows/test/pipeline_run.test.js
+++ b/workflows/test/pipeline_run.test.js
@@ -720,16 +720,33 @@ test('F4-3: checkpoints:null discloses NOTHING — validateArgs never rejected i
   assert.match(named[0], /reviewConfig/);
 });
 
-test('F4-3: every OTHER nullable key still discloses (the filter is not a blanket mute)', async () => {
-  // delivery.tier / delivery.prIdentity are nested drops; each is rejected by validateArgs as
-  // a stamped null, so each keeps its disclosure.
+test('F4-3: every non-derived nullable key still discloses (the filter is not a blanket mute)', async () => {
+  // delivery.tier is immediately re-derived from its receipt, so R7 deliberately suppresses
+  // its null disclosure. delivery.prIdentity has no derivation and keeps its disclosure.
   const args = validArgs({ delivery: { tier: null, prIdentity: null } });
   const out = await runWith(makeCtx(args), args);
   assert.equal(out.ok, true);
   const named = out.gaps.filter((g) => /^null_arg: /.test(g));
-  assert.equal(named.length, 2, `got: ${named}`);
-  assert.ok(named.some((g) => g.includes('delivery.tier')));
+  // Mutation: pass no derivedPaths through stages.js, which would disclose delivery.tier too.
+  assert.equal(named.length, 1, `got: ${named}`);
   assert.ok(named.some((g) => g.includes('delivery.prIdentity')));
+});
+
+test('R7: a derived headless scopeAnswer null is normalized and not disclosed', async () => {
+  const base = validArgs();
+  const args = validArgs({
+    riskTable: [{ path: 'a.js', risk: 'low' }],
+    changedLines: 10,
+    scopeAnswer: null,
+    configEcho: {
+      ...base.configEcho,
+      trivial_scope: { value: 'light', source: 'default' },
+    },
+  });
+  const out = await runWith(makeCtx(args), args);
+  assert.equal(out.ok, true, `a derived null must not reject the run; gaps: ${out.gaps}`);
+  // Mutation: omit derivedPaths from the stages.js differential probe.
+  assert.deepEqual(out.gaps.filter((g) => /^null_arg: /.test(g)), []);
 });
 
 test('a clean waist records NO null_arg gap (disclosure is not noise)', async () => {


### PR DESCRIPTION
This PR makes `validateArgs` registry-driven for waist lockstep and aligns `scopeAnswer` presence with light eligibility. It also records derived paths so the null-tolerance disclosure stops naming a field derivation refilled, and regenerates the derived-waist fence.

Closes #315
Closes #316

## Mechanism

- `workflows/src/args.js`: Adds shared, fail-closed `deriveWhenHolds` logic.
- `workflows/src/args.js`: Adds a final registry lockstep pass with mapped receipt values, CSV equality, mode filtering, and focused malformed-receipt handling.
- `workflows/src/args.js`: Retains the explicit presence and absence rules (headless cap must be a number, interactive absent cap needs a `null` receipt, absent tier means `all`, receipt `light` on an ineligible table); each records its path in `reported` so the lockstep pass yields and one fault is one error. An ill-typed cap keeps only its shape error.
- `workflows/src/args.js`: Replaces one-way scope checks with a biconditional presence rule.
- `workflows/src/args.js` and `workflows/src/stages.js`: `deriveConfigWaist` returns `{ args, derivedPaths }`; `normalizeArgsReport` reports `derivedPaths` and the null-tolerance probe skips a dropped key that derivation refilled.
- `workflows/pipeline.js`: Regenerates the workflow bundle.
- `scripts/generate_contract_requirements.py`, `skills/code-gauntlet/*`, and Python tests: Regenerate the waist fence and update its refusal guidance, expected bodies, and census.

## Decisions of record

- R1-R3: The shared predicate fails closed for unknown or inherited names. Special arms remain because undefined values need presence rules.
- R4: `scopeAnswer` must be present exactly when the waist is light-eligible. Either `light` or `full` is accepted when eligible.
- R5: Equal headless caller-stamped values remain accepted. Rejecting correct values adds friction without observable protection.
- R6: Ineligible `full` with a light receipt uses the scope gate and trivial-scope receipt errors, not a deleted equality arm.
- R7: Null disclosures are suppressed only for paths re-derived during normalization. Other nullable keys remain disclosed.
- R8-R9: Generated prose describes conditional receipt disagreement. Refusal guidance lists the three validator refusals.

## Tests

- T1-T2: Probe and real registry lockstep pairs go red when the pass, `waistMap`, row filtering, or old equality arms are changed.
- T3: `derivedFrom` validation goes red when its loop is deleted.
- T4: Unknown and inherited `deriveWhen` names go red when the ownership guard is removed.
- T5-T7: Unhandled types, CSV ordering, and stamped nulls go red when their skips or comparisons change.
- T8-T11: Malformed receipts, duplicate cap errors, mode filtering, and missing `configEcho` go red under their listed guard mutations.
- T12-T15: Scope presence, accepted values, caller stamps, and the combined case go red when the biconditional or special arms change.
- T16 and pipeline R7: Derived null filtering goes red when derived paths are omitted.
- T18: Direct presence and effective-tier fixtures go red when named special arms are deleted.
- T17: Python followability, generated-body, census, and bundle checks cover the contract updates.

## Gates

- `node --test workflows/test/*.test.js` - PASS, 1365 tests, 0 failures (Node 24.20.0).
- `node workflows/build.js && git diff --exit-code workflows/pipeline.js` - PASS after the bundle was committed (the builder's run saw the uncommitted bundle).
- `python3 scripts/generate_contract_requirements.py && python3 scripts/generate_contract_requirements.py --check` - PASS. Last output: `generated registry blocks are current`.
- `/Users/lee/personal/claude-deep-review/.venv/bin/python -m pytest tests/ -q` - PASS. `2140 passed, 1602 subtests passed in 29.15s`.
- `/Users/lee/personal/claude-deep-review/.venv/bin/python -m pytest bench/tests/ -q` - PASS. `645 passed, 106 subtests passed in 22.93s`.
- `python3 workflows/test/tools/biome_check.py` - PASS (run by the orchestrator; the builder's sandbox could not execute the cached binary): `Checked 39 files in 19ms. No fixes applied.`
- JS coverage command from `AGENTS.md` - PASS. Lines `98.86`, branches `90.76`, functions `98.31` (floors 98.2 / 89.6 / 97.6, unchanged).

## Review record

Three luna review rounds (mutation ledger and spec conformance lenses in detached worktrees): round 1 found one major (the headless cap presence arm spliced an earlier shape error out of the list) and two minors (a misplaced omit hint on the receipt refusal, an out-parameter); round 2 found one major in the tests (T4 never reached the derivation caller of the shared predicate) and one minor; round 3 passed both lenses with 20 and 18 mutations red. CI is green on every commit.

## Adjacent

none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrPvPqRF4KPVvodPKdVuYr

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-dispatch args validation and scope gating in the review pipeline; incorrect logic could block valid runs or accept incoherent waist args, but behavior is heavily covered by new unit and pipeline tests.
> 
> **Overview**
> **Adds registry-driven lockstep validation** so `validateArgs` rejects any stamped derived waist field that disagrees with its `configEcho` receipt (plus `derivedFrom` receipt rows), replacing scattered one-off equality checks with a final `KNOB_REGISTRY` pass that honors `waistMap`, `deriveWhen`, and ordered `csv_list` comparison.
> 
> **Tightens `scopeAnswer` rules** to a biconditional: the field must be present exactly when `riskTable`/`changedLines` are light-eligible (any value when ineligible is refused with an omit hint), while still accepting either `light` or `full` when eligible.
> 
> **Tracks re-derived paths during normalization** — `deriveConfigWaist` / `normalizeArgsReport` now expose `derivedPaths`, and `nullToleranceRejectedKeys` skips null-disclosure gaps for keys immediately refilled from the receipt (e.g. `delivery.tier`, headless `scopeAnswer`).
> 
> **Regenerates operator docs** (derived-waist fence + Phase 3 prose) to state that receipt disagreements are refused pre-dispatch, with matching Python generator/tests and a mirrored `workflows/pipeline.js` bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b61100f753df511909f727be82bb65928295307. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->