### PR TITLE
fix(bench): drop the report G3 carrier and make profiler stage rules data (#280, #282)

### DIFF
--- a/bench/MEASUREMENT.md
+++ b/bench/MEASUREMENT.md
@@ -74,18 +74,13 @@ python3 bench/run.py --check <RUN_ID>
 2. Payload parse + adapter-required fields + union-schema findings check
    (requires ≥1 `code-gauntlet-findings-*.json` per PR)
 3. Zero `origin=unknown` findings; no writer no-write-proof / partial-artifacts
-   degrade. The report is rendered before persistence from data that carries only a gap
-   count, so code-owned report text is not a G3 writer-degrade carrier. Every persistence
-   path pushes its writer-degrade signal through `partial()` into `writeOut.gaps` and
-   the Workflow-return structured carrier. The legacy renderer-era report hits retained
-   in the corpus were model prose. `raw.json` remains the TEXT carrier and is scanned
-   as-is. Carriers that own a `gaps` array — `workflows/wf_*.json` (the compact
-   Workflow return) and `code-gauntlet-checkpoint-all-*.json` — are judged from that
-   parsed array alone; their raw bytes are never scanned, because a wf record echoes
-   the whole `workflows/pipeline.js` bundle into its `script` field and the bundle's
-   own source contains those sentinels as ordinary substrings. When such a carrier
-   will not parse, or carries no `gaps` at all, it falls back to a raw-text scan with
-   that `script` field blanked first.
+   degrade. The report is not a carrier: it is rendered before persistence from data
+   that carries only a gap count, so code-owned report text cannot hold the signal,
+   although model prose can. G3 scans only the direct `workflows/wf_*.json`, `raw.json`,
+   and `code-gauntlet-checkpoint-all-*.json` carriers. `raw.json` is scanned as text.
+   The other carriers are judged from parsed `gaps` arrays and their string items alone;
+   an empty array is clean. If a structured carrier cannot parse or has no `gaps` array,
+   G3 falls back to a raw scan after blanking its `script` field.
 4. Plugin identity — when the Headless config echo carries `pipeline_version` and
    `plugin_root`, those receipts are validated against the repo's
    `workflows/pipeline.js` version and plugin root (primary). A complete valid

--- a/bench/MEASUREMENT.md
+++ b/bench/MEASUREMENT.md
@@ -74,18 +74,18 @@ python3 bench/run.py --check <RUN_ID>
 2. Payload parse + adapter-required fields + union-schema findings check
    (requires ≥1 `code-gauntlet-findings-*.json` per PR)
 3. Zero `origin=unknown` findings; no writer no-write-proof / partial-artifacts
-   degrade. Carriers that own a `gaps` array — `workflows/wf_*.json` (the
-   compact Workflow return) and `code-gauntlet-checkpoint-all-*.json` — are
-   judged from that parsed array alone; their raw bytes are never scanned,
-   because a wf record echoes the whole `workflows/pipeline.js` bundle into its
-   `script` field and the bundle's own source contains those sentinels as
-   ordinary substrings.
-   When such a
-   carrier will not parse, or carries no `gaps`
-   at all, it falls back to a raw-text scan with that `script` field blanked
-   first. Carriers with no `gaps` structure to parse — `raw.json` (a result
-   envelope whose `.result` is prose) and `code-gauntlet-report-*.md` — are
-   raw-text scanned as-is; they never embed the bundle.
+   degrade. The report is rendered before persistence from data that carries only a gap
+   count, so code-owned report text is not a G3 writer-degrade carrier. Every persistence
+   path pushes its writer-degrade signal through `partial()` into `writeOut.gaps` and
+   the Workflow-return structured carrier. The legacy renderer-era report hits retained
+   in the corpus were model prose. `raw.json` remains the TEXT carrier and is scanned
+   as-is. Carriers that own a `gaps` array — `workflows/wf_*.json` (the compact
+   Workflow return) and `code-gauntlet-checkpoint-all-*.json` — are judged from that
+   parsed array alone; their raw bytes are never scanned, because a wf record echoes
+   the whole `workflows/pipeline.js` bundle into its `script` field and the bundle's
+   own source contains those sentinels as ordinary substrings. When such a carrier
+   will not parse, or carries no `gaps` at all, it falls back to a raw-text scan with
+   that `script` field blanked first.
 4. Plugin identity — when the Headless config echo carries `pipeline_version` and
    `plugin_root`, those receipts are validated against the repo's
    `workflows/pipeline.js` version and plugin root (primary). A complete valid

--- a/bench/PROFILING.md
+++ b/bench/PROFILING.md
@@ -58,18 +58,19 @@ With neither `--out-json` nor `--out-md`, both are printed to stdout. `RUN_ID` i
   run's shape has drifted and the rest of the report should be treated with
   suspicion. `durationMs` is not independently re-derived (it defines the workflow
   wall clock everything else is measured against).
-- **Stage profile** — stages are derived by grouping `workflowProgress[]` labels:
-  `summarize`, `discover` (the 7 discovery agentTypes, grouped together), the pure-JS
-  `merge`/`filter` transform phases (no agent — see `workflows/src/stages.js`
-  `runPhase('merge', ...)` / `runPhase('filter', ...)`; only observable as the gap
-  between the stages either side), `verify-slice-*`,
-  `validate-batch-*`, `challenge-*`, `report-writer`, `artifact-writer`. No
-  `report-writer` bucket exists in runs after v3.25 — the Report stage dispatches
-  nothing. The bucket is kept so the archived corpus still profiles. `avg
-  concurrency` = agent-seconds used / stage span (how "full" the stage was on
-  average); `max concurrency` is the actual peak overlap from a sweep-line over each
-  agent's `[startedAt, startedAt+durationMs]` interval (closed; a touching start/end
-  counts as overlap).
+- **Stage profile** — stages are derived by grouping `workflowProgress[]` through the
+  ordered `STAGE_RULES` data table in `bench/profile_run.py`: label prefixes, exact
+  labels, and discovery `agentType` membership are represented in one place. A
+  historical rule is included only when that bucket ran, and its row carries
+  `historical: true` plus the rule's `historical_note`; a live rule with zero agents
+  remains an `UNAVAILABLE` row. The pure-JS `merge`/`filter` transform phases have no
+  agent and are observable only as gaps between the stages either side. The
+  transform-gap resolver uses the nearest earlier and later rows that carry a span,
+  so omitted or spanless rows cannot change the endpoints. `avg concurrency` =
+  agent-seconds used / stage span (how "full" the stage was on average); `max
+  concurrency` is the actual peak overlap from a sweep-line over each agent's
+  `[startedAt,startedAt+durationMs]` interval (closed; a touching start/end counts as
+  overlap).
 - **Parallel-capacity accounting** — for each stage, `capacity = slowest-agent duration
   × slots` (slots = however many agents were actually dispatched in that stage), `used
   = Σ durationMs`, `idle = capacity − used`. High idle % on a fan-out stage means the

--- a/bench/profile_run.py
+++ b/bench/profile_run.py
@@ -50,8 +50,8 @@ UNAVAILABLE = "UNAVAILABLE"
 DEFAULT_PROJECTS_DIR = Path.home() / ".claude" / "projects"
 
 # Discovery agentTypes that make up the "discover" stage (CLAUDE.md's 7-agent list,
-# minus change-summarizer/artifact-writer/executor/validator/challenger/report-writer
-# which have their own stages).
+# minus change-summarizer/artifact-writer/executor/validator/challenger, which have
+# their own stages).
 DISCOVER_AGENT_TYPES = {
     "code-gauntlet:bug-detector",
     "code-gauntlet:security-reviewer",
@@ -63,22 +63,67 @@ DISCOVER_AGENT_TYPES = {
 }
 
 
-# Ordered stage-grouping rules: (stage_name, predicate(label, agentType)). Order matters
-# for the pipeline-order stage list; first match wins.
+# Ordered stage-grouping rules. The table is the source for stage order, predicates,
+# and historical metadata; first matching entry wins.
+STAGE_RULES = (
+    {"name": "summarize", "match": "prefix", "label": "summarize"},
+    {
+        "name": "discover",
+        "match": "agent_type",
+        "agent_types": DISCOVER_AGENT_TYPES,
+    },
+    {
+        "name": "verify-input-writer",
+        "match": "prefix",
+        "label": "verify-input-writer-",
+        "historical_note": "slice input is passed inline; no writer agent is dispatched",
+    },
+    {"name": "verify-slice", "match": "prefix", "label": "verify-slice-"},
+    {
+        "name": "validate-batch",
+        "match": "prefix",
+        "label": "validate-batch-",
+    },
+    {"name": "challenge", "match": "prefix", "label": "challenge-"},
+    {
+        "name": "report-writer",
+        "match": "exact",
+        "label": "report-writer",
+        "historical_note": "the report is rendered in code; no writer agent is dispatched",
+    },
+    {"name": "artifact-writer", "match": "exact", "label": "artifact-writer"},
+    {
+        "name": "assemble-artifacts",
+        "match": "exact",
+        "label": "assemble-artifacts",
+    },
+)
+
+
+def _stage_predicate(rule):
+    if rule["match"] == "agent_type":
+        agent_types = rule["agent_types"]
+
+        def predicate(_label, agent_type):
+            return agent_type in agent_types
+
+    elif rule["match"] == "prefix":
+        prefix = rule["label"]
+
+        def predicate(label, _agent_type):
+            return label.startswith(prefix)
+
+    else:
+        expected_label = rule["label"]
+
+        def predicate(label, _agent_type):
+            return label == expected_label
+
+    return predicate
+
+
 def _stage_rules():
-    return [
-        ("summarize", lambda label, _atype: label == "summarize"),
-        ("discover", lambda _label, atype: atype in DISCOVER_AGENT_TYPES),
-        (
-            "verify-input-writer",
-            lambda label, _atype: label.startswith("verify-input-writer-"),
-        ),
-        ("verify-slice", lambda label, _atype: label.startswith("verify-slice-")),
-        ("validate-batch", lambda label, _atype: label.startswith("validate-batch-")),
-        ("challenge", lambda label, _atype: label.startswith("challenge-")),
-        ("report-writer", lambda label, _atype: label == "report-writer"),
-        ("artifact-writer", lambda label, _atype: label == "artifact-writer"),
-    ]
+    return [(rule["name"], _stage_predicate(rule)) for rule in STAGE_RULES]
 
 
 # Non-agent transform phases that sit between agent stages in the pipeline (workflows/src/stages.js
@@ -90,7 +135,12 @@ TRANSFORM_STAGE_AFTER = {
     "validate-batch": "filter",
 }
 
-STAGE_ORDER = [name for name, _ in _stage_rules()]
+STAGE_ORDER = [rule["name"] for rule in STAGE_RULES]
+HISTORICAL_STAGES = {
+    rule["name"]: rule["historical_note"]
+    for rule in STAGE_RULES
+    if rule.get("historical_note")
+}
 
 
 # --------------------------------------------------------------------------- helpers
@@ -332,6 +382,15 @@ def _group_by_stage(agents):
     return by_stage
 
 
+def _stage_row(name, **values):
+    row = {"stage": name, **values}
+    historical_note = HISTORICAL_STAGES.get(name)
+    if historical_note is not None:
+        row["historical"] = True
+        row["historical_note"] = historical_note
+    return row
+
+
 def build_stage_profile(agents, workflow_start_ms, workflow_duration_ms):
     by_stage = _group_by_stage(agents)
 
@@ -339,6 +398,8 @@ def build_stage_profile(agents, workflow_start_ms, workflow_duration_ms):
     for name in STAGE_ORDER:
         members = by_stage.get(name, [])
         if not members:
+            if name in HISTORICAL_STAGES:
+                continue
             stages_out.append(
                 {
                     "stage": name,
@@ -348,6 +409,7 @@ def build_stage_profile(agents, workflow_start_ms, workflow_duration_ms):
                 }
             )
             continue
+
         starts = [m["started_at"] for m in members if m["started_at"] is not None]
         ends = [
             m["started_at"] + m["duration_ms"]
@@ -356,11 +418,11 @@ def build_stage_profile(agents, workflow_start_ms, workflow_duration_ms):
         ]
         if not starts or not ends:
             stages_out.append(
-                {
-                    "stage": name,
-                    "agent_count": len(members),
-                    "note": UNAVAILABLE + ": missing timing fields",
-                }
+                _stage_row(
+                    name,
+                    agent_count=len(members),
+                    note=UNAVAILABLE + ": missing timing fields",
+                )
             )
             continue
         span_start, span_end = min(starts), max(ends)
@@ -375,19 +437,19 @@ def build_stage_profile(agents, workflow_start_ms, workflow_duration_ms):
             ]
         )
         stages_out.append(
-            {
-                "stage": name,
-                "agent_count": len(members),
-                "span_start_offset_s": (span_start - workflow_start_ms) / 1000.0,
-                "span_end_offset_s": (span_end - workflow_start_ms) / 1000.0,
-                "span_wall_s": span_ms / 1000.0,
-                "share_of_workflow_wall": (span_ms / workflow_duration_ms)
+            _stage_row(
+                name,
+                agent_count=len(members),
+                span_start_offset_s=(span_start - workflow_start_ms) / 1000.0,
+                span_end_offset_s=(span_end - workflow_start_ms) / 1000.0,
+                span_wall_s=span_ms / 1000.0,
+                share_of_workflow_wall=(span_ms / workflow_duration_ms)
                 if workflow_duration_ms
                 else None,
-                "agent_seconds_used": busy_ms / 1000.0,
-                "avg_concurrency": avg_concurrency,
-                "max_concurrency": max_concurrency,
-            }
+                agent_seconds_used=busy_ms / 1000.0,
+                avg_concurrency=avg_concurrency,
+                max_concurrency=max_concurrency,
+            )
         )
         transform_after = TRANSFORM_STAGE_AFTER.get(name)
         if transform_after:
@@ -429,20 +491,34 @@ def _max_overlap(intervals):
 
 
 def _fill_transform_gaps(stages_out):
-    """Resolve the gap-derived transform stages' actual span now that all stage spans exist."""
+    """Resolve transform spans from the nearest earlier/later span-bearing rows."""
     stage_span = {}
     for s in stages_out:
-        if "span_start_offset_s" in s:
+        if (
+            s.get("span_start_offset_s") is not None
+            and s.get("span_end_offset_s") is not None
+        ):
             stage_span[s["stage"]] = (s["span_start_offset_s"], s["span_end_offset_s"])
 
-    order = [s["stage"] for s in stages_out]
     for idx, s in enumerate(stages_out):
         if "(transform, no agent)" not in s["stage"]:
             continue
-        prev_stage = order[idx - 1] if idx > 0 else None
-        next_stage = order[idx + 1] if idx + 1 < len(order) else None
-        prev_end = stage_span.get(prev_stage, (None, None))[1]
-        next_start = stage_span.get(next_stage, (None, None))[0]
+        prev_end = next(
+            (
+                stage_span[stages_out[prev_idx]["stage"]][1]
+                for prev_idx in range(idx - 1, -1, -1)
+                if stages_out[prev_idx]["stage"] in stage_span
+            ),
+            None,
+        )
+        next_start = next(
+            (
+                stage_span[stages_out[next_idx]["stage"]][0]
+                for next_idx in range(idx + 1, len(stages_out))
+                if stages_out[next_idx]["stage"] in stage_span
+            ),
+            None,
+        )
         if prev_end is not None and next_start is not None:
             s["span_start_offset_s"] = prev_end
             s["span_end_offset_s"] = next_start
@@ -928,14 +1004,15 @@ def render_markdown(profile):
     )
     lines.append("|---|---|---|---|---|---|---|---|")
     for s in p["stage_profile"]:
+        stage_name = s["stage"] + (" (historical)" if s.get("historical") else "")
         if "note" in s and "span_wall_s" not in s:
             lines.append(
-                f"| {s['stage']} | {s['agent_count']} | {s['note']} | | | | | |"
+                f"| {stage_name} | {s['agent_count']} | {s['note']} | | | | | |"
             )
             continue
         lines.append(
             "| {stage} | {n} | {span} | {sstart} | {send} | {share} | {avgc} | {maxc} |".format(
-                stage=s["stage"],
+                stage=stage_name,
                 n=s["agent_count"],
                 span=_fmt(s.get("span_wall_s"), "s"),
                 sstart=_fmt(s.get("span_start_offset_s"), "s"),
@@ -1081,9 +1158,7 @@ def render_markdown(profile):
     lines.append("")
 
     # Output-byte accounting for write-shaped agents
-    lines.append(
-        "## Output-byte accounting (Write-shaped agents: artifact-writer, verify-input-writer)"
-    )
+    lines.append("## Output-byte accounting (Write-shaped agents)")
     lines.append("")
     write_rows = []
     for a in p["agents"]:
@@ -1094,7 +1169,7 @@ def render_markdown(profile):
             write_rows.append((a["label"], w))
     if not write_rows:
         lines.append(
-            f"_{UNAVAILABLE}: no Write tool calls found on artifact-writer/verify-input-writer transcripts_"
+            f"_{UNAVAILABLE}: no Write tool calls found on Write-shaped agent transcripts_"
         )
     else:
         lines.append("| label | file | content bytes | seconds spent |")

--- a/bench/runner/check.py
+++ b/bench/runner/check.py
@@ -80,23 +80,15 @@ _SCRIPT_FIELD_OPEN_RE = re.compile(r'"script"\s*:\s*"(?:\\.|[^"\\])*\Z', re.DOTA
 PIPELINE_REL = Path("workflows") / "pipeline.js"
 
 # G3 writer-degrade carrier policy (issue #52):
-# The report is rendered before persistence from data that carries only a gap COUNT, so
-# code-owned report text cannot carry the writer-degrade signal (render_report.test.js
-# T-G3). Every persistence path (legacy by-value writer, derived writer, RETURN fallback,
-# replay) pushes the signal through ``partial()`` into ``writeOut.gaps`` and the
-# Workflow-return structured carrier. Every renderer-era report hit in the retained
-# corpus was model prose. ``raw.json`` stays a TEXT carrier. STRUCTURED carriers
-# (``workflows/wf_*.json`` at ``result.gaps``, and the persisted checkpoint's ``gaps``)
-# are judged from the parsed array alone; their raw bytes are never scanned. A wf record
-# echoes the whole ``workflows/pipeline.js`` bundle into its ``script`` field, and the
-# bundle carries both sentinels as ordinary substrings. This is registered in
-# ``docs/machine-parsed-strings.md`` and pinned by ``tests/test_machine_parsed_strings.py``.
-# A structured carrier that will not parse or has no ``gaps`` falls back to a raw scan
-# with the ``script`` field blanked. The superseded archives (``workflows/superseded/``
-# for wf records, #85; ``pr_dir/superseded/`` for deliverables, #165) are invisible
-# because every G3/G6 glob is non-recursive. G3 is the writer degrade gate. A Phase 8
-# timeout has no structural artifact signal: the awaiter reports ``workflow-timeout``
-# on its own stdout, and G6 catches a lost deliverable.
+# The report is not a carrier: it is rendered before persistence from data that carries
+# only a gap count, so code-owned report text cannot carry the signal, although model
+# prose can. Scan only the direct ``workflows/wf_*.json``, ``raw.json``, and
+# ``code-gauntlet-checkpoint-all-*.json`` carriers. ``raw.json`` is scanned as TEXT.
+# STRUCTURED carriers are judged from parsed ``gaps`` arrays and their string items
+# alone; an empty array is clean. If a structured carrier cannot parse or has no
+# ``gaps`` array, fall back to a raw scan after blanking its ``script`` field. The
+# patterns are non-recursive. G3 is the writer-degrade gate; Phase 8 timeouts have no
+# structural carrier and are reported by the awaiter.
 # Do not include bench-only fixture names such as deep-review-report.md.
 _DEGRADE_STRUCTURED = "structured"
 _DEGRADE_TEXT = "text"

--- a/bench/runner/check.py
+++ b/bench/runner/check.py
@@ -80,22 +80,23 @@ _SCRIPT_FIELD_OPEN_RE = re.compile(r'"script"\s*:\s*"(?:\\.|[^"\\])*\Z', re.DOTA
 PIPELINE_REL = Path("workflows") / "pipeline.js"
 
 # G3 writer-degrade carrier policy (issue #52):
-# STRUCTURED carriers (``workflows/wf_*.json`` at ``result.gaps``, and the
-# persisted checkpoint's ``gaps``) are judged from the parsed array alone; their
-# raw bytes are never scanned. A wf record echoes the whole ``workflows/pipeline.js``
-# bundle into its ``script`` field, and the bundle carries both sentinels as
-# ordinary substrings. This is registered in ``docs/machine-parsed-strings.md``
-# and pinned by ``tests/test_machine_parsed_strings.py``. A structured carrier
-# that will not parse or has no ``gaps`` falls back to a raw scan with the
-# ``script`` field blanked.
-# TEXT carriers (``raw.json``, whose ``.result`` is model prose and never embeds
-# the bundle -- measured 0/131 in the retained corpus, max 9.5 KB -- and
-# ``code-gauntlet-report-*.md``) are raw-scanned as-is. The superseded archives
-# (``workflows/superseded/`` for wf records, #85; ``pr_dir/superseded/`` for
-# deliverables, #165) are invisible because every G3/G6 glob is non-recursive.
-# G3 is the writer degrade gate. A Phase 8 timeout has no structural artifact
-# signal: the awaiter reports ``workflow-timeout`` on its own stdout, and G6
-# catches a lost deliverable.
+# The report is rendered before persistence from data that carries only a gap COUNT, so
+# code-owned report text cannot carry the writer-degrade signal (render_report.test.js
+# T-G3). Every persistence path (legacy by-value writer, derived writer, RETURN fallback,
+# replay) pushes the signal through ``partial()`` into ``writeOut.gaps`` and the
+# Workflow-return structured carrier. Every renderer-era report hit in the retained
+# corpus was model prose. ``raw.json`` stays a TEXT carrier. STRUCTURED carriers
+# (``workflows/wf_*.json`` at ``result.gaps``, and the persisted checkpoint's ``gaps``)
+# are judged from the parsed array alone; their raw bytes are never scanned. A wf record
+# echoes the whole ``workflows/pipeline.js`` bundle into its ``script`` field, and the
+# bundle carries both sentinels as ordinary substrings. This is registered in
+# ``docs/machine-parsed-strings.md`` and pinned by ``tests/test_machine_parsed_strings.py``.
+# A structured carrier that will not parse or has no ``gaps`` falls back to a raw scan
+# with the ``script`` field blanked. The superseded archives (``workflows/superseded/``
+# for wf records, #85; ``pr_dir/superseded/`` for deliverables, #165) are invisible
+# because every G3/G6 glob is non-recursive. G3 is the writer degrade gate. A Phase 8
+# timeout has no structural artifact signal: the awaiter reports ``workflow-timeout``
+# on its own stdout, and G6 catches a lost deliverable.
 # Do not include bench-only fixture names such as deep-review-report.md.
 _DEGRADE_STRUCTURED = "structured"
 _DEGRADE_TEXT = "text"
@@ -103,7 +104,6 @@ _DEGRADE_TEXT = "text"
 _DEGRADE_CARRIER_POLICY = {
     "workflows/wf_*.json": _DEGRADE_STRUCTURED,
     "raw.json": _DEGRADE_TEXT,
-    "code-gauntlet-report-*.md": _DEGRADE_TEXT,
     "code-gauntlet-checkpoint-all-*.json": _DEGRADE_STRUCTURED,
 }
 

--- a/bench/tests/test_check.py
+++ b/bench/tests/test_check.py
@@ -572,7 +572,7 @@ class CheckRunTest(unittest.TestCase):
         """Legacy writer no-write-proof gaps land in the structured Workflow return."""
         _build_ok_run(self.run_dir)
         pr = self.run_dir / "pr-example-repo-1"
-        # Mutation: restore the report policy entry and put this gap in the report; only the structured carrier may fire G3.
+        # Mutation: restore the report policy entry while retaining this gap in the structured Workflow record; only the structured carrier may fire G3.
         (pr / "code-gauntlet-report-deadbeef.md").write_text(
             "# Report\n", encoding="utf-8"
         )

--- a/bench/tests/test_check.py
+++ b/bench/tests/test_check.py
@@ -332,9 +332,15 @@ class CheckRunTest(unittest.TestCase):
         _build_ok_run(self.run_dir)
         pr = self.run_dir / "pr-example-repo-1"
         (pr / "code-gauntlet-checkpoint-all-deadbeef.json").unlink()
-        (pr / "code-gauntlet-report-deadbeef.md").write_text(
-            "# Report\n\nwriter no write proof (partial-artifacts)\n",
-            encoding="utf-8",
+        # Mutation: move this sentinel back into the report; the report must no longer be a G3 carrier.
+        _write_json(
+            pr / "raw.json",
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": "gaps: writeArtifacts: no write proof (partial-artifacts)",
+            },
         )
         result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
         self.assertFalse(result["ok"])
@@ -344,7 +350,9 @@ class CheckRunTest(unittest.TestCase):
                 for f in result["failures"]
             )
         )
-        self.assertTrue(any("writer degrade" in f for f in result["failures"]))
+        self.assertTrue(
+            any("raw.json" in f and "writer degrade" in f for f in result["failures"])
+        )
 
     def test_unparseable_post_review_artifact_fails_g6(self):
         _build_ok_run(self.run_dir)
@@ -511,16 +519,26 @@ class CheckRunTest(unittest.TestCase):
             )
         )
 
-    def test_report_degrade_fails_g3(self):
+    def test_report_degrade_text_does_not_fail_g3(self):
         _build_ok_run(self.run_dir)
         report = self.run_dir / "pr-example-repo-1" / "code-gauntlet-report-deadbeef.md"
         report.write_text(
-            "# Report\n\ngaps: writeArtifacts: no write proof — partial-artifacts\n",
+            "# Report\n\nFinding prose: no write proof and partial-artifacts are not\n"
+            "writer status in this reviewed code.\n",
             encoding="utf-8",
         )
+        # Mutation: restore the report policy entry; this clean-carrier case must go red.
         result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
-        self.assertFalse(result["ok"])
-        self.assertTrue(any("code-gauntlet-report" in f for f in result["failures"]))
+        self.assertTrue(result["ok"], result["failures"])
+        self.assertFalse(any("writer degrade" in f for f in result["failures"]))
+        self.assertEqual(
+            check._DEGRADE_CARRIER_POLICY,
+            {
+                "workflows/wf_*.json": "structured",
+                "raw.json": "text",
+                "code-gauntlet-checkpoint-all-*.json": "structured",
+            },
+        )
 
     def test_g3_ignores_benign_spaced_partial_artifacts_prose(self):
         """#57: ordinary English ``partial artifacts`` must not trip G3.
@@ -531,10 +549,18 @@ class CheckRunTest(unittest.TestCase):
         """
         _build_ok_run(self.run_dir)
         pr = self.run_dir / "pr-example-repo-1"
-        (pr / "code-gauntlet-report-deadbeef.md").write_text(
-            "# Report\n\nThe build produces partial artifacts in the build dir.\n"
-            "Also noted: partialXartifacts naming and the partial/artifacts path.\n",
-            encoding="utf-8",
+        # Mutation: put the sentinel prose back in the report; the raw carrier must remain the only text scan.
+        _write_json(
+            pr / "raw.json",
+            {
+                "type": "result",
+                "subtype": "success",
+                "is_error": False,
+                "result": (
+                    "The build produces partial artifacts in the build dir.\n"
+                    "Also noted: partialXartifacts naming and the partial/artifacts path.\n"
+                ),
+            },
         )
         result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
         self.assertTrue(result["ok"], result["failures"])
@@ -543,10 +569,10 @@ class CheckRunTest(unittest.TestCase):
         )
 
     def test_workflow_return_partial_artifacts_gap_fails_g3(self):
-        """writeArtifacts gaps land on the compact return, not report/checkpoint."""
+        """Legacy writer no-write-proof gaps land in the structured Workflow return."""
         _build_ok_run(self.run_dir)
         pr = self.run_dir / "pr-example-repo-1"
-        # Clean secondary carriers so only the compact-return path can fire.
+        # Mutation: restore the report policy entry and put this gap in the report; only the structured carrier may fire G3.
         (pr / "code-gauntlet-report-deadbeef.md").write_text(
             "# Report\n", encoding="utf-8"
         )
@@ -574,6 +600,79 @@ class CheckRunTest(unittest.TestCase):
                 },
             },
         )
+        report_text = (pr / "code-gauntlet-report-deadbeef.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("no write proof", report_text)
+        self.assertNotIn("partial-artifacts", report_text)
+        result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any(
+                "workflows/wf_" in f and "partial-artifacts" in f
+                for f in result["failures"]
+            )
+        )
+
+    def test_derived_writer_partial_artifacts_gap_fails_g3(self):
+        _build_ok_run(self.run_dir)
+        pr = self.run_dir / "pr-example-repo-1"
+        self._clean_secondary_carriers(pr)
+        # Mutation: delete the structured carrier policy entry; this derived-writer path must go green.
+        _write_json(
+            pr / "workflows" / "wf_test-0001.json",
+            {
+                "runId": "wf_test-0001",
+                "scriptPath": PIPELINE,
+                "status": "completed",
+                "result": {
+                    "ok": True,
+                    "partial": True,
+                    "gaps": [
+                        "writeArtifacts: writer returned null — artifacts not persisted (partial-artifacts)"
+                    ],
+                },
+            },
+        )
+        report_text = (pr / "code-gauntlet-report-deadbeef.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("no write proof", report_text)
+        self.assertNotIn("partial-artifacts", report_text)
+        result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any(
+                "workflows/wf_" in f and "partial-artifacts" in f
+                for f in result["failures"]
+            )
+        )
+
+    def test_return_oversize_failed_fallback_gap_fails_g3(self):
+        _build_ok_run(self.run_dir)
+        pr = self.run_dir / "pr-example-repo-1"
+        self._clean_secondary_carriers(pr)
+        # Mutation: remove the fallback's structured gap; this RETURN oversize path must go green.
+        _write_json(
+            pr / "workflows" / "wf_test-0001.json",
+            {
+                "runId": "wf_test-0001",
+                "scriptPath": PIPELINE,
+                "status": "completed",
+                "result": {
+                    "ok": True,
+                    "partial": True,
+                    "gaps": [
+                        "writeArtifacts: the persisted primaries serialize to 120001 chars, over the 120000-char return budget — artifacts not persisted (partial-artifacts)"
+                    ],
+                },
+            },
+        )
+        report_text = (pr / "code-gauntlet-report-deadbeef.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("no write proof", report_text)
+        self.assertNotIn("partial-artifacts", report_text)
         result = check.check_run(self.run_dir, repo_root=REPO_ROOT)
         self.assertFalse(result["ok"])
         self.assertTrue(
@@ -613,10 +712,7 @@ class CheckRunTest(unittest.TestCase):
         )
 
     def _clean_secondary_carriers(self, pr):
-        """Blank the report/checkpoint carriers so only the wf record can fire."""
-        (pr / "code-gauntlet-report-deadbeef.md").write_text(
-            "# Report\n", encoding="utf-8"
-        )
+        """Blank the checkpoint carrier so only the wf record can fire."""
         _write_json(pr / "code-gauntlet-checkpoint-all-deadbeef.json", {"phases": {}})
 
     def test_wf_script_field_bundle_literals_do_not_fail_g3(self):
@@ -855,8 +951,8 @@ class CheckRunTest(unittest.TestCase):
     def test_patches_artifact_is_never_a_g3_degrade_carrier(self):
         """``code-gauntlet-patches-*.md`` (issue #226's read-only apply-check
         artifact) must never be added to ``_DEGRADE_CARRIER_POLICY``: unlike
-        ``code-gauntlet-report-*.md``, it renders the REVIEWED REPO's own
-        source text verbatim inside fenced code blocks — a repo could
+        ``raw.json``, whose result prose is a TEXT carrier, it renders the
+        REVIEWED REPO's own source text verbatim inside fenced code blocks — a repo could
         legitimately contain either G3 sentinel phrase ("no write proof",
         "partial-artifacts") in a comment, string literal, or docstring having
         nothing to do with this harness's own degrade signal, so scanning it

--- a/bench/tests/test_profile_run.py
+++ b/bench/tests/test_profile_run.py
@@ -9,9 +9,8 @@ data, which lives outside this repo.
 
 Covers:
   - run discovery (explicit run_id, and default-to-most-recent-completed)
-  - stage grouping (summarize / discover / verify-input-writer / verify-slice /
-    validate-batch / challenge / report-writer / artifact-writer) + the merge/filter
-    transform-gap placeholders
+  - stage grouping across legacy and current labels, including historical buckets and
+    the merge/filter transform-gap placeholders
   - concurrency accounting (avg + max overlap) for a 2-wide fan-out stage
   - parallel-capacity accounting (slowest x slots vs used vs idle)
   - critical-path hop selection (slowest member of each fan-out stage)
@@ -33,6 +32,8 @@ from tempfile import TemporaryDirectory
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import profile_run as pr
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def iso(ms):
@@ -60,14 +61,23 @@ class SyntheticRunBuilder:
       T0 + 7000  report-writer starts, duration  400 -> ends T0+7400
       T0 + 7500  artifact-writer starts, duration  700 -> ends T0+8200
       workflow durationMs = 8300 (a little slack after artifact-writer, like the real run)
+
+    ``era="legacy"`` uses this historical writer layout. ``era="current"`` replaces
+    the single summarize call with two buckets plus a merge and adds the
+    ``assemble-artifacts`` executor after the artifact writer.
     """
 
     T0: int = 1_800_000_000_000
 
-    def __init__(self, root: Path, run_id="wf_test0001-1", task_id="ttest0001"):
+    def __init__(
+        self, root: Path, run_id="wf_test0001-1", task_id="ttest0001", era="legacy"
+    ):
+        if era not in ("legacy", "current"):
+            raise ValueError("era must be 'legacy' or 'current'")
         self.root = root
         self.run_id = run_id
         self.task_id = task_id
+        self.era = era
         self.project_dir = root / "-fake-project"
         self.session_id = f"sess-{run_id}"
         self.session_dir = self.project_dir / self.session_id
@@ -76,7 +86,7 @@ class SyntheticRunBuilder:
         self.workflows_dir.mkdir(parents=True)
         self.subagents_dir.mkdir(parents=True)
 
-        self.agents_spec = [
+        legacy_specs = [
             ("summarize", "code-gauntlet:change-summarizer", 100, 1000, "a-summarize"),
             (
                 "code-gauntlet:bug-detector",
@@ -112,6 +122,62 @@ class SyntheticRunBuilder:
                 "a-artifact",
             ),
         ]
+        current_specs = [
+            (
+                "summarize-bucket-0",
+                "code-gauntlet:change-summarizer",
+                100,
+                1000,
+                "a-summarize-b0",
+            ),
+            (
+                "summarize-bucket-1",
+                "code-gauntlet:change-summarizer",
+                100,
+                1000,
+                "a-summarize-b1",
+            ),
+            (
+                "summarize-merge",
+                "code-gauntlet:change-summarizer",
+                1100,
+                500,
+                "a-summarize-merge",
+            ),
+            (
+                "code-gauntlet:bug-detector",
+                "code-gauntlet:bug-detector",
+                1200,
+                3000,
+                "a-discover-a",
+            ),
+            (
+                "code-gauntlet:security-reviewer",
+                "code-gauntlet:security-reviewer",
+                1200,
+                1000,
+                "a-discover-b",
+            ),
+            ("verify-slice-0", "code-gauntlet:executor", 4900, 400, "a-vslice"),
+            ("validate-batch-0", "code-gauntlet:validator", 5400, 600, "a-vbatch"),
+            ("challenge-0", "code-gauntlet:challenger", 6100, 800, "a-chal0"),
+            ("challenge-1", "code-gauntlet:challenger", 6100, 300, "a-chal1"),
+            (
+                "artifact-writer",
+                "code-gauntlet:artifact-writer",
+                7500,
+                700,
+                "a-artifact",
+            ),
+            (
+                "assemble-artifacts",
+                "code-gauntlet:executor",
+                8200,
+                100,
+                "a-assemble",
+            ),
+        ]
+        self.agents_spec = legacy_specs if era == "legacy" else current_specs
         self.workflow_duration_ms = 8300
 
     def _write_json(self, path, obj):
@@ -562,6 +628,12 @@ class ProfileRunTestCase(unittest.TestCase):
     def tearDown(self):
         self._tmp.cleanup()
 
+    def _profile_for(self, builder):
+        record, record_path, session_dir = pr.find_run_record(self.root, builder.run_id)
+        return pr.build_profile(
+            record, record_path, session_dir, builder.run_id, self.root
+        )
+
     # -- discovery -----------------------------------------------------------
 
     def test_find_run_record_explicit_id(self):
@@ -584,6 +656,197 @@ class ProfileRunTestCase(unittest.TestCase):
     def test_missing_run_id_raises(self):
         with self.assertRaises(FileNotFoundError):
             pr.find_run_record(self.root, "wf_does-not-exist-1")
+
+    def test_stage_rules_classify_live_labels(self):
+        # Mutation: replace the data-driven predicates with exact-only summarize matching;
+        # the bucket and merge probes must then go red.
+        probes = [
+            ("summarize", "", "summarize"),
+            ("summarize-bucket-0", "", "summarize"),
+            ("summarize-merge", "", "summarize"),
+            ("verify-slice-3", "", "verify-slice"),
+            ("verify-slice-3-retry", "", "verify-slice"),
+            ("validate-batch-1", "", "validate-batch"),
+            ("challenge-2", "", "challenge"),
+            ("artifact-writer", "", "artifact-writer"),
+            ("assemble-artifacts", "", "assemble-artifacts"),
+            (
+                "code-gauntlet:bug-detector",
+                "code-gauntlet:bug-detector",
+                "discover",
+            ),
+        ]
+        for label, agent_type, expected in probes:
+            self.assertEqual(
+                pr.classify_stage(label, agent_type),
+                expected,
+                f"STAGE_RULES must classify {label!r} as {expected}; edit the rule table",
+            )
+        self.assertTrue(
+            all(
+                pr.classify_stage(label, agent_type) != "other"
+                for label, agent_type, _ in probes
+            ),
+            "STAGE_RULES live probes must not classify to other; edit the rule table",
+        )
+
+    def test_stage_rules_pin_live_and_historical_labels_to_source(self):
+        # Mutation: add either historical label to workflows/src; the source pin must go red.
+        source = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in (REPO_ROOT / "workflows" / "src").glob("*.js")
+        )
+        stages_source = (REPO_ROOT / "workflows" / "src" / "stages.js").read_text(
+            encoding="utf-8"
+        )
+        for rule in pr.STAGE_RULES:
+            label = rule.get("label")
+            if rule["name"] in pr.HISTORICAL_STAGES:
+                self.assertNotIn(
+                    rule["name"],
+                    source,
+                    f"STAGE_RULES historical stage {rule['name']!r} must stay absent from workflows/src; edit the rule table",
+                )
+                if label:
+                    self.assertNotIn(
+                        label,
+                        source,
+                        f"STAGE_RULES historical label {label!r} must stay absent from workflows/src; edit the rule table",
+                    )
+                continue
+            if not label:
+                continue
+            if rule["match"] == "exact" or label == "summarize":
+                needle = "label: '" + label + "'"
+            else:
+                needle = "`" + label + "${"
+            self.assertIn(
+                needle,
+                stages_source,
+                f"STAGE_RULES label {label!r} is not pinned by workflows/src; edit the rule table or live label",
+            )
+
+    def test_current_era_uses_live_stage_labels(self):
+        # Mutation: remove the assemble-artifacts rule; this current-era assertion must go red.
+        current = SyntheticRunBuilder(
+            self.root,
+            run_id="wf_current0001-1",
+            task_id="tcurrent0001",
+            era="current",
+        )
+        record = current.build()
+        profile = pr.build_profile(
+            record,
+            current.workflows_dir / f"{current.run_id}.json",
+            current.session_dir,
+            current.run_id,
+            self.root,
+        )
+        by_stage = {stage["stage"]: stage for stage in profile["stage_profile"]}
+        self.assertNotIn("report-writer", by_stage)
+        self.assertNotIn("verify-input-writer", by_stage)
+        self.assertEqual(by_stage["summarize"]["agent_count"], 3)
+        self.assertIn("assemble-artifacts", by_stage)
+        self.assertIn("span_wall_s", by_stage["merge (transform, no agent)"])
+
+        legacy = {
+            stage["stage"]: stage
+            for stage in self._profile_for(self.builder)["stage_profile"]
+        }
+        for name in (
+            "discover",
+            "verify-slice",
+            "validate-batch",
+            "challenge",
+            "artifact-writer",
+        ):
+            self.assertEqual(
+                by_stage[name]["agent_count"],
+                legacy[name]["agent_count"],
+                f"STAGE_RULES current stage {name!r} drifted from the legacy fixture; edit the rule table",
+            )
+
+        md = pr.render_markdown(profile)
+        self.assertNotIn("report-writer", md)
+        self.assertNotIn("verify-input-writer", md)
+
+    def test_legacy_stages_are_marked_historical(self):
+        # Mutation: empty HISTORICAL_STAGES or drop the markdown suffix; this legacy assertion must go red.
+        profile = self._profile_for(self.builder)
+        by_stage = {stage["stage"]: stage for stage in profile["stage_profile"]}
+        self.assertTrue(by_stage["report-writer"]["historical"])
+        self.assertEqual(
+            by_stage["report-writer"]["historical_note"],
+            "the report is rendered in code; no writer agent is dispatched",
+        )
+        self.assertTrue(by_stage["verify-input-writer"]["historical"])
+        self.assertEqual(
+            by_stage["verify-input-writer"]["historical_note"],
+            "slice input is passed inline; no writer agent is dispatched",
+        )
+        md = pr.render_markdown(profile)
+        self.assertIn("report-writer (historical)", md)
+        self.assertIn("verify-input-writer (historical)", md)
+
+    def test_live_zero_agent_stage_keeps_unavailable_row(self):
+        # Mutation: omit every empty stage row; the live artifact-writer row must go red.
+        current = SyntheticRunBuilder(
+            self.root,
+            run_id="wf_current0002-1",
+            task_id="tcurrent0002",
+            era="current",
+        )
+        current.agents_spec = [
+            spec for spec in current.agents_spec if spec[0] != "artifact-writer"
+        ]
+        record = current.build()
+        profile = pr.build_profile(
+            record,
+            current.workflows_dir / f"{current.run_id}.json",
+            current.session_dir,
+            current.run_id,
+            self.root,
+        )
+        artifact = next(
+            stage
+            for stage in profile["stage_profile"]
+            if stage["stage"] == "artifact-writer"
+        )
+        self.assertEqual(artifact["agent_count"], 0)
+        self.assertEqual(
+            artifact["note"],
+            "UNAVAILABLE: no agents dispatched under this label in this run",
+        )
+
+    def test_transform_gap_uses_nearest_span_bearing_rows(self):
+        # Mutation: use positional transform neighbours; the spanless row would prevent this from resolving.
+        stages = [
+            {
+                "stage": "discover",
+                "agent_count": 1,
+                "span_start_offset_s": 1.0,
+                "span_end_offset_s": 2.0,
+                "span_wall_s": 1.0,
+            },
+            {"stage": "merge (transform, no agent)", "agent_count": 0},
+            {
+                "stage": "verify-slice",
+                "agent_count": 1,
+                "note": "UNAVAILABLE: missing timing fields",
+            },
+            {
+                "stage": "validate-batch",
+                "agent_count": 1,
+                "span_start_offset_s": 4.0,
+                "span_end_offset_s": 5.0,
+                "span_wall_s": 1.0,
+            },
+        ]
+        pr._fill_transform_gaps(stages)
+        merge = stages[1]
+        self.assertEqual(merge["span_start_offset_s"], 2.0)
+        self.assertEqual(merge["span_end_offset_s"], 4.0)
+        self.assertEqual(merge["span_wall_s"], 2.0)
 
     # -- stage grouping / concurrency -----------------------------------------
 

--- a/bench/tests/test_profile_run.py
+++ b/bench/tests/test_profile_run.py
@@ -727,7 +727,8 @@ class ProfileRunTestCase(unittest.TestCase):
             )
 
     def test_current_era_uses_live_stage_labels(self):
-        # Mutation: remove the assemble-artifacts rule; this current-era assertion must go red.
+        # Mutation: drift one timing value in the current fixture (3000 -> 3001); this
+        # field-for-field parity assertion must go red.
         current = SyntheticRunBuilder(
             self.root,
             run_id="wf_current0001-1",
@@ -753,16 +754,29 @@ class ProfileRunTestCase(unittest.TestCase):
             stage["stage"]: stage
             for stage in self._profile_for(self.builder)["stage_profile"]
         }
-        for name in (
-            "discover",
-            "verify-slice",
-            "validate-batch",
-            "challenge",
-            "artifact-writer",
-        ):
+        # Summarize is intentionally different, assemble-artifacts exists only in the
+        # current era, historical rows are omitted there, and the merge transform is
+        # gap-derived from those different layouts.
+        intentionally_different = {
+            "summarize",
+            "assemble-artifacts",
+            "merge (transform, no agent)",
+        }
+        current_live = {
+            name
+            for name, stage in by_stage.items()
+            if not stage.get("historical") and name not in intentionally_different
+        }
+        legacy_live = {
+            name
+            for name, stage in legacy.items()
+            if not stage.get("historical") and name not in intentionally_different
+        }
+        self.assertEqual(current_live, legacy_live)
+        for name in sorted(current_live):
             self.assertEqual(
-                by_stage[name]["agent_count"],
-                legacy[name]["agent_count"],
+                by_stage[name],
+                legacy[name],
                 f"STAGE_RULES current stage {name!r} drifted from the legacy fixture; edit the rule table",
             )
 


### PR DESCRIPTION
Closes #280. Closes #282.

## #280: the report leaves the G3 degrade-carrier policy

`bench/runner/check.py` raw-scanned `code-gauntlet-report-*.md` for the writer-degrade sentinels (`no write proof`, `partial-artifacts`). Since the report became a pure code render, that scan could only false-degrade:

- The report is rendered before persistence from `reportInput`, which carries a gap **count**, never gap strings, so code-owned report text cannot hold the sentinel (`render_report.test.js` T-G3 pins it).
- Every persistence path (legacy by-value writer, derived writer, RETURN fallback, replay) pushes the writer-degrade gap through `partial()` into `writeOut.gaps` and the structured Workflow-return carrier, which G3 already judges from its parsed `gaps` array.
- Measured over the retained corpus before the change: 248 reports, 17 sentinel hits; every one of the 6 renderer-era hits sat in model prose (the change summary or a finding body of a review of this repository, whose code names the sentinels). Zero hits in code-owned text.

Mechanism: the report pattern is removed from `_DEGRADE_CARRIER_POLICY`; `raw.json` stays a text carrier; the policy dict is pinned by a hand-typed equality. Tests: a renderer-era report carrying both literals in finding prose with clean structured carriers passes G3 (`ok` true, no `writer degrade` failure); the missing-checkpoint and benign-spacing fixtures move their sentinels into `raw.json`'s `.result` string; one path test per structured branch (legacy writer no-proof gap, derived writer gap, RETURN oversize with a failed fallback, a genuine workflow gap) proves the structured carrier still fails while the report carries nothing. `bench/MEASUREMENT.md` and the policy comment describe the carrier rules.

Recorded loss: archived pre-v3.25 runs are no longer G3-checkable through the report, the only carrier the deleted writer agent's degrade prose ever used; those runs also carry `wf_*.json` and checkpoint records. An era-gated report carrier was considered and declined (it keeps a false-degrade surface alive for an archive nobody re-checks).

## #282: profiler stage rules are data, historical buckets are labelled

`bench/profile_run.py` kept `report-writer` (removed in v3.25) and `verify-input-writer` (slice input moved inline) as live-looking buckets that rendered `0 UNAVAILABLE` rows on every current run, while three live labels (`summarize-bucket-N`, `summarize-merge`, `assemble-artifacts`) classified as `other`.

Mechanism: one ordered `STAGE_RULES` table (name, matcher, label or agent types, optional historical note) derives `STAGE_ORDER`, the predicates and `HISTORICAL_STAGES`. `summarize` matches its bucketed labels; `assemble-artifacts` gains a bucket. A historical stage's row carries `historical: true` and a note and is omitted when it has no agents; a live stage with zero agents keeps its UNAVAILABLE row (that is the anomaly worth seeing); a historical stage that did run (archived runs) renders with a ` (historical)` suffix. Transform gaps (merge, filter) resolve against the nearest earlier and later rows that carry a span, not positional neighbours, so omitted or spanless rows cannot change the answer.

Tests: hand-typed live labels classify to their stages and nothing classifies as `other`; a source pin derived from the table checks each live label literal appears in `workflows/src/stages.js` and each historical label appears nowhere in `workflows/src`; `SyntheticRunBuilder` gains an `era` flag (legacy keeps the old agent list; current drops the historical agents and adds bucketed summarize plus the assembler); both eras are asserted in JSON and Markdown, the current era field-for-field against the legacy rows that are not era-specific, plus the live-zero-agent row and the nearest-span transform rule. `bench/PROFILING.md` describes the table and the rules.

## Verification

Suites only, per both issues. Local gates at HEAD: Python 2146 passed, bench 653 passed, JS 1365 passed, bundle fixed point, generator `--check` current, Biome clean, pre-commit clean, bench coverage 89.56 (floor 88.2). Review: two Codex luna lenses (mutation ledger 10 of 10 red, spec conformance), one fix round (row equality was `agent_count` only; docs reduced to rules), one confirmation round (11 of 11 red).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tGgdQCJmUhdLwtQgxN4WE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Bench-only smoke checker and profiler behavior; no runtime pipeline or auth changes. Slightly relaxes G3 on report text while structured carriers remain the source of truth for writer degrade.
> 
> **Overview**
> **Smoke G3 (#280):** Removes `code-gauntlet-report-*.md` from the writer-degrade scan policy so finding prose that mentions `no write proof` / `partial-artifacts` no longer fails mechanical smoke. Degrade is still enforced on `workflows/wf_*.json`, `raw.json`, and `code-gauntlet-checkpoint-all-*.json` (structured `gaps` vs text scan). `bench/MEASUREMENT.md` and tests are updated to match, including cases where only structured carriers should trip G3.
> 
> **Profiler (#282):** Replaces ad-hoc stage predicates in `bench/profile_run.py` with an ordered `STAGE_RULES` table (order, matchers, optional `historical_note`). Live labels like `summarize-bucket-*`, `summarize-merge`, and `assemble-artifacts` bucket correctly; legacy `report-writer` and `verify-input-writer` show as **(historical)** when present and are omitted when absent. Merge/filter transform gaps resolve from the nearest earlier/later span-bearing rows. `bench/PROFILING.md` and `test_profile_run.py` cover legacy vs current eras and source pins to `workflows/src/stages.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39ea1003c18895542fce0388b4c3afa1c2225f93. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->